### PR TITLE
Set Vercel outputDirectory to build

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,3 @@
+{
+  "outputDirectory": "build"
+}


### PR DESCRIPTION
### Motivation
- Align Vercel deployment settings with the Vite build output (`build.outDir = "build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699cafd6b5c0832cb99a33001c549c76)