### PR TITLE
Redirect all runtime errors to hosted 404 page

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -6,17 +6,20 @@ import ThemeProvider from './theme';
 // components
 import ScrollToTop from './components/ScrollToTop';
 import { BaseOptionChartStyle } from './components/chart/BaseOptionChart';
+import GlobalErrorBoundary from './components/GlobalErrorBoundary';
 
 
 // ----------------------------------------------------------------------
 
 export default function App() {
   return (
-    <ThemeProvider>
-      <ScrollToTop />
-      <BaseOptionChartStyle />
-      <Router />
-      <Analytics />
-    </ThemeProvider>
+    <GlobalErrorBoundary>
+      <ThemeProvider>
+        <ScrollToTop />
+        <BaseOptionChartStyle />
+        <Router />
+        <Analytics />
+      </ThemeProvider>
+    </GlobalErrorBoundary>
   );
 }

--- a/src/components/GlobalErrorBoundary.js
+++ b/src/components/GlobalErrorBoundary.js
@@ -1,0 +1,21 @@
+import { Component } from 'react';
+
+const ERROR_REDIRECT_URL = 'https://hortelan.vercel.app/404';
+
+export default class GlobalErrorBoundary extends Component {
+  static getDerivedStateFromError() {
+    return { hasError: true };
+  }
+
+  componentDidCatch() {
+    window.location.replace(ERROR_REDIRECT_URL);
+  }
+
+  render() {
+    if (this.state?.hasError) {
+      return null;
+    }
+
+    return this.props.children;
+  }
+}

--- a/src/index.js
+++ b/src/index.js
@@ -16,6 +16,18 @@ import { tryLoadAndStartRecorder } from '@alwaysmeticulous/recorder-loader'
 
 const root = ReactDOM.createRoot(document.getElementById('root'));
 
+
+const ERROR_REDIRECT_URL = 'https://hortelan.vercel.app/404';
+
+function redirectToErrorPage() {
+  if (window.location.href !== ERROR_REDIRECT_URL) {
+    window.location.replace(ERROR_REDIRECT_URL);
+  }
+}
+
+window.addEventListener('error', redirectToErrorPage);
+window.addEventListener('unhandledrejection', redirectToErrorPage);
+
 async function startApp() {
     // Record all sessions on localhost, staging stacks and preview URLs
     if (!isProduction()) {


### PR DESCRIPTION
### Motivation
- Garantir que qualquer erro de runtime exiba a página 404 hospedada (`https://hortelan.vercel.app/404`) como fallback padrão para melhorar a experiência do usuário e evitar telas de erro nativas do browser.
- Cobrir tanto erros de render/lifecycle do React quanto erros fora do fluxo de render (ex.: promises não tratadas) com um comportamento único e previsível.

### Description
- Adicionado `src/components/GlobalErrorBoundary.js`, um error boundary React que chama `window.location.replace(ERROR_REDIRECT_URL)` dentro de `componentDidCatch` para redirecionar quando ocorrer um erro de render/lifecycle.
- Envolvida a árvore principal do app com `GlobalErrorBoundary` em `src/App.js` para aplicar o fallback globalmente a todas as rotas e componentes.
- Adicionados listeners globais no bootstrap em `src/index.js` que escutam `error` e `unhandledrejection` e invocam o mesmo redirecionamento usando a constante `ERROR_REDIRECT_URL`.

### Testing
- Executado `npx react-scripts build`, que gerou o build com sucesso e artefatos de saída (build concluído), observando apenas warnings de ESLint pré-existentes em arquivos não alterados.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699c8d64f3d8832c8cc7e94188303b4d)