### PR TITLE
Start app at /login and add mocked admin credentials

### DIFF
--- a/src/pages/Login.js
+++ b/src/pages/Login.js
@@ -92,7 +92,10 @@ export default function Login() {
               Sign in to Hortelan
             </Typography>
 
-            <Typography sx={{ color: 'text.secondary', mb: 5 }}>Enter your details below.</Typography>
+            <Typography sx={{ color: 'text.secondary', mb: 1 }}>Enter your details below.</Typography>
+            <Typography sx={{ color: 'text.secondary', mb: 5 }}>
+              Mock admin access: <strong>davidfernandes</strong> / <strong>admin</strong>.
+            </Typography>
 
             <AuthSocial />
 

--- a/src/routes.js
+++ b/src/routes.js
@@ -41,7 +41,7 @@ export default function Router() {
       path: '/',
       element: <LogoOnlyLayout />,
       children: [
-        { path: '/', element: <Navigate to="/dashboard/app" /> },
+        { path: '/', element: <Navigate to="/login" /> },
         { path: '404', element: <NotFound /> },
         { path: '*', element: <Navigate to="/404" /> },
       ],

--- a/src/sections/auth/login/LoginForm.js
+++ b/src/sections/auth/login/LoginForm.js
@@ -11,6 +11,12 @@ import { LoadingButton } from '@mui/lab';
 import Iconify from '../../../components/Iconify';
 import { FormProvider, RHFTextField, RHFCheckbox } from '../../../components/hook-form';
 
+const MOCK_ADMIN_USER = {
+  username: 'davidfernandes',
+  password: 'admin',
+  role: 'administrator',
+};
+
 // ----------------------------------------------------------------------
 
 export default function LoginForm() {
@@ -19,13 +25,13 @@ export default function LoginForm() {
   const [showPassword, setShowPassword] = useState(false);
 
   const LoginSchema = Yup.object().shape({
-    email: Yup.string().email('Email must be a valid email address').required('Email is required'),
+    email: Yup.string().required('Username is required'),
     password: Yup.string().required('Password is required'),
   });
 
   const defaultValues = {
-    email: '',
-    password: '',
+    email: MOCK_ADMIN_USER.username,
+    password: MOCK_ADMIN_USER.password,
     remember: true,
   };
 
@@ -36,17 +42,29 @@ export default function LoginForm() {
 
   const {
     handleSubmit,
+    setError,
     formState: { isSubmitting },
   } = methods;
 
-  const onSubmit = async () => {
-    navigate('/dashboard', { replace: true });
+  const onSubmit = async ({ email, password }) => {
+    const isValidAdmin = email === MOCK_ADMIN_USER.username && password === MOCK_ADMIN_USER.password;
+
+    if (!isValidAdmin) {
+      setError('password', {
+        type: 'manual',
+        message: 'Invalid credentials. Use davidfernandes / admin.',
+      });
+      return;
+    }
+
+    localStorage.setItem('hortelan-auth', JSON.stringify(MOCK_ADMIN_USER));
+    navigate('/dashboard/app', { replace: true });
   };
 
   return (
     <FormProvider methods={methods} onSubmit={handleSubmit(onSubmit)}>
       <Stack spacing={3}>
-        <RHFTextField name="email" label="Email address" />
+        <RHFTextField name="email" label="Username" />
 
         <RHFTextField
           name="password"


### PR DESCRIPTION
### Motivation
- Ensure the web app opens on the login screen first instead of redirecting directly to the dashboard to make initial access explicit.
- Provide an easy way to access an administrator account during development by mocking admin credentials so evaluators can sign in without backend integration.

### Description
- Changed the root redirect from `'/dashboard/app'` to `'/login'` in `src/routes.js` so the app starts at the login page.
- Reworked the login form in `src/sections/auth/login/LoginForm.js` to use a `username` field instead of email and added a `MOCK_ADMIN_USER` with credentials `davidfernandes` / `admin`.
- Prefilled the login form with the mocked admin values and implemented client-side validation that sets an error when credentials are invalid.
- On successful mock login the code persists the mock user payload to `localStorage` under `hortelan-auth` and navigates to `/dashboard/app`, and the login page (`src/pages/Login.js`) now displays a helper hint with the mocked admin credentials.

### Testing
- Ran `npm run lint` which completed successfully and reported only pre-existing warnings unrelated to these changes.
- Launched the dev server with `npm start` which compiled the app (webpack compiled with warnings) and served the site successfully.
- Executed an automated Playwright script to navigate to `http://127.0.0.1:3000/login` and capture a screenshot of the login screen which succeeded and produced an artifact (login-screen.png).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699c8d431e60832ca9f88aa80559246c)