### PR TITLE
Implementa cadastro com LGPD, telefone opcional e confirmação de e-mail

### DIFF
--- a/src/pages/Register.js
+++ b/src/pages/Register.js
@@ -1,76 +1,76 @@
-import { Link as RouterLink } from 'react-router-dom';
+import { Link as RouterLink } from "react-router-dom";
 // @mui
-import { styled } from '@mui/material/styles';
-import { Card, Link, Container, Typography } from '@mui/material';
+import { styled } from "@mui/material/styles";
+import { Card, Link, Container, Typography } from "@mui/material";
 // hooks
-import useResponsive from '../hooks/useResponsive';
+import useResponsive from "../hooks/useResponsive";
 // components
-import Page from '../components/Page';
-import Logo from '../components/Logo';
+import Page from "../components/Page";
+import Logo from "../components/Logo";
 // sections
-import { RegisterForm } from '../sections/auth/register';
-import AuthSocial from '../sections/auth/AuthSocial';
+import { RegisterForm } from "../sections/auth/register";
+import AuthSocial from "../sections/auth/AuthSocial";
 
 // ----------------------------------------------------------------------
 
-const RootStyle = styled('div')(({ theme }) => ({
-  [theme.breakpoints.up('md')]: {
-    display: 'flex',
+const RootStyle = styled("div")(({ theme }) => ({
+  [theme.breakpoints.up("md")]: {
+    display: "flex",
   },
 }));
 
-const HeaderStyle = styled('header')(({ theme }) => ({
+const HeaderStyle = styled("header")(({ theme }) => ({
   top: 0,
   zIndex: 9,
   lineHeight: 0,
-  width: '100%',
-  display: 'flex',
-  alignItems: 'center',
-  position: 'absolute',
+  width: "100%",
+  display: "flex",
+  alignItems: "center",
+  position: "absolute",
   padding: theme.spacing(3),
-  justifyContent: 'space-between',
-  [theme.breakpoints.up('md')]: {
-    alignItems: 'flex-start',
+  justifyContent: "space-between",
+  [theme.breakpoints.up("md")]: {
+    alignItems: "flex-start",
     padding: theme.spacing(7, 5, 0, 7),
   },
 }));
 
 const SectionStyle = styled(Card)(({ theme }) => ({
-  width: '100%',
+  width: "100%",
   maxWidth: 464,
-  display: 'flex',
-  flexDirection: 'column',
-  justifyContent: 'center',
+  display: "flex",
+  flexDirection: "column",
+  justifyContent: "center",
   margin: theme.spacing(2, 0, 2, 2),
 }));
 
-const ContentStyle = styled('div')(({ theme }) => ({
+const ContentStyle = styled("div")(({ theme }) => ({
   maxWidth: 480,
-  margin: 'auto',
-  minHeight: '100vh',
-  display: 'flex',
-  justifyContent: 'center',
-  flexDirection: 'column',
+  margin: "auto",
+  minHeight: "100vh",
+  display: "flex",
+  justifyContent: "center",
+  flexDirection: "column",
   padding: theme.spacing(12, 0),
 }));
 
 // ----------------------------------------------------------------------
 
 export default function Register() {
-  const smUp = useResponsive('up', 'sm');
+  const smUp = useResponsive("up", "sm");
 
-  const mdUp = useResponsive('up', 'md');
+  const mdUp = useResponsive("up", "md");
 
   return (
-    <Page title="Register">
+    <Page title="Cadastro">
       <RootStyle>
         <HeaderStyle>
           <Logo />
           {smUp && (
             <Typography variant="body2" sx={{ mt: { md: -2 } }}>
-              Already have an account? {''}
+              Já tem uma conta? {""}
               <Link variant="subtitle2" component={RouterLink} to="/login">
-                Login
+                Entrar
               </Link>
             </Typography>
           )}
@@ -79,41 +79,35 @@ export default function Register() {
         {mdUp && (
           <SectionStyle>
             <Typography variant="h3" sx={{ px: 5, mt: 10, mb: 5 }}>
-              Be efficient in your plantation with Hortelan
+              Crie sua conta na Hortelan
             </Typography>
-            <img alt="register" src="/static/illustrations/illustration_register.png" />
+            <img
+              alt="register"
+              src="/static/illustrations/illustration_register.png"
+            />
           </SectionStyle>
         )}
 
         <Container>
           <ContentStyle>
             <Typography variant="h4" gutterBottom>
-              Get started plan absolutely free.
+              Cadastre-se para começar
             </Typography>
 
-            <Typography sx={{ color: 'text.secondary', mb: 5 }}>Completely free starter plan</Typography>
+            <Typography sx={{ color: "text.secondary", mb: 5 }}>
+              Preencha seus dados e confirme seu e-mail para acessar a
+              plataforma.
+            </Typography>
 
             <AuthSocial />
 
             <RegisterForm />
 
-            <Typography variant="body2" align="center" sx={{ color: 'text.secondary', mt: 3 }}>
-              By registering, I agree to Minimal&nbsp;
-              <Link underline="always" color="text.primary" href="#">
-                Terms of Service
-              </Link>
-              {''}and{''}
-              <Link underline="always" color="text.primary" href="#">
-                Privacy Policy
-              </Link>
-              .
-            </Typography>
-
             {!smUp && (
-              <Typography variant="body2" sx={{ mt: 3, textAlign: 'center' }}>
-                Already have an account?{' '}
+              <Typography variant="body2" sx={{ mt: 3, textAlign: "center" }}>
+                Já tem uma conta?{" "}
                 <Link variant="subtitle2" to="/login" component={RouterLink}>
-                  Login
+                  Entrar
                 </Link>
               </Typography>
             )}


### PR DESCRIPTION
### Motivation
- Adaptar o fluxo de cadastro para o público brasileiro com textos em português e orientação para confirmação de e-mail.
- Coletar os dados necessários (nome, e-mail, senha) e suportar telefone como campo opcional.
- Assegurar conformidade de aceitação de termos e privacidade (LGPD) exigindo um checkbox obrigatório antes de prosseguir.

### Description
- Traduziu e atualizou a página de cadastro (`src/pages/Register.js`) para português e ajustou os textos de onboarding/CTA. 
- Substituiu o formulário antigo por um novo `RegisterForm` em `src/sections/auth/register/RegisterForm.js` que coleta `name`, `email`, `phone` (opcional), `password` e `acceptedTerms`. 
- Adicionou validações via `Yup` para todos os campos, incluindo formato opcional de telefone e senha mínima de 8 caracteres, e validação obrigatória do checkbox de aceite (`acceptedTerms`).
- Implementou etapa pós-submit que simula envio de e-mail de verificação: ao submeter, o formulário mostra uma mensagem de sucesso com o e-mail verificado e um botão para ir ao login.

### Testing
- Executed `npx prettier --check src/pages/Register.js src/sections/auth/register/RegisterForm.js` and it passed after formatting changes. 
- Ran `npm run build` and the production build completed successfully. 
- Started the dev server with `npm run dev` and captured a screenshot of `/register` via Playwright to validate the UI render. 
- `npm run lint` failed because no ESLint configuration was present in the environment (this is unrelated to the changed files themselves).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699cb515cc58832cbfad8831d1aa7118)