### PR TITLE
feat: adicionar tela de perfil e preferências do usuário

### DIFF
--- a/src/auth/AuthContext.js
+++ b/src/auth/AuthContext.js
@@ -12,6 +12,7 @@ import {
   logoutCurrentSession,
   logoutOtherSessions,
   revokeTrustedDevice,
+  updateAuthenticatedUserProfile,
   updateTwoFactorSettings,
 } from './session';
 
@@ -94,6 +95,16 @@ export function AuthProvider({ children }) {
     refreshAuthState();
   }, [refreshAuthState]);
 
+  const updateProfile = useCallback((payload) => {
+    const result = updateAuthenticatedUserProfile(payload);
+
+    if (!result.error) {
+      refreshAuthState();
+    }
+
+    return result;
+  }, [refreshAuthState]);
+
   const value = useMemo(
     () => ({
       user,
@@ -108,6 +119,7 @@ export function AuthProvider({ children }) {
       logoutOthers,
       update2FASettings,
       removeTrustedDevice,
+      updateProfile,
       refreshAuthState,
     }),
     [
@@ -122,6 +134,7 @@ export function AuthProvider({ children }) {
       logoutOthers,
       update2FASettings,
       removeTrustedDevice,
+      updateProfile,
       refreshAuthState,
     ]
   );

--- a/src/auth/session.js
+++ b/src/auth/session.js
@@ -19,8 +19,57 @@ const USERS = [
     password: 'admin123',
     name: 'Administrador Hortelan',
     role: 'administrator',
+    photoURL: '',
+    bio: 'Cultivando alimentos e tecnologia para uma horta mais inteligente.',
+    preferences: {
+      language: 'pt-BR',
+      measurementUnit: 'métrico',
+      timezone: 'America/Sao_Paulo',
+    },
+    notifications: {
+      irrigationAlerts: true,
+      pestAlerts: true,
+      weatherAlerts: true,
+      communityUpdates: false,
+      marketing: false,
+    },
+    savedAddresses: [
+      {
+        id: 'address-admin-1',
+        label: 'Casa',
+        addressLine: 'Rua das Hortas, 123 - São Paulo/SP',
+      },
+    ],
+    cultivationLevel: 'intermediario',
   },
 ];
+
+const buildSafeUser = (user) => ({
+  id: user.id,
+  email: user.email,
+  role: user.role,
+  name: user.name,
+  photoURL: user.photoURL || '',
+  bio: user.bio || '',
+  preferences: {
+    language: user.preferences?.language || 'pt-BR',
+    measurementUnit: user.preferences?.measurementUnit || 'métrico',
+    timezone: user.preferences?.timezone || 'America/Sao_Paulo',
+  },
+  notifications: {
+    irrigationAlerts: Boolean(user.notifications?.irrigationAlerts),
+    pestAlerts: Boolean(user.notifications?.pestAlerts),
+    weatherAlerts: Boolean(user.notifications?.weatherAlerts),
+    communityUpdates: Boolean(user.notifications?.communityUpdates),
+    marketing: Boolean(user.notifications?.marketing),
+  },
+  savedAddresses: (user.savedAddresses || []).map((address) => ({
+    id: address.id,
+    label: address.label,
+    addressLine: address.addressLine,
+  })),
+  cultivationLevel: user.cultivationLevel || 'iniciante',
+});
 
 const INITIAL_PASSWORD_HISTORY = [
   {
@@ -302,12 +351,7 @@ export const loginWithEmailAndPassword = ({
   saveActiveSessions(sessions);
   setCurrentSessionId(sessionId, remember);
 
-  const safeUser = {
-    id: user.id,
-    email: user.email,
-    role: user.role,
-    name: user.name,
-  };
+  const safeUser = buildSafeUser(user);
 
   persistAuthUser(safeUser, remember);
 
@@ -373,12 +417,57 @@ export const getAuthenticatedUser = () => {
     return null;
   }
 
-  return {
-    id: user.id,
-    email: user.email,
-    role: user.role,
-    name: user.name,
+  return buildSafeUser(user);
+};
+
+export const updateAuthenticatedUserProfile = (payload) => {
+  const user = getAuthenticatedUser();
+
+  if (!user) {
+    return { error: 'Usuário não autenticado.' };
+  }
+
+  const users = getUsers();
+  const currentUser = users.find((item) => item.id === user.id);
+
+  if (!currentUser) {
+    return { error: 'Usuário não encontrado.' };
+  }
+
+  const nextUser = {
+    ...currentUser,
+    name: payload.name?.trim() || currentUser.name,
+    photoURL: payload.photoURL?.trim() || '',
+    bio: payload.bio?.trim() || '',
+    preferences: {
+      language: payload.preferences?.language || currentUser.preferences?.language || 'pt-BR',
+      measurementUnit: payload.preferences?.measurementUnit || currentUser.preferences?.measurementUnit || 'métrico',
+      timezone: payload.preferences?.timezone || currentUser.preferences?.timezone || 'America/Sao_Paulo',
+    },
+    notifications: {
+      irrigationAlerts: Boolean(payload.notifications?.irrigationAlerts),
+      pestAlerts: Boolean(payload.notifications?.pestAlerts),
+      weatherAlerts: Boolean(payload.notifications?.weatherAlerts),
+      communityUpdates: Boolean(payload.notifications?.communityUpdates),
+      marketing: Boolean(payload.notifications?.marketing),
+    },
+    savedAddresses: (payload.savedAddresses || []).map((address, index) => ({
+      id: address.id || `address-${Date.now()}-${index}`,
+      label: address.label?.trim() || `Endereço ${index + 1}`,
+      addressLine: address.addressLine?.trim() || '',
+    })),
+    cultivationLevel: payload.cultivationLevel || currentUser.cultivationLevel || 'iniciante',
   };
+
+  const updatedUsers = users.map((item) => (item.id === currentUser.id ? nextUser : item));
+  saveUsers(updatedUsers);
+
+  const safeUser = buildSafeUser(nextUser);
+  const currentSessionId = getCurrentSessionId();
+  const currentSession = getCurrentSession();
+  persistAuthUser(safeUser, Boolean(currentSession?.persistent || localStorage.getItem(SESSION_STORAGE_KEY) === currentSessionId));
+
+  return { success: true, user: safeUser };
 };
 
 export const requestPasswordReset = (email) => {

--- a/src/layouts/dashboard/AccountPopover.js
+++ b/src/layouts/dashboard/AccountPopover.js
@@ -21,15 +21,15 @@ import useAuth from '../../auth/useAuth';
 const MENU_OPTIONS = [
   {
     label: 'Home',
-    linkTo: '/',
+    linkTo: '/dashboard/app',
   },
   {
     label: 'Profile',
-    linkTo: '#',
+    linkTo: '/dashboard/profile',
   },
   {
     label: 'Settings',
-    linkTo: '#',
+    linkTo: '/dashboard/security',
   },
 ];
 
@@ -87,7 +87,7 @@ export default function AccountPopover() {
           }),
         }}
       >
-        <Avatar alt={user?.name || 'Usuário'} />
+        <Avatar src={user?.photoURL || ''} alt={user?.name || 'Usuário'} />
       </IconButton>
 
       <MenuPopover

--- a/src/layouts/dashboard/DashboardSidebar.js
+++ b/src/layouts/dashboard/DashboardSidebar.js
@@ -4,8 +4,6 @@ import { Link as RouterLink, useLocation } from 'react-router-dom';
 // material
 import { styled } from '@mui/material/styles';
 import { Box, Link, Button, Drawer, Typography, Avatar, Stack } from '@mui/material';
-// mock
-import account from '../../_mock/account';
 // hooks
 import useResponsive from '../../hooks/useResponsive';
 // components
@@ -14,6 +12,7 @@ import Scrollbar from '../../components/Scrollbar';
 import NavSection from '../../components/NavSection';
 //
 import navConfig from './NavConfig';
+import useAuth from '../../auth/useAuth';
 
 // ----------------------------------------------------------------------
 
@@ -45,6 +44,7 @@ export default function DashboardSidebar({ isOpenSidebar, onCloseSidebar }) {
   const { pathname } = useLocation();
 
   const isDesktop = useResponsive('up', 'lg');
+  const { user } = useAuth();
 
   useEffect(() => {
     if (isOpenSidebar) {
@@ -67,13 +67,13 @@ export default function DashboardSidebar({ isOpenSidebar, onCloseSidebar }) {
       <Box sx={{ mb: 5, mx: 2.5 }}>
         <Link underline="none" component={RouterLink} to="#">
           <AccountStyle>
-            <Avatar src={account.photoURL} alt="photoURL" />
+            <Avatar src={user?.photoURL || ''} alt={user?.name || 'Usuário'} />
             <Box sx={{ ml: 2 }}>
               <Typography variant="subtitle2" sx={{ color: 'text.primary' }}>
-                {account.displayName}
+                {user?.name || 'Usuário'}
               </Typography>
               <Typography variant="body2" sx={{ color: 'text.secondary' }}>
-                {account.role}
+                {user?.role || '-'}
               </Typography>
             </Box>
           </AccountStyle>

--- a/src/layouts/dashboard/NavConfig.js
+++ b/src/layouts/dashboard/NavConfig.js
@@ -57,6 +57,12 @@ const navConfig = [
     path: '/dashboard/security',
     icon: getIcon('eva:shield-fill'),
   },
+
+  {
+    title: 'perfil',
+    path: '/dashboard/profile',
+    icon: getIcon('eva:person-fill'),
+  },
 ];
 
 export default navConfig;

--- a/src/pages/ProfileSettings.js
+++ b/src/pages/ProfileSettings.js
@@ -1,0 +1,317 @@
+import { useMemo, useState } from 'react';
+import {
+  Alert,
+  Avatar,
+  Box,
+  Button,
+  Card,
+  Container,
+  Divider,
+  FormControl,
+  IconButton,
+  InputLabel,
+  MenuItem,
+  Select,
+  Stack,
+  Switch,
+  TextField,
+  Typography,
+} from '@mui/material';
+import Iconify from '../components/Iconify';
+import Page from '../components/Page';
+import useAuth from '../auth/useAuth';
+
+const CULTIVATION_LEVEL_OPTIONS = [
+  { value: 'iniciante', label: 'Iniciante' },
+  { value: 'intermediario', label: 'Intermediário' },
+  { value: 'avancado', label: 'Avançado' },
+];
+
+const LANGUAGE_OPTIONS = [
+  { value: 'pt-BR', label: 'Português (Brasil)' },
+  { value: 'en-US', label: 'English (US)' },
+  { value: 'es-ES', label: 'Español' },
+];
+
+const TIMEZONE_OPTIONS = [
+  { value: 'America/Sao_Paulo', label: 'America/Sao_Paulo (GMT-3)' },
+  { value: 'America/Manaus', label: 'America/Manaus (GMT-4)' },
+  { value: 'UTC', label: 'UTC (GMT+0)' },
+];
+
+export default function ProfileSettings() {
+  const { user, updateProfile } = useAuth();
+
+  const [form, setForm] = useState(() => ({
+    name: user?.name || '',
+    photoURL: user?.photoURL || '',
+    bio: user?.bio || '',
+    preferences: {
+      language: user?.preferences?.language || 'pt-BR',
+      measurementUnit: user?.preferences?.measurementUnit || 'métrico',
+      timezone: user?.preferences?.timezone || 'America/Sao_Paulo',
+    },
+    notifications: {
+      irrigationAlerts: Boolean(user?.notifications?.irrigationAlerts),
+      pestAlerts: Boolean(user?.notifications?.pestAlerts),
+      weatherAlerts: Boolean(user?.notifications?.weatherAlerts),
+      communityUpdates: Boolean(user?.notifications?.communityUpdates),
+      marketing: Boolean(user?.notifications?.marketing),
+    },
+    savedAddresses: user?.savedAddresses?.length ? user.savedAddresses : [{ id: `address-${Date.now()}`, label: '', addressLine: '' }],
+    cultivationLevel: user?.cultivationLevel || 'iniciante',
+  }));
+  const [feedback, setFeedback] = useState(null);
+
+  const avatarLetter = useMemo(() => (form.name ? form.name[0]?.toUpperCase() : 'U'), [form.name]);
+
+  const setField = (key, value) => {
+    setForm((prev) => ({ ...prev, [key]: value }));
+  };
+
+  return (
+    <Page title="Perfil e preferências">
+      <Container>
+        <Stack spacing={3}>
+          <Typography variant="h4">Perfil e preferências</Typography>
+
+          {feedback && <Alert severity={feedback.type}>{feedback.message}</Alert>}
+
+          <Card sx={{ p: 3 }}>
+            <Stack spacing={2}>
+              <Typography variant="h6">Dados de perfil</Typography>
+
+              <Stack direction={{ xs: 'column', md: 'row' }} spacing={2} alignItems={{ md: 'center' }}>
+                <Avatar src={form.photoURL} sx={{ width: 64, height: 64 }}>{avatarLetter}</Avatar>
+                <TextField
+                  fullWidth
+                  label="URL da foto"
+                  value={form.photoURL}
+                  onChange={(event) => setField('photoURL', event.target.value)}
+                  placeholder="https://..."
+                />
+              </Stack>
+
+              <TextField
+                fullWidth
+                label="Nome"
+                value={form.name}
+                onChange={(event) => setField('name', event.target.value)}
+              />
+
+              <TextField
+                fullWidth
+                label="Bio"
+                minRows={3}
+                multiline
+                value={form.bio}
+                onChange={(event) => setField('bio', event.target.value)}
+              />
+            </Stack>
+          </Card>
+
+          <Card sx={{ p: 3 }}>
+            <Stack spacing={2}>
+              <Typography variant="h6">Preferências</Typography>
+
+              <Stack direction={{ xs: 'column', md: 'row' }} spacing={2}>
+                <FormControl fullWidth>
+                  <InputLabel id="language-label">Idioma</InputLabel>
+                  <Select
+                    labelId="language-label"
+                    label="Idioma"
+                    value={form.preferences.language}
+                    onChange={(event) =>
+                      setField('preferences', {
+                        ...form.preferences,
+                        language: event.target.value,
+                      })
+                    }
+                  >
+                    {LANGUAGE_OPTIONS.map((option) => (
+                      <MenuItem key={option.value} value={option.value}>
+                        {option.label}
+                      </MenuItem>
+                    ))}
+                  </Select>
+                </FormControl>
+
+                <FormControl fullWidth>
+                  <InputLabel id="measurement-label">Unidade de medida</InputLabel>
+                  <Select
+                    labelId="measurement-label"
+                    label="Unidade de medida"
+                    value={form.preferences.measurementUnit}
+                    onChange={(event) =>
+                      setField('preferences', {
+                        ...form.preferences,
+                        measurementUnit: event.target.value,
+                      })
+                    }
+                  >
+                    <MenuItem value="métrico">Métrico (°C, mm, cm)</MenuItem>
+                    <MenuItem value="imperial">Imperial (°F, in)</MenuItem>
+                  </Select>
+                </FormControl>
+
+                <FormControl fullWidth>
+                  <InputLabel id="timezone-label">Fuso horário</InputLabel>
+                  <Select
+                    labelId="timezone-label"
+                    label="Fuso horário"
+                    value={form.preferences.timezone}
+                    onChange={(event) =>
+                      setField('preferences', {
+                        ...form.preferences,
+                        timezone: event.target.value,
+                      })
+                    }
+                  >
+                    {TIMEZONE_OPTIONS.map((option) => (
+                      <MenuItem key={option.value} value={option.value}>
+                        {option.label}
+                      </MenuItem>
+                    ))}
+                  </Select>
+                </FormControl>
+              </Stack>
+            </Stack>
+          </Card>
+
+          <Card sx={{ p: 3 }}>
+            <Stack spacing={2}>
+              <Typography variant="h6">Preferências de notificações</Typography>
+
+              {[
+                ['irrigationAlerts', 'Alertas de irrigação'],
+                ['pestAlerts', 'Alertas de pragas'],
+                ['weatherAlerts', 'Alertas climáticos'],
+                ['communityUpdates', 'Atualizações da comunidade'],
+                ['marketing', 'Novidades e campanhas'],
+              ].map(([key, label]) => (
+                <Stack key={key} direction="row" justifyContent="space-between" alignItems="center">
+                  <Typography>{label}</Typography>
+                  <Switch
+                    checked={form.notifications[key]}
+                    onChange={(_, checked) =>
+                      setField('notifications', {
+                        ...form.notifications,
+                        [key]: checked,
+                      })
+                    }
+                  />
+                </Stack>
+              ))}
+            </Stack>
+          </Card>
+
+          <Card sx={{ p: 3 }}>
+            <Stack spacing={2}>
+              <Typography variant="h6">Endereços salvos</Typography>
+
+              {form.savedAddresses.map((address, index) => (
+                <Box key={address.id}>
+                  <Stack direction={{ xs: 'column', md: 'row' }} spacing={2} alignItems={{ md: 'center' }}>
+                    <TextField
+                      fullWidth
+                      label="Rótulo"
+                      value={address.label}
+                      onChange={(event) => {
+                        const nextAddresses = [...form.savedAddresses];
+                        nextAddresses[index] = { ...address, label: event.target.value };
+                        setField('savedAddresses', nextAddresses);
+                      }}
+                    />
+                    <TextField
+                      fullWidth
+                      label="Endereço"
+                      value={address.addressLine}
+                      onChange={(event) => {
+                        const nextAddresses = [...form.savedAddresses];
+                        nextAddresses[index] = { ...address, addressLine: event.target.value };
+                        setField('savedAddresses', nextAddresses);
+                      }}
+                    />
+                    <IconButton
+                      color="error"
+                      onClick={() => {
+                        if (form.savedAddresses.length === 1) {
+                          return;
+                        }
+
+                        setField(
+                          'savedAddresses',
+                          form.savedAddresses.filter((item) => item.id !== address.id)
+                        );
+                      }}
+                    >
+                      <Iconify icon="eva:trash-2-outline" />
+                    </IconButton>
+                  </Stack>
+                  {index < form.savedAddresses.length - 1 && <Divider sx={{ mt: 2 }} />}
+                </Box>
+              ))}
+
+              <Button
+                variant="outlined"
+                startIcon={<Iconify icon="eva:plus-outline" />}
+                onClick={() =>
+                  setField('savedAddresses', [
+                    ...form.savedAddresses,
+                    { id: `address-${Date.now()}-${Math.random().toString(16).slice(2)}`, label: '', addressLine: '' },
+                  ])
+                }
+              >
+                Adicionar endereço
+              </Button>
+            </Stack>
+          </Card>
+
+          <Card sx={{ p: 3 }}>
+            <Stack spacing={2}>
+              <Typography variant="h6">Dados de cultivo</Typography>
+              <FormControl fullWidth>
+                <InputLabel id="cultivation-level-label">Nível de cultivo</InputLabel>
+                <Select
+                  labelId="cultivation-level-label"
+                  label="Nível de cultivo"
+                  value={form.cultivationLevel}
+                  onChange={(event) => setField('cultivationLevel', event.target.value)}
+                >
+                  {CULTIVATION_LEVEL_OPTIONS.map((option) => (
+                    <MenuItem key={option.value} value={option.value}>
+                      {option.label}
+                    </MenuItem>
+                  ))}
+                </Select>
+              </FormControl>
+            </Stack>
+          </Card>
+
+          <Stack direction="row" justifyContent="flex-end">
+            <Button
+              variant="contained"
+              onClick={() => {
+                const normalized = {
+                  ...form,
+                  savedAddresses: form.savedAddresses.filter((item) => item.label.trim() || item.addressLine.trim()),
+                };
+
+                const result = updateProfile(normalized);
+
+                if (result.error) {
+                  setFeedback({ type: 'error', message: result.error });
+                  return;
+                }
+
+                setFeedback({ type: 'success', message: 'Perfil atualizado com sucesso.' });
+              }}
+            >
+              Salvar alterações
+            </Button>
+          </Stack>
+        </Stack>
+      </Container>
+    </Page>
+  );
+}

--- a/src/routes.js
+++ b/src/routes.js
@@ -16,6 +16,7 @@ import StatusPage from './pages/StatusPage';
 import ForgotPassword from './pages/ForgotPassword';
 import ResetPassword from './pages/ResetPassword';
 import Security from './pages/Security';
+import ProfileSettings from './pages/ProfileSettings';
 import RequireAuth from './components/auth/RequireAuth';
 import RedirectIfAuth from './components/auth/RedirectIfAuth';
 
@@ -39,6 +40,7 @@ export default function Router() {
         { path: 'onboarding', element: <Onboarding /> },
         { path: 'status', element: <StatusPage /> },
         { path: 'security', element: <Security /> },
+        { path: 'profile', element: <ProfileSettings /> },
       ],
     },
     {


### PR DESCRIPTION
### Motivation

- Fornecer uma interface para o usuário editar nome, foto e bio e definir preferências pessoais e de cultivo para a experiência da aplicação.
- Permitir configuração de preferências (idioma, unidade de medida, fuso horário), preferências de notificações, endereços salvos e nível de cultivo com persistência local.
- Integrar as alterações do perfil ao sistema de autenticação para que avatar/nome/perfis reflitam imediatamente na UI do dashboard.

### Description

- Adiciona nova página de configurações `src/pages/ProfileSettings.js` com campos para nome, foto, bio, preferências (idioma/unidade/fuso/hora), notificações, endereços e nível de cultivo (iniciante/intermediário/avançado). 
- Estende o módulo de sessão em `src/auth/session.js` com `buildSafeUser` para retornar um usuário seguro e `updateAuthenticatedUserProfile` para persistir alterações no `localStorage` e atualizar o usuário autenticado. 
- Expõe a ação `updateProfile` no `AuthContext` (`src/auth/AuthContext.js`) que chama `updateAuthenticatedUserProfile` e recarrega o estado de autenticação. 
- Atualiza roteamento e navegação (`src/routes.js`, `src/layouts/dashboard/NavConfig.js`) e ajusta componentes de conta (`AccountPopover.js`, `DashboardSidebar.js`) para exibir avatar/nome/role provenientes do perfil do usuário.

### Testing

- Executado `npm run build` com sucesso (Vite build concluído sem erros).
- Executado `npm test` com sucesso (script retorna exit 0; não há runner de testes configurado no repositório).
- Executado `npm run lint` que falhou devido à ausência de configuração ESLint no ambiente, portanto não foi possível validar estilo via `eslint` automaticamente.
- Start do servidor de desenvolvimento e verificação automática com Playwright que efetuou login e navegou até `/dashboard/profile`, gerando screenshot de validação (artifact gerado durante execução do script Playwright).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699cbfc2658c832ca584e14d54ac794b)