### PR TITLE
chore: set Node.js engine to 24.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,9 @@
   "licence": "MIT",
   "version": "1.5.0",
   "private": false,
+  "engines": {
+    "node": "24.x"
+  },
   "scripts": {
     "start": "react-scripts start",
     "build": "react-scripts build && yarn sentry:sourcemaps",


### PR DESCRIPTION
### Motivation
- The project reported an invalid/discontinued Node runtime ("18.x"), so declare a supported Node version to ensure builds and deployments use Node.js `24.x`.

### Description
- Added an `engines` entry to `package.json` with `"node": "24.x"`.

### Testing
- Validated the updated `package.json` is syntactically correct by running `node -e "const fs=require('fs'); JSON.parse(fs.readFileSync('package.json','utf8')); console.log('package.json valid')"`, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699c8c236ffc832cb0b9c71f47391d51)