### PR TITLE
feat: implement forgot-password flow with reset tokens and password-history

### DIFF
--- a/src/auth/session.js
+++ b/src/auth/session.js
@@ -1,6 +1,10 @@
 const AUTH_STORAGE_KEY = 'hortelan-auth';
 const SESSION_STORAGE_KEY = 'hortelan-auth-session-id';
 const ACTIVE_SESSIONS_KEY = 'hortelan-active-sessions';
+const USERS_STORAGE_KEY = 'hortelan-users';
+const RESET_TOKENS_KEY = 'hortelan-reset-tokens';
+const PASSWORD_HISTORY_KEY = 'hortelan-password-history';
+const RESET_TOKEN_EXPIRY_MINUTES = 30;
 
 const USERS = [
   {
@@ -9,6 +13,17 @@ const USERS = [
     password: 'admin123',
     name: 'Administrador Hortelan',
     role: 'administrator',
+  },
+];
+
+const INITIAL_PASSWORD_HISTORY = [
+  {
+    id: `pwd-history-${Date.now()}`,
+    userId: 'admin-1',
+    userEmail: 'admin@hortelan.com',
+    changedAt: new Date().toISOString(),
+    method: 'seed',
+    changedBy: 'system',
   },
 ];
 
@@ -48,11 +63,43 @@ const clearCurrentSessionId = () => {
 
 const getActiveSessions = () => getLocalJson(ACTIVE_SESSIONS_KEY, []);
 
+const getUsers = () => getLocalJson(USERS_STORAGE_KEY, USERS);
+
+const saveUsers = (users) => {
+  localStorage.setItem(USERS_STORAGE_KEY, JSON.stringify(users));
+};
+
+const getResetTokens = () => getLocalJson(RESET_TOKENS_KEY, []);
+
+const saveResetTokens = (tokens) => {
+  localStorage.setItem(RESET_TOKENS_KEY, JSON.stringify(tokens));
+};
+
+const getPasswordHistory = () => getLocalJson(PASSWORD_HISTORY_KEY, INITIAL_PASSWORD_HISTORY);
+
+const savePasswordHistory = (history) => {
+  localStorage.setItem(PASSWORD_HISTORY_KEY, JSON.stringify(history));
+};
+
+const appendPasswordHistory = ({ user, method, changedBy }) => {
+  const history = getPasswordHistory();
+  history.push({
+    id: `pwd-history-${Date.now()}-${Math.random().toString(16).slice(2)}`,
+    userId: user.id,
+    userEmail: user.email,
+    changedAt: new Date().toISOString(),
+    method,
+    changedBy,
+  });
+  savePasswordHistory(history);
+};
+
 const saveActiveSessions = (sessions) => {
   localStorage.setItem(ACTIVE_SESSIONS_KEY, JSON.stringify(sessions));
 };
 
-const getUserByCredentials = ({ email, password }) => USERS.find((user) => user.email === email && user.password === password);
+const getUserByCredentials = ({ email, password }) =>
+  getUsers().find((user) => user.email === email && user.password === password);
 
 const getCurrentSession = () => {
   const sessionId = getCurrentSessionId();
@@ -121,7 +168,7 @@ export const getAuthenticatedUser = () => {
     return null;
   }
 
-  const user = USERS.find((item) => item.id === session.userId);
+  const user = getUsers().find((item) => item.id === session.userId);
 
   if (!user) {
     clearCurrentSessionId();
@@ -135,6 +182,95 @@ export const getAuthenticatedUser = () => {
     name: user.name,
   };
 };
+
+export const requestPasswordReset = (email) => {
+  const user = getUsers().find((item) => item.email.toLowerCase() === email.toLowerCase());
+
+  if (!user) {
+    return {
+      message:
+        'Se o e-mail existir, você receberá um link para redefinir sua senha.',
+      resetLink: null,
+    };
+  }
+
+  const now = Date.now();
+  const expiresAt = new Date(now + RESET_TOKEN_EXPIRY_MINUTES * 60 * 1000).toISOString();
+  const token = `rst-${now}-${Math.random().toString(36).slice(2, 10)}`;
+
+  const activeTokens = getResetTokens().filter((item) => item.userId !== user.id || item.usedAt);
+  activeTokens.push({
+    token,
+    userId: user.id,
+    createdAt: new Date(now).toISOString(),
+    expiresAt,
+    usedAt: null,
+  });
+  saveResetTokens(activeTokens);
+
+  return {
+    message: 'Link de redefinição gerado com sucesso.',
+    resetLink: `${window.location.origin}/reset-password?token=${token}`,
+    expiresAt,
+  };
+};
+
+export const validatePasswordResetToken = (token) => {
+  if (!token) {
+    return { valid: false, error: 'Token não informado.' };
+  }
+
+  const tokenEntry = getResetTokens().find((item) => item.token === token);
+
+  if (!tokenEntry) {
+    return { valid: false, error: 'Token inválido.' };
+  }
+
+  if (tokenEntry.usedAt) {
+    return { valid: false, error: 'Este token já foi utilizado.' };
+  }
+
+  if (new Date(tokenEntry.expiresAt).getTime() < Date.now()) {
+    return { valid: false, error: 'Token expirado. Solicite um novo link.' };
+  }
+
+  return { valid: true, tokenEntry };
+};
+
+export const resetPasswordWithToken = ({ token, newPassword }) => {
+  const validation = validatePasswordResetToken(token);
+
+  if (!validation.valid) {
+    return { error: validation.error };
+  }
+
+  const { tokenEntry } = validation;
+  const users = getUsers();
+  const user = users.find((item) => item.id === tokenEntry.userId);
+
+  if (!user) {
+    return { error: 'Usuário não encontrado para este token.' };
+  }
+
+  const updatedUsers = users.map((item) => (item.id === user.id ? { ...item, password: newPassword } : item));
+  saveUsers(updatedUsers);
+
+  const updatedTokens = getResetTokens().map((item) =>
+    item.token === token ? { ...item, usedAt: new Date().toISOString() } : item
+  );
+  saveResetTokens(updatedTokens);
+
+  appendPasswordHistory({
+    user,
+    method: 'reset-token',
+    changedBy: user.email,
+  });
+
+  return { success: true };
+};
+
+export const getPasswordChangeHistory = () =>
+  getPasswordHistory().sort((a, b) => new Date(b.changedAt) - new Date(a.changedAt));
 
 export const isAuthenticated = () => Boolean(getAuthenticatedUser());
 

--- a/src/layouts/dashboard/NavConfig.js
+++ b/src/layouts/dashboard/NavConfig.js
@@ -52,6 +52,11 @@ const navConfig = [
     path: '/dashboard/status',
     icon: getIcon('eva:activity-fill'),
   },
+  {
+    title: 'security',
+    path: '/dashboard/security',
+    icon: getIcon('eva:shield-fill'),
+  },
 ];
 
 export default navConfig;

--- a/src/pages/ForgotPassword.js
+++ b/src/pages/ForgotPassword.js
@@ -1,0 +1,76 @@
+import * as Yup from 'yup';
+import { useState } from 'react';
+import { Link as RouterLink } from 'react-router-dom';
+import { yupResolver } from '@hookform/resolvers/yup';
+import { useForm } from 'react-hook-form';
+import { Alert, Card, Container, Link, Stack, Typography } from '@mui/material';
+import { LoadingButton } from '@mui/lab';
+import Page from '../components/Page';
+import { FormProvider, RHFTextField } from '../components/hook-form';
+import { requestPasswordReset } from '../auth/session';
+
+export default function ForgotPassword() {
+  const [response, setResponse] = useState(null);
+
+  const ForgotPasswordSchema = Yup.object().shape({
+    email: Yup.string().email('Informe um e-mail válido').required('E-mail é obrigatório'),
+  });
+
+  const methods = useForm({
+    resolver: yupResolver(ForgotPasswordSchema),
+    defaultValues: { email: '' },
+  });
+
+  const {
+    handleSubmit,
+    formState: { isSubmitting },
+  } = methods;
+
+  const onSubmit = async ({ email }) => {
+    const result = requestPasswordReset(email);
+    setResponse(result);
+  };
+
+  return (
+    <Page title="Esqueci minha senha">
+      <Container maxWidth="sm" sx={{ py: 8 }}>
+        <Card sx={{ p: 4 }}>
+          <Typography variant="h4" gutterBottom>
+            Esqueci minha senha
+          </Typography>
+
+          <Typography color="text.secondary" sx={{ mb: 3 }}>
+            Informe seu e-mail para gerar um link/token de redefinição de senha.
+          </Typography>
+
+          <FormProvider methods={methods} onSubmit={handleSubmit(onSubmit)}>
+            <Stack spacing={3}>
+              {response && <Alert severity="success">{response.message}</Alert>}
+
+              <RHFTextField name="email" label="E-mail" />
+
+              {response?.resetLink && (
+                <Alert severity="info">
+                  Token válido até: <strong>{new Date(response.expiresAt).toLocaleString()}</strong>
+                  <br />
+                  Link de redefinição:{' '}
+                  <Link component={RouterLink} to={response.resetLink.replace(window.location.origin, '')}>
+                    Abrir redefinição
+                  </Link>
+                </Alert>
+              )}
+
+              <LoadingButton type="submit" variant="contained" loading={isSubmitting}>
+                Enviar link de redefinição
+              </LoadingButton>
+
+              <Link component={RouterLink} to="/login" underline="hover">
+                Voltar para login
+              </Link>
+            </Stack>
+          </FormProvider>
+        </Card>
+      </Container>
+    </Page>
+  );
+}

--- a/src/pages/ResetPassword.js
+++ b/src/pages/ResetPassword.js
@@ -1,0 +1,76 @@
+import * as Yup from 'yup';
+import { useMemo, useState } from 'react';
+import { Link as RouterLink, useSearchParams } from 'react-router-dom';
+import { yupResolver } from '@hookform/resolvers/yup';
+import { useForm } from 'react-hook-form';
+import { Alert, Card, Container, Link, Stack, Typography } from '@mui/material';
+import { LoadingButton } from '@mui/lab';
+import Page from '../components/Page';
+import { FormProvider, RHFTextField } from '../components/hook-form';
+import { resetPasswordWithToken, validatePasswordResetToken } from '../auth/session';
+
+export default function ResetPassword() {
+  const [searchParams] = useSearchParams();
+  const [submitStatus, setSubmitStatus] = useState(null);
+
+  const token = searchParams.get('token') || '';
+
+  const tokenValidation = useMemo(() => validatePasswordResetToken(token), [token]);
+
+  const ResetPasswordSchema = Yup.object().shape({
+    password: Yup.string().min(6, 'A senha deve ter pelo menos 6 caracteres').required('Senha é obrigatória'),
+    confirmPassword: Yup.string()
+      .oneOf([Yup.ref('password')], 'As senhas precisam ser iguais')
+      .required('Confirmação obrigatória'),
+  });
+
+  const methods = useForm({
+    resolver: yupResolver(ResetPasswordSchema),
+    defaultValues: { password: '', confirmPassword: '' },
+  });
+
+  const {
+    handleSubmit,
+    formState: { isSubmitting },
+  } = methods;
+
+  const onSubmit = async ({ password }) => {
+    const result = resetPasswordWithToken({ token, newPassword: password });
+    setSubmitStatus(result.error ? { type: 'error', message: result.error } : { type: 'success' });
+  };
+
+  return (
+    <Page title="Redefinir senha">
+      <Container maxWidth="sm" sx={{ py: 8 }}>
+        <Card sx={{ p: 4 }}>
+          <Typography variant="h4" gutterBottom>
+            Redefinir senha
+          </Typography>
+
+          {!tokenValidation.valid && <Alert severity="error">{tokenValidation.error}</Alert>}
+
+          {tokenValidation.valid && (
+            <FormProvider methods={methods} onSubmit={handleSubmit(onSubmit)}>
+              <Stack spacing={3} sx={{ mt: 2 }}>
+                {submitStatus?.type === 'error' && <Alert severity="error">{submitStatus.message}</Alert>}
+
+                {submitStatus?.type === 'success' && (
+                  <Alert severity="success">
+                    Senha alterada com sucesso. <Link component={RouterLink} to="/login">Ir para login</Link>
+                  </Alert>
+                )}
+
+                <RHFTextField name="password" label="Nova senha" type="password" />
+                <RHFTextField name="confirmPassword" label="Confirmar nova senha" type="password" />
+
+                <LoadingButton type="submit" variant="contained" loading={isSubmitting}>
+                  Salvar nova senha
+                </LoadingButton>
+              </Stack>
+            </FormProvider>
+          )}
+        </Card>
+      </Container>
+    </Page>
+  );
+}

--- a/src/pages/Security.js
+++ b/src/pages/Security.js
@@ -1,0 +1,54 @@
+import { Card, Container, Stack, Table, TableBody, TableCell, TableHead, TableRow, Typography } from '@mui/material';
+import Page from '../components/Page';
+import useAuth from '../auth/useAuth';
+import { getPasswordChangeHistory } from '../auth/session';
+
+const METHOD_LABELS = {
+  seed: 'Inicialização do sistema',
+  'reset-token': 'Redefinição por token',
+};
+
+export default function Security() {
+  const { user } = useAuth();
+
+  const history = getPasswordChangeHistory();
+
+  return (
+    <Page title="Segurança">
+      <Container>
+        <Stack spacing={3}>
+          <Typography variant="h4">Segurança de senha</Typography>
+
+          <Card sx={{ p: 3 }}>
+            {user?.role !== 'administrator' ? (
+              <Typography color="text.secondary">
+                O histórico de troca de senha é visível apenas para administradores.
+              </Typography>
+            ) : (
+              <Table>
+                <TableHead>
+                  <TableRow>
+                    <TableCell>Usuário</TableCell>
+                    <TableCell>Método</TableCell>
+                    <TableCell>Alterado por</TableCell>
+                    <TableCell>Data/Hora</TableCell>
+                  </TableRow>
+                </TableHead>
+                <TableBody>
+                  {history.map((entry) => (
+                    <TableRow key={entry.id}>
+                      <TableCell>{entry.userEmail}</TableCell>
+                      <TableCell>{METHOD_LABELS[entry.method] || entry.method}</TableCell>
+                      <TableCell>{entry.changedBy}</TableCell>
+                      <TableCell>{new Date(entry.changedAt).toLocaleString()}</TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            )}
+          </Card>
+        </Stack>
+      </Container>
+    </Page>
+  );
+}

--- a/src/routes.js
+++ b/src/routes.js
@@ -13,6 +13,9 @@ import DashboardApp from './pages/DashboardApp';
 import Hortelan360 from './pages/Hortelan360';
 import Onboarding from './pages/Onboarding';
 import StatusPage from './pages/StatusPage';
+import ForgotPassword from './pages/ForgotPassword';
+import ResetPassword from './pages/ResetPassword';
+import Security from './pages/Security';
 import RequireAuth from './components/auth/RequireAuth';
 import RedirectIfAuth from './components/auth/RedirectIfAuth';
 
@@ -35,6 +38,7 @@ export default function Router() {
         { path: 'hortelan-360', element: <Hortelan360 /> },
         { path: 'onboarding', element: <Onboarding /> },
         { path: 'status', element: <StatusPage /> },
+        { path: 'security', element: <Security /> },
       ],
     },
     {
@@ -52,6 +56,14 @@ export default function Router() {
           <Register />
         </RedirectIfAuth>
       ),
+    },
+    {
+      path: 'forgot-password',
+      element: <ForgotPassword />,
+    },
+    {
+      path: 'reset-password',
+      element: <ResetPassword />,
     },
     {
       path: '/',

--- a/src/sections/auth/login/LoginForm.js
+++ b/src/sections/auth/login/LoginForm.js
@@ -1,6 +1,6 @@
 import * as Yup from 'yup';
 import { useState } from 'react';
-import { useLocation, useNavigate } from 'react-router-dom';
+import { Link as RouterLink, useLocation, useNavigate } from 'react-router-dom';
 // form
 import { useForm } from 'react-hook-form';
 import { yupResolver } from '@hookform/resolvers/yup';
@@ -82,7 +82,7 @@ export default function LoginForm() {
 
       <Stack direction="row" alignItems="center" justifyContent="space-between" sx={{ my: 2 }}>
         <RHFCheckbox name="remember" label="Lembrar-me" />
-        <Link variant="subtitle2" underline="hover">
+        <Link variant="subtitle2" underline="hover" component={RouterLink} to="/forgot-password">
           Esqueceu sua senha?
         </Link>
       </Stack>


### PR DESCRIPTION
### Motivation
- Add a client-side "Esqueci minha senha" flow so users can request password resets and administrators can audit password changes.

### Description
- Persist users, reset tokens and password history in localStorage and add token expiration logic (`src/auth/session.js`).
- Implement `requestPasswordReset`, `validatePasswordResetToken`, `resetPasswordWithToken` and `getPasswordChangeHistory` and record events to a password history key with a 30-minute expiry for tokens.
- Add UI pages and route entries for forgot/reset password and a dashboard security page (`src/pages/ForgotPassword.js`, `src/pages/ResetPassword.js`, `src/pages/Security.js`, `src/routes.js`) and wire the login form link to `/forgot-password` (`src/sections/auth/login/LoginForm.js`).
- Add a "security" nav item (`src/layouts/dashboard/NavConfig.js`) and show the password-change history table only to users with role `administrator`.

### Testing
- Built the production bundle with `npm run build` and it completed successfully.
- Ran `npm run lint` which reported a warning/failure due to missing ESLint configuration in the repository (project limitation).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699cb94d1558832cb1ace75dc18143fe)