### PR TITLE
feat(security): adicionar desativação, exclusão, exportação de dados e consentimentos (LGPD)

### DIFF
--- a/src/auth/session.js
+++ b/src/auth/session.js
@@ -7,6 +7,8 @@ const PASSWORD_HISTORY_KEY = 'hortelan-password-history';
 const MFA_SETTINGS_KEY = 'hortelan-mfa-settings';
 const MFA_CHALLENGES_KEY = 'hortelan-mfa-challenges';
 const TRUSTED_DEVICES_KEY = 'hortelan-trusted-devices';
+const CONSENTS_KEY = 'hortelan-consents';
+const ACCOUNT_DELETION_REQUESTS_KEY = 'hortelan-account-deletion-requests';
 const DEVICE_STORAGE_KEY = 'hortelan-device-id';
 const RESET_TOKEN_EXPIRY_MINUTES = 30;
 const MFA_CODE_EXPIRY_MINUTES = 5;
@@ -37,6 +39,15 @@ const INITIAL_MFA_SETTINGS = {
   'admin-1': {
     enabled: true,
     method: 'email',
+  },
+};
+
+const INITIAL_CONSENTS = {
+  'admin-1': {
+    marketing: false,
+    analytics: true,
+    communications: true,
+    updatedAt: new Date().toISOString(),
   },
 };
 
@@ -110,6 +121,18 @@ const getTrustedDevicesStore = () => getLocalJson(TRUSTED_DEVICES_KEY, []);
 
 const saveTrustedDevicesStore = (devices) => {
   localStorage.setItem(TRUSTED_DEVICES_KEY, JSON.stringify(devices));
+};
+
+const getConsentsMap = () => getLocalJson(CONSENTS_KEY, INITIAL_CONSENTS);
+
+const saveConsentsMap = (consents) => {
+  localStorage.setItem(CONSENTS_KEY, JSON.stringify(consents));
+};
+
+const getAccountDeletionRequestsStore = () => getLocalJson(ACCOUNT_DELETION_REQUESTS_KEY, []);
+
+const saveAccountDeletionRequestsStore = (requests) => {
+  localStorage.setItem(ACCOUNT_DELETION_REQUESTS_KEY, JSON.stringify(requests));
 };
 
 const appendPasswordHistory = ({ user, method, changedBy }) => {
@@ -261,6 +284,10 @@ export const loginWithEmailAndPassword = ({
     return { error: 'Credenciais inválidas. Use admin@hortelan.com / admin123.' };
   }
 
+  if (user.isActive === false) {
+    return { error: 'Conta desativada. Entre em contato com o suporte para reativação.' };
+  }
+
   const mfaSettings = getMfaSettingsMap()[user.id] || { enabled: false, method: 'email' };
   const currentDeviceId = getCurrentDeviceId();
   const trustedDevice = isTrustedDeviceForUser(user.id, currentDeviceId);
@@ -378,6 +405,135 @@ export const getAuthenticatedUser = () => {
     email: user.email,
     role: user.role,
     name: user.name,
+    isActive: user.isActive !== false,
+  };
+};
+
+export const getUserConsents = () => {
+  const user = getAuthenticatedUser();
+
+  if (!user) {
+    return {
+      marketing: false,
+      analytics: false,
+      communications: false,
+      updatedAt: null,
+    };
+  }
+
+  return (
+    getConsentsMap()[user.id] || {
+      marketing: false,
+      analytics: true,
+      communications: true,
+      updatedAt: null,
+    }
+  );
+};
+
+export const updateUserConsents = (nextConsents) => {
+  const user = getAuthenticatedUser();
+
+  if (!user) {
+    return { error: 'Usuário não autenticado.' };
+  }
+
+  const consents = getConsentsMap();
+  consents[user.id] = {
+    ...getUserConsents(),
+    ...nextConsents,
+    updatedAt: new Date().toISOString(),
+  };
+
+  saveConsentsMap(consents);
+  return { success: true, consents: consents[user.id] };
+};
+
+export const getAccountDeletionRequest = () => {
+  const user = getAuthenticatedUser();
+
+  if (!user) {
+    return null;
+  }
+
+  return getAccountDeletionRequestsStore().find((request) => request.userId === user.id) || null;
+};
+
+export const requestAccountDeletion = ({ reason }) => {
+  const user = getAuthenticatedUser();
+
+  if (!user) {
+    return { error: 'Usuário não autenticado.' };
+  }
+
+  const now = new Date().toISOString();
+  const requests = getAccountDeletionRequestsStore().filter((request) => request.userId !== user.id);
+  requests.push({
+    id: `deletion-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+    userId: user.id,
+    email: user.email,
+    reason: reason?.trim() || 'Não informado',
+    requestedAt: now,
+    status: 'pending',
+  });
+  saveAccountDeletionRequestsStore(requests);
+
+  return { success: true };
+};
+
+export const deactivateCurrentAccount = ({ reason }) => {
+  const user = getAuthenticatedUser();
+
+  if (!user) {
+    return { error: 'Usuário não autenticado.' };
+  }
+
+  const users = getUsers();
+  const updatedUsers = users.map((item) =>
+    item.id === user.id
+      ? {
+          ...item,
+          isActive: false,
+          deactivatedAt: new Date().toISOString(),
+          deactivationReason: reason?.trim() || 'Não informado',
+        }
+      : item
+  );
+  saveUsers(updatedUsers);
+
+  logoutAllSessions();
+  return { success: true };
+};
+
+export const exportCurrentUserData = () => {
+  const user = getAuthenticatedUser();
+
+  if (!user) {
+    return { error: 'Usuário não autenticado.' };
+  }
+
+  const fullUser = getUsers().find((item) => item.id === user.id);
+
+  if (!fullUser) {
+    return { error: 'Dados de usuário não encontrados.' };
+  }
+
+  return {
+    exportedAt: new Date().toISOString(),
+    user: {
+      id: fullUser.id,
+      name: fullUser.name,
+      email: fullUser.email,
+      role: fullUser.role,
+      isActive: fullUser.isActive !== false,
+      deactivatedAt: fullUser.deactivatedAt || null,
+    },
+    consents: getConsentsMap()[fullUser.id] || null,
+    twoFactor: getMfaSettingsMap()[fullUser.id] || null,
+    sessions: getActiveSessions().filter((session) => session.userId === fullUser.id),
+    trustedDevices: getTrustedDevicesStore().filter((device) => device.userId === fullUser.id),
+    passwordHistory: getPasswordHistory().filter((entry) => entry.userId === fullUser.id),
+    accountDeletionRequest: getAccountDeletionRequestsStore().find((request) => request.userId === fullUser.id) || null,
   };
 };
 

--- a/src/pages/Security.js
+++ b/src/pages/Security.js
@@ -3,6 +3,10 @@ import {
   Button,
   Card,
   Container,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
   FormControl,
   InputLabel,
   MenuItem,
@@ -14,9 +18,11 @@ import {
   TableCell,
   TableHead,
   TableRow,
+  TextField,
   Typography,
 } from '@mui/material';
 import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import Page from '../components/Page';
 import useAuth from '../auth/useAuth';
 import { getPasswordChangeHistory } from '../auth/session';
@@ -31,12 +37,95 @@ const TWO_FACTOR_METHOD_LABELS = {
   authenticator: 'App autenticador',
 };
 
+const CONSENT_LABELS = {
+  marketing: 'Marketing',
+  analytics: 'Analytics',
+  communications: 'Comunicações',
+};
+
 export default function Security() {
-  const { user, twoFactor, trustedDevices, update2FASettings, removeTrustedDevice } = useAuth();
+  const navigate = useNavigate();
+  const {
+    user,
+    twoFactor,
+    trustedDevices,
+    consents,
+    deletionRequest,
+    update2FASettings,
+    removeTrustedDevice,
+    updateConsents,
+    requestDeletion,
+    deactivateAccount,
+    exportPersonalData,
+  } = useAuth();
 
   const history = getPasswordChangeHistory();
   const [method, setMethod] = useState(twoFactor?.method || 'email');
   const [feedback, setFeedback] = useState('');
+  const [error, setError] = useState('');
+  const [deactivationReason, setDeactivationReason] = useState('');
+  const [deletionReason, setDeletionReason] = useState('');
+  const [deactivationOpen, setDeactivationOpen] = useState(false);
+  const [deletionOpen, setDeletionOpen] = useState(false);
+
+  const handleConsentToggle = (field, checked) => {
+    const result = updateConsents({ [field]: checked });
+
+    if (result.error) {
+      setError(result.error);
+      return;
+    }
+
+    setError('');
+    setFeedback(`Consentimento de ${CONSENT_LABELS[field]} atualizado com sucesso.`);
+  };
+
+  const handleExport = () => {
+    const result = exportPersonalData();
+
+    if (result.error) {
+      setError(result.error);
+      return;
+    }
+
+    const blob = new Blob([JSON.stringify(result, null, 2)], { type: 'application/json' });
+    const url = URL.createObjectURL(blob);
+    const anchor = document.createElement('a');
+    const date = new Date().toISOString().slice(0, 10);
+    anchor.href = url;
+    anchor.download = `hortelan-dados-pessoais-${date}.json`;
+    anchor.click();
+    URL.revokeObjectURL(url);
+
+    setError('');
+    setFeedback('Arquivo de dados pessoais exportado com sucesso.');
+  };
+
+  const handleDeletionRequest = () => {
+    const result = requestDeletion({ reason: deletionReason });
+
+    if (result.error) {
+      setError(result.error);
+      return;
+    }
+
+    setDeletionOpen(false);
+    setDeletionReason('');
+    setError('');
+    setFeedback('Solicitação de exclusão registrada. Nossa equipe entrará em contato.');
+  };
+
+  const handleDeactivate = () => {
+    const result = deactivateAccount({ reason: deactivationReason });
+
+    if (result.error) {
+      setError(result.error);
+      return;
+    }
+
+    setDeactivationOpen(false);
+    navigate('/login', { replace: true });
+  };
 
   return (
     <Page title="Segurança">
@@ -44,14 +133,15 @@ export default function Security() {
         <Stack spacing={3}>
           <Typography variant="h4">Segurança da conta</Typography>
 
+          {feedback && <Alert severity="success">{feedback}</Alert>}
+          {error && <Alert severity="error">{error}</Alert>}
+
           <Card sx={{ p: 3 }}>
             <Stack spacing={2}>
               <Typography variant="h6">Autenticação em dois fatores (2FA)</Typography>
               <Typography color="text.secondary">
                 Ative o segundo fator por e-mail ou app autenticador para elevar o nível de proteção do login.
               </Typography>
-
-              {feedback && <Alert severity="success">{feedback}</Alert>}
 
               <Stack direction={{ xs: 'column', md: 'row' }} spacing={2} alignItems={{ md: 'center' }}>
                 <Stack direction="row" spacing={1} alignItems="center">
@@ -89,6 +179,56 @@ export default function Security() {
                   </Select>
                 </FormControl>
               </Stack>
+            </Stack>
+          </Card>
+
+          <Card sx={{ p: 3 }}>
+            <Stack spacing={2}>
+              <Typography variant="h6">Consentimentos e preferências</Typography>
+              <Typography color="text.secondary">
+                Gerencie as permissões para uso dos seus dados em campanhas, analytics e comunicações da plataforma.
+              </Typography>
+
+              <Stack spacing={1}>
+                {Object.entries(CONSENT_LABELS).map(([key, label]) => (
+                  <Stack key={key} direction="row" justifyContent="space-between" alignItems="center">
+                    <Typography>{label}</Typography>
+                    <Switch checked={Boolean(consents?.[key])} onChange={(_, checked) => handleConsentToggle(key, checked)} />
+                  </Stack>
+                ))}
+              </Stack>
+
+              <Typography variant="caption" color="text.secondary">
+                Última atualização: {consents?.updatedAt ? new Date(consents.updatedAt).toLocaleString() : 'Sem registro'}
+              </Typography>
+            </Stack>
+          </Card>
+
+          <Card sx={{ p: 3 }}>
+            <Stack spacing={2}>
+              <Typography variant="h6">LGPD e dados pessoais</Typography>
+              <Typography color="text.secondary">
+                Exporte seus dados pessoais em formato JSON para atender solicitações de portabilidade (LGPD).
+              </Typography>
+              <Stack direction={{ xs: 'column', sm: 'row' }} spacing={2}>
+                <Button variant="contained" onClick={handleExport}>
+                  Exportar dados pessoais
+                </Button>
+                <Button color="warning" variant="outlined" onClick={() => setDeactivationOpen(true)}>
+                  Desativar conta
+                </Button>
+                <Button color="error" variant="outlined" onClick={() => setDeletionOpen(true)}>
+                  Solicitar exclusão de conta
+                </Button>
+              </Stack>
+
+              {deletionRequest && (
+                <Alert severity="info">
+                  Solicitação em andamento ({new Date(deletionRequest.requestedAt).toLocaleString()}) - status: {deletionRequest.status}.
+                </Alert>
+              )}
+
+              {!user?.isActive && <Alert severity="warning">Sua conta está desativada.</Alert>}
             </Stack>
           </Card>
 
@@ -179,6 +319,54 @@ export default function Security() {
           </Card>
         </Stack>
       </Container>
+
+      <Dialog open={deactivationOpen} onClose={() => setDeactivationOpen(false)} fullWidth maxWidth="sm">
+        <DialogTitle>Desativar conta</DialogTitle>
+        <DialogContent>
+          <Stack spacing={2} sx={{ mt: 1 }}>
+            <Typography color="text.secondary">
+              A desativação encerra suas sessões e bloqueia novos logins até a reativação manual pelo suporte.
+            </Typography>
+            <TextField
+              label="Motivo da desativação (opcional)"
+              value={deactivationReason}
+              onChange={(event) => setDeactivationReason(event.target.value)}
+              multiline
+              minRows={3}
+            />
+          </Stack>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setDeactivationOpen(false)}>Cancelar</Button>
+          <Button color="warning" variant="contained" onClick={handleDeactivate}>
+            Confirmar desativação
+          </Button>
+        </DialogActions>
+      </Dialog>
+
+      <Dialog open={deletionOpen} onClose={() => setDeletionOpen(false)} fullWidth maxWidth="sm">
+        <DialogTitle>Solicitar exclusão de conta</DialogTitle>
+        <DialogContent>
+          <Stack spacing={2} sx={{ mt: 1 }}>
+            <Typography color="text.secondary">
+              Sua solicitação será registrada e analisada conforme os critérios de retenção legal aplicáveis.
+            </Typography>
+            <TextField
+              label="Motivo da solicitação (opcional)"
+              value={deletionReason}
+              onChange={(event) => setDeletionReason(event.target.value)}
+              multiline
+              minRows={3}
+            />
+          </Stack>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setDeletionOpen(false)}>Cancelar</Button>
+          <Button color="error" variant="contained" onClick={handleDeletionRequest}>
+            Confirmar solicitação
+          </Button>
+        </DialogActions>
+      </Dialog>
     </Page>
   );
 }


### PR DESCRIPTION
### Motivation
- Implementar fluxos de privacidade e gestão de conta exigidos pela LGPD: exportação de dados, solicitação de exclusão, desativação de conta e gerenciamento de consentimentos.
- Disponibilizar essas ações ao front-end para que usuários possam gerir preferências e solicitar operações sobre sua conta sem necessidade de backend real.

### Description
- Adicionado armazenamento e APIs locais em `src/auth/session.js` para `consents`, `account deletion requests`, `exportCurrentUserData`, `requestAccountDeletion`, `deactivateCurrentAccount`, `getUserConsents` e `updateUserConsents`.
- Exposto o novo estado e ações no contexto de autenticação em `src/auth/AuthContext.js` (`consents`, `deletionRequest`, `updateConsents`, `requestDeletion`, `deactivateAccount`, `exportPersonalData`).
- Atualizada a UI em `src/pages/Security.js` com seção de consentimentos (toggles persistidos), seções LGPD (exportar JSON), modais para desativação e solicitação de exclusão e indicadores de feedback/estado.
- Mudanças principais em arquivos: `src/auth/session.js`, `src/auth/AuthContext.js`, `src/pages/Security.js`.

### Testing
- Executado `npm run build` (produziu build de produção com sucesso).
- Executado `npm run lint`, que falhou por ausência de configuração de ESLint no ambiente/repositório (limitação do ambiente, não do patch).
- Smoke e2e: iniciação do servidor de desenvolvimento e execução de script Playwright que autenticou o usuário demo e gerou screenshots da página de Segurança (artefatos gerados durante a validação).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699cc0dadde8832c89166e6ef88acc5d)