### PR TITLE
Adicionar Status Page como última opção do menu

### DIFF
--- a/src/layouts/dashboard/NavConfig.js
+++ b/src/layouts/dashboard/NavConfig.js
@@ -48,9 +48,9 @@ const navConfig = [
     icon: getIcon('eva:person-add-fill'),
   },
   {
-    title: 'Page for Error Usage',
-    path: '/404',
-    icon: getIcon('eva:alert-triangle-fill'),
+    title: 'status page',
+    path: '/dashboard/status',
+    icon: getIcon('eva:activity-fill'),
   },
 ];
 

--- a/src/pages/StatusPage.js
+++ b/src/pages/StatusPage.js
@@ -1,0 +1,88 @@
+import {
+  Alert,
+  Box,
+  Card,
+  CardContent,
+  Container,
+  Grid,
+  Link,
+  Stack,
+  Typography,
+} from '@mui/material';
+import Page from '../components/Page';
+
+const featureStatus = [
+  { name: 'Monitoring', status: 'operational' },
+  { name: 'Garden', status: 'operational' },
+  { name: 'Ecommerce Gardens', status: 'operational' },
+  { name: 'Onboarding', status: 'operational' },
+  { name: 'Hortelan 360', status: 'operational' },
+  { name: 'Community', status: 'failed' },
+];
+
+const STATUS_URL = 'https://hortelan.vercel.app/404';
+
+export default function StatusPage() {
+  const failedFeatures = featureStatus.filter((feature) => feature.status === 'failed');
+
+  return (
+    <Page title="Status">
+      <Container>
+        <Stack spacing={3}>
+          <Typography variant="h4">Status Page</Typography>
+          <Grid container spacing={3}>
+            {featureStatus.map((feature) => {
+              const isOperational = feature.status === 'operational';
+
+              return (
+                <Grid item xs={12} md={6} key={feature.name}>
+                  <Card>
+                    <CardContent>
+                      <Stack direction="row" justifyContent="space-between" alignItems="center">
+                        <Typography variant="subtitle1">{feature.name}</Typography>
+                        <Typography
+                          variant="caption"
+                          sx={{
+                            px: 1.25,
+                            py: 0.5,
+                            borderRadius: 1,
+                            color: isOperational ? 'success.dark' : 'error.dark',
+                            bgcolor: isOperational ? 'success.lighter' : 'error.lighter',
+                            textTransform: 'uppercase',
+                            fontWeight: 700,
+                            letterSpacing: 0.5,
+                          }}
+                        >
+                          {feature.status}
+                        </Typography>
+                      </Stack>
+                    </CardContent>
+                  </Card>
+                </Grid>
+              );
+            })}
+          </Grid>
+
+          {failedFeatures.length > 0 && (
+            <Stack spacing={2}>
+              <Alert severity="error">
+                Funcionalidades com status <strong>failed</strong> exibem a tela 404 em{' '}
+                <Link href={STATUS_URL} target="_blank" rel="noopener noreferrer">
+                  {STATUS_URL}
+                </Link>
+                .
+              </Alert>
+
+              <Box
+                component="iframe"
+                src={STATUS_URL}
+                title="Hortelan 404"
+                sx={{ width: '100%', height: 540, border: 0, borderRadius: 2 }}
+              />
+            </Stack>
+          )}
+        </Stack>
+      </Container>
+    </Page>
+  );
+}

--- a/src/routes.js
+++ b/src/routes.js
@@ -12,6 +12,7 @@ import Products from './pages/Products';
 import DashboardApp from './pages/DashboardApp';
 import Hortelan360 from './pages/Hortelan360';
 import Onboarding from './pages/Onboarding';
+import StatusPage from './pages/StatusPage';
 
 // ----------------------------------------------------------------------
 
@@ -27,6 +28,7 @@ export default function Router() {
         { path: 'blog', element: <Blog /> },
         { path: 'hortelan-360', element: <Hortelan360 /> },
         { path: 'onboarding', element: <Onboarding /> },
+        { path: 'status', element: <StatusPage /> },
       ],
     },
     {


### PR DESCRIPTION
### Motivation
- Fornecer uma página de status acessível pelo painel que liste funcionalidades e indique quais estão `operational` ou `failed`. 
- Quando houver funcionalidades `failed`, exibir a tela pública de erro `https://hortelan.vercel.app/404` como referência para o usuário.

### Description
- Adiciona a nova página de interface `src/pages/StatusPage.js` que lista funcionalidades e, se alguma estiver com status `failed`, mostra um link e um `iframe` apontando para `https://hortelan.vercel.app/404`.
- Registra a rota `/dashboard/status` em `src/routes.js` e importa `StatusPage` para tornar a página navegável sob o layout do dashboard.
- Atualiza o menu lateral em `src/layouts/dashboard/NavConfig.js` substituindo a entrada de erro anterior pela nova entrada `status page` apontando para `/dashboard/status` como última opção.

### Testing
- Rodei `npm run lint` que concluiu com sucesso e reportou apenas avisos (0 errors, 8 warnings).
- Rodei os testes com `CI=true npm test -- --watchAll=false`, que falharam por não haver testes configurados no repositório (comando saiu com código 1).
- Iniciei o servidor de desenvolvimento (`npm start`) e capturei uma captura visual automatizada da página em execução (`/dashboard/status`) para validação visual (artefato gerado: `artifacts/status-page.png`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699c8de23728832caca93fac2b06f0da)