### PR TITLE
feat(auth): implementar 2FA por e-mail/authenticator, login social e dispositivos confiáveis

### DIFF
--- a/src/auth/AuthContext.js
+++ b/src/auth/AuthContext.js
@@ -2,12 +2,17 @@ import PropTypes from 'prop-types';
 import { createContext, useCallback, useEffect, useMemo, useState } from 'react';
 import {
   getAuthenticatedUser,
+  getTrustedDevices,
+  getTwoFactorSettings,
   getUserSessions,
   isAuthenticated,
   loginWithEmailAndPassword,
+  loginWithSocialProvider,
   logoutAllSessions,
   logoutCurrentSession,
   logoutOtherSessions,
+  revokeTrustedDevice,
+  updateTwoFactorSettings,
 } from './session';
 
 export const AuthContext = createContext(null);
@@ -15,20 +20,32 @@ export const AuthContext = createContext(null);
 export function AuthProvider({ children }) {
   const [user, setUser] = useState(() => getAuthenticatedUser());
   const [sessions, setSessions] = useState(() => getUserSessions());
+  const [twoFactor, setTwoFactor] = useState(() => getTwoFactorSettings());
+  const [trustedDevices, setTrustedDevices] = useState(() => getTrustedDevices());
 
   const refreshAuthState = useCallback(() => {
     setUser(getAuthenticatedUser());
     setSessions(getUserSessions());
+    setTwoFactor(getTwoFactorSettings());
+    setTrustedDevices(getTrustedDevices());
   }, []);
 
   useEffect(() => {
     refreshAuthState();
   }, [refreshAuthState]);
 
-  const login = useCallback(({ email, password, remember }) => {
-    const result = loginWithEmailAndPassword({ email, password, remember });
+  const login = useCallback(({ email, password, remember, trustDevice, deviceName, challengeId, twoFactorCode }) => {
+    const result = loginWithEmailAndPassword({
+      email,
+      password,
+      remember,
+      trustDevice,
+      deviceName,
+      challengeId,
+      twoFactorCode,
+    });
 
-    if (result.error) {
+    if (result.error || result.requiresTwoFactor) {
       return result;
     }
 
@@ -51,18 +68,62 @@ export function AuthProvider({ children }) {
     refreshAuthState();
   }, [refreshAuthState]);
 
+  const loginWithSocial = useCallback(({ provider, remember, trustDevice, deviceName }) => {
+    const result = loginWithSocialProvider({ provider, remember, trustDevice, deviceName });
+
+    if (result.error || result.requiresTwoFactor) {
+      return result;
+    }
+
+    refreshAuthState();
+    return result;
+  }, [refreshAuthState]);
+
+  const update2FASettings = useCallback(({ enabled, method }) => {
+    const result = updateTwoFactorSettings({ enabled, method });
+
+    if (!result.error) {
+      refreshAuthState();
+    }
+
+    return result;
+  }, [refreshAuthState]);
+
+  const removeTrustedDevice = useCallback((trustedDeviceId) => {
+    revokeTrustedDevice(trustedDeviceId);
+    refreshAuthState();
+  }, [refreshAuthState]);
+
   const value = useMemo(
     () => ({
       user,
       sessions,
+      twoFactor,
+      trustedDevices,
       authenticated: isAuthenticated(),
       login,
+      loginWithSocial,
       logout,
       logoutAll,
       logoutOthers,
+      update2FASettings,
+      removeTrustedDevice,
       refreshAuthState,
     }),
-    [user, sessions, login, logout, logoutAll, logoutOthers, refreshAuthState]
+    [
+      user,
+      sessions,
+      twoFactor,
+      trustedDevices,
+      login,
+      loginWithSocial,
+      logout,
+      logoutAll,
+      logoutOthers,
+      update2FASettings,
+      removeTrustedDevice,
+      refreshAuthState,
+    ]
   );
 
   return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;

--- a/src/pages/Security.js
+++ b/src/pages/Security.js
@@ -1,4 +1,22 @@
-import { Card, Container, Stack, Table, TableBody, TableCell, TableHead, TableRow, Typography } from '@mui/material';
+import {
+  Alert,
+  Button,
+  Card,
+  Container,
+  FormControl,
+  InputLabel,
+  MenuItem,
+  Select,
+  Stack,
+  Switch,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableRow,
+  Typography,
+} from '@mui/material';
+import { useState } from 'react';
 import Page from '../components/Page';
 import useAuth from '../auth/useAuth';
 import { getPasswordChangeHistory } from '../auth/session';
@@ -8,16 +26,123 @@ const METHOD_LABELS = {
   'reset-token': 'Redefinição por token',
 };
 
+const TWO_FACTOR_METHOD_LABELS = {
+  email: 'E-mail',
+  authenticator: 'App autenticador',
+};
+
 export default function Security() {
-  const { user } = useAuth();
+  const { user, twoFactor, trustedDevices, update2FASettings, removeTrustedDevice } = useAuth();
 
   const history = getPasswordChangeHistory();
+  const [method, setMethod] = useState(twoFactor?.method || 'email');
+  const [feedback, setFeedback] = useState('');
 
   return (
     <Page title="Segurança">
       <Container>
         <Stack spacing={3}>
-          <Typography variant="h4">Segurança de senha</Typography>
+          <Typography variant="h4">Segurança da conta</Typography>
+
+          <Card sx={{ p: 3 }}>
+            <Stack spacing={2}>
+              <Typography variant="h6">Autenticação em dois fatores (2FA)</Typography>
+              <Typography color="text.secondary">
+                Ative o segundo fator por e-mail ou app autenticador para elevar o nível de proteção do login.
+              </Typography>
+
+              {feedback && <Alert severity="success">{feedback}</Alert>}
+
+              <Stack direction={{ xs: 'column', md: 'row' }} spacing={2} alignItems={{ md: 'center' }}>
+                <Stack direction="row" spacing={1} alignItems="center">
+                  <Switch
+                    checked={Boolean(twoFactor?.enabled)}
+                    onChange={(_, checked) => {
+                      const result = update2FASettings({ enabled: checked, method });
+
+                      if (!result.error) {
+                        setFeedback(checked ? '2FA ativado com sucesso.' : '2FA desativado com sucesso.');
+                      }
+                    }}
+                  />
+                  <Typography>{twoFactor?.enabled ? '2FA habilitado' : '2FA desabilitado'}</Typography>
+                </Stack>
+
+                <FormControl sx={{ minWidth: 220 }} size="small" disabled={!twoFactor?.enabled}>
+                  <InputLabel id="two-factor-method-label">Método</InputLabel>
+                  <Select
+                    labelId="two-factor-method-label"
+                    label="Método"
+                    value={method}
+                    onChange={(event) => {
+                      const nextMethod = event.target.value;
+                      setMethod(nextMethod);
+                      const result = update2FASettings({ enabled: true, method: nextMethod });
+
+                      if (!result.error) {
+                        setFeedback(`Método de 2FA alterado para ${TWO_FACTOR_METHOD_LABELS[nextMethod]}.`);
+                      }
+                    }}
+                  >
+                    <MenuItem value="email">E-mail</MenuItem>
+                    <MenuItem value="authenticator">App autenticador</MenuItem>
+                  </Select>
+                </FormControl>
+              </Stack>
+            </Stack>
+          </Card>
+
+          <Card sx={{ p: 3 }}>
+            <Stack spacing={2}>
+              <Typography variant="h6">Dispositivos confiáveis</Typography>
+              <Typography color="text.secondary">
+                Dispositivos confiáveis podem pular o segundo fator enquanto o vínculo estiver válido.
+              </Typography>
+
+              {trustedDevices.length === 0 ? (
+                <Typography color="text.secondary">Nenhum dispositivo confiável cadastrado.</Typography>
+              ) : (
+                <Table>
+                  <TableHead>
+                    <TableRow>
+                      <TableCell>Nome</TableCell>
+                      <TableCell>Confiado em</TableCell>
+                      <TableCell>Expira em</TableCell>
+                      <TableCell align="right">Ações</TableCell>
+                    </TableRow>
+                  </TableHead>
+                  <TableBody>
+                    {trustedDevices.map((device) => (
+                      <TableRow key={device.id}>
+                        <TableCell>
+                          <Stack spacing={0.5}>
+                            <Typography variant="subtitle2">{device.deviceName || 'Dispositivo sem nome'}</Typography>
+                            <Typography variant="caption" color="text.secondary">
+                              {device.userAgent}
+                            </Typography>
+                          </Stack>
+                        </TableCell>
+                        <TableCell>{new Date(device.trustedAt).toLocaleString()}</TableCell>
+                        <TableCell>{new Date(device.expiresAt).toLocaleString()}</TableCell>
+                        <TableCell align="right">
+                          <Button
+                            color="error"
+                            variant="text"
+                            onClick={() => {
+                              removeTrustedDevice(device.id);
+                              setFeedback('Dispositivo removido da lista de confiança.');
+                            }}
+                          >
+                            Revogar
+                          </Button>
+                        </TableCell>
+                      </TableRow>
+                    ))}
+                  </TableBody>
+                </Table>
+              )}
+            </Stack>
+          </Card>
 
           <Card sx={{ p: 3 }}>
             {user?.role !== 'administrator' ? (
@@ -25,26 +150,31 @@ export default function Security() {
                 O histórico de troca de senha é visível apenas para administradores.
               </Typography>
             ) : (
-              <Table>
-                <TableHead>
-                  <TableRow>
-                    <TableCell>Usuário</TableCell>
-                    <TableCell>Método</TableCell>
-                    <TableCell>Alterado por</TableCell>
-                    <TableCell>Data/Hora</TableCell>
-                  </TableRow>
-                </TableHead>
-                <TableBody>
-                  {history.map((entry) => (
-                    <TableRow key={entry.id}>
-                      <TableCell>{entry.userEmail}</TableCell>
-                      <TableCell>{METHOD_LABELS[entry.method] || entry.method}</TableCell>
-                      <TableCell>{entry.changedBy}</TableCell>
-                      <TableCell>{new Date(entry.changedAt).toLocaleString()}</TableCell>
+              <>
+                <Typography variant="h6" sx={{ mb: 2 }}>
+                  Histórico de troca de senha
+                </Typography>
+                <Table>
+                  <TableHead>
+                    <TableRow>
+                      <TableCell>Usuário</TableCell>
+                      <TableCell>Método</TableCell>
+                      <TableCell>Alterado por</TableCell>
+                      <TableCell>Data/Hora</TableCell>
                     </TableRow>
-                  ))}
-                </TableBody>
-              </Table>
+                  </TableHead>
+                  <TableBody>
+                    {history.map((entry) => (
+                      <TableRow key={entry.id}>
+                        <TableCell>{entry.userEmail}</TableCell>
+                        <TableCell>{METHOD_LABELS[entry.method] || entry.method}</TableCell>
+                        <TableCell>{entry.changedBy}</TableCell>
+                        <TableCell>{new Date(entry.changedAt).toLocaleString()}</TableCell>
+                      </TableRow>
+                    ))}
+                  </TableBody>
+                </Table>
+              </>
             )}
           </Card>
         </Stack>

--- a/src/sections/auth/AuthSocial.js
+++ b/src/sections/auth/AuthSocial.js
@@ -1,30 +1,58 @@
+import { useState } from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
 // material
-import { Stack, Button, Divider, Typography } from '@mui/material';
+import { Stack, Button, Divider, Typography, Alert } from '@mui/material';
 // component
 import Iconify from '../../components/Iconify';
+import useAuth from '../../auth/useAuth';
 
 // ----------------------------------------------------------------------
 
 export default function AuthSocial() {
+  const navigate = useNavigate();
+  const location = useLocation();
+  const { loginWithSocial } = useAuth();
+  const [socialError, setSocialError] = useState('');
+
+  const handleSocialLogin = (provider) => {
+    setSocialError('');
+    const result = loginWithSocial({ provider, remember: true, trustDevice: true });
+
+    if (result.error) {
+      setSocialError(result.error);
+      return;
+    }
+
+    if (result.requiresTwoFactor) {
+      setSocialError('Este provedor exige 2FA. Faça login com e-mail/senha para validar o código.');
+      return;
+    }
+
+    const destination = location.state?.from || '/dashboard/app';
+    navigate(destination, { replace: true });
+  };
+
   return (
     <>
+      {socialError && (
+        <Alert severity="warning" sx={{ mb: 2 }}>
+          {socialError}
+        </Alert>
+      )}
+
       <Stack direction="row" spacing={2}>
-        <Button fullWidth size="large" color="inherit" variant="outlined">
+        <Button fullWidth size="large" color="inherit" variant="outlined" onClick={() => handleSocialLogin('google')}>
           <Iconify icon="eva:google-fill" color="#DF3E30" width={22} height={22} />
         </Button>
 
-        <Button fullWidth size="large" color="inherit" variant="outlined">
-          <Iconify icon="eva:facebook-fill" color="#1877F2" width={22} height={22} />
-        </Button>
-
-        <Button fullWidth size="large" color="inherit" variant="outlined">
-          <Iconify icon="eva:twitter-fill" color="#1C9CEA" width={22} height={22} />
+        <Button fullWidth size="large" color="inherit" variant="outlined" onClick={() => handleSocialLogin('apple')}>
+          <Iconify icon="mdi:apple" color="#000000" width={22} height={22} />
         </Button>
       </Stack>
 
       <Divider sx={{ my: 3 }}>
         <Typography variant="body2" sx={{ color: 'text.secondary' }}>
-          OR
+          OU
         </Typography>
       </Divider>
     </>

--- a/src/sections/auth/login/LoginForm.js
+++ b/src/sections/auth/login/LoginForm.js
@@ -5,7 +5,7 @@ import { Link as RouterLink, useLocation, useNavigate } from 'react-router-dom';
 import { useForm } from 'react-hook-form';
 import { yupResolver } from '@hookform/resolvers/yup';
 // @mui
-import { Alert, Link, Stack, IconButton, InputAdornment } from '@mui/material';
+import { Alert, Link, Stack, IconButton, InputAdornment, Typography } from '@mui/material';
 import { LoadingButton } from '@mui/lab';
 // components
 import Iconify from '../../../components/Iconify';
@@ -21,16 +21,27 @@ export default function LoginForm() {
 
   const [showPassword, setShowPassword] = useState(false);
   const [submitError, setSubmitError] = useState('');
+  const [twoFactorChallenge, setTwoFactorChallenge] = useState(null);
+  const [twoFactorHint, setTwoFactorHint] = useState('');
+  const [demoCode, setDemoCode] = useState('');
 
   const LoginSchema = Yup.object().shape({
     email: Yup.string().email('Informe um e-mail válido').required('E-mail é obrigatório'),
     password: Yup.string().required('Senha é obrigatória'),
+    twoFactorCode: Yup.string().when([], {
+      is: () => Boolean(twoFactorChallenge),
+      then: (schema) => schema.required('Código 2FA obrigatório').length(6, 'O código deve ter 6 dígitos'),
+      otherwise: (schema) => schema,
+    }),
   });
 
   const defaultValues = {
     email: '',
     password: '',
     remember: true,
+    trustDevice: true,
+    deviceName: '',
+    twoFactorCode: '',
   };
 
   const methods = useForm({
@@ -40,16 +51,36 @@ export default function LoginForm() {
 
   const {
     handleSubmit,
+    setValue,
     formState: { isSubmitting },
   } = methods;
 
-  const onSubmit = async ({ email, password, remember }) => {
+  const onSubmit = async ({ email, password, remember, trustDevice, deviceName, twoFactorCode }) => {
     setSubmitError('');
 
-    const result = login({ email, password, remember });
+    const result = login({
+      email,
+      password,
+      remember,
+      trustDevice,
+      deviceName,
+      challengeId: twoFactorChallenge?.challengeId,
+      twoFactorCode,
+    });
 
     if (result.error) {
       setSubmitError(result.error);
+      return;
+    }
+
+    if (result.requiresTwoFactor) {
+      setTwoFactorChallenge(result);
+      setTwoFactorHint(
+        result.method === 'email'
+          ? `Código enviado para ${result.deliveryHint}.`
+          : 'Abra seu app autenticador e informe o código de 6 dígitos.'
+      );
+      setDemoCode(result.demoCode);
       return;
     }
 
@@ -62,12 +93,23 @@ export default function LoginForm() {
       <Stack spacing={3}>
         {submitError && <Alert severity="error">{submitError}</Alert>}
 
-        <RHFTextField name="email" label="E-mail" />
+        {twoFactorChallenge && (
+          <Alert severity="info">
+            <Typography variant="subtitle2">2FA obrigatório</Typography>
+            <Typography variant="body2">{twoFactorHint}</Typography>
+            <Typography variant="caption" sx={{ display: 'block', mt: 1 }}>
+              Ambiente de demo: código gerado <strong>{demoCode}</strong> (expira em 5 minutos).
+            </Typography>
+          </Alert>
+        )}
+
+        <RHFTextField name="email" label="E-mail" disabled={Boolean(twoFactorChallenge)} />
 
         <RHFTextField
           name="password"
           label="Senha"
           type={showPassword ? 'text' : 'password'}
+          disabled={Boolean(twoFactorChallenge)}
           InputProps={{
             endAdornment: (
               <InputAdornment position="end">
@@ -78,18 +120,60 @@ export default function LoginForm() {
             ),
           }}
         />
+
+        {twoFactorChallenge && (
+          <RHFTextField
+            name="twoFactorCode"
+            label="Código de autenticação"
+            placeholder="000000"
+            inputProps={{ maxLength: 6 }}
+          />
+        )}
       </Stack>
 
       <Stack direction="row" alignItems="center" justifyContent="space-between" sx={{ my: 2 }}>
-        <RHFCheckbox name="remember" label="Lembrar-me" />
+        <RHFCheckbox name="remember" label="Lembrar-me" disabled={Boolean(twoFactorChallenge)} />
         <Link variant="subtitle2" underline="hover" component={RouterLink} to="/forgot-password">
           Esqueceu sua senha?
         </Link>
       </Stack>
 
+      <Stack sx={{ mb: 2 }}>
+        <RHFCheckbox
+          name="trustDevice"
+          label="Confiar neste dispositivo por 30 dias"
+          disabled={Boolean(twoFactorChallenge)}
+        />
+        <RHFTextField
+          name="deviceName"
+          label="Nome do dispositivo (opcional)"
+          placeholder="Ex.: Notebook escritório"
+          disabled={Boolean(twoFactorChallenge)}
+        />
+      </Stack>
+
       <LoadingButton fullWidth size="large" type="submit" variant="contained" loading={isSubmitting}>
-        Entrar
+        {twoFactorChallenge ? 'Validar 2FA e entrar' : 'Entrar'}
       </LoadingButton>
+
+      {twoFactorChallenge && (
+        <LoadingButton
+          sx={{ mt: 2 }}
+          fullWidth
+          size="large"
+          type="button"
+          color="inherit"
+          variant="outlined"
+          onClick={() => {
+            setTwoFactorChallenge(null);
+            setTwoFactorHint('');
+            setDemoCode('');
+            setValue('twoFactorCode', '');
+          }}
+        >
+          Voltar e alterar credenciais
+        </LoadingButton>
+      )}
     </FormProvider>
   );
 }


### PR DESCRIPTION
### Motivation
- Elevar a segurança de autenticação adicionando suporte a autenticação em dois fatores (2FA) por e-mail ou app autenticador.
- Fornecer opção de login social (Google/Apple) para cenários de demonstração e integração simples com o fluxo de autenticação local.
- Permitir gestão de dispositivos confiáveis para reduzir atrito de 2FA em dispositivos de uso frequente.

### Description
- Implementa nova lógica de sessão em `src/auth/session.js` com chaves de storage, geração/validação de desafios 2FA (`buildTwoFactorChallenge`, `validateTwoFactorChallenge`), mapeamento de configurações 2FA, suporte a dispositivos confiáveis e helper `loginWithSocialProvider` para login social.
- Atualiza o contexto de autenticação em `src/auth/AuthContext.js` para expor estados e ações de 2FA, dispositivos confiáveis e login social, além de propagar atualizações de estado (`refreshAuthState`).
- Altera a UI de login em `src/sections/auth/login/LoginForm.js` para fluxo em duas etapas (credenciais → desafio 2FA), opção `trustDevice`/`deviceName` e exibição de código demo em ambiente local.
- Atualiza `src/sections/auth/AuthSocial.js` para acionar o fluxo social e `src/pages/Security.js` para permitir gerenciamento de 2FA e revogação/listagem de dispositivos confiáveis na interface.

### Testing
- `npm run build` foi executado com sucesso (`vite build`) e artefatos de build gerados com aviso de chunk grande — ✅.
- `npm run lint` foi executado e falhou devido à ausência de configuração de ESLint no repositório (ferramenta reportou falta de arquivo de configuração) — ⚠️.
- Importação do módulo foi validada com `node -e "import('./src/auth/session.js')..."` e retornou OK, confirmando que o novo código é importável — ✅.
- Iniciado servidor dev com `npm run dev` e executado um teste automatizado com Playwright que preencheu o formulário de login e gerou um screenshot do fluxo 2FA/Segurança (artefato gerado) — ✅.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699cbbb16750832cbe7f8e08897c7b3d)