### PR TITLE
feat(profile): permitir múltiplas hortas por usuário

### DIFF
--- a/src/auth/AuthContext.js
+++ b/src/auth/AuthContext.js
@@ -107,6 +107,14 @@ export function AuthProvider({ children }) {
 
   const updateConsents = useCallback((nextConsents) => {
     const result = updateUserConsents(nextConsents);
+
+    if (!result.error) {
+      refreshAuthState();
+    }
+
+    return result;
+  }, [refreshAuthState]);
+
   const updateProfile = useCallback((payload) => {
     const result = updateAuthenticatedUserProfile(payload);
 


### PR DESCRIPTION
### Motivation
- Adicionar suporte para que cada usuário possa criar e gerenciar uma ou mais hortas com campos básicos (nome, tipo, localização, foto) a partir da tela de perfil.
- Garantir que a camada de sessão/auth normalize e persista esses dados no perfil do usuário de forma segura.

### Description
- Atualiza `src/pages/ProfileSettings.js` para permitir criar/editar/remover múltiplas hortas por usuário, com campos `name`, `gardenType` (opções: `solo`, `vaso`, `vertical`, `hidroponia`, `indoor`, `estufa`), `location` e `photoURL`, incluindo pré-visualização da imagem e normalização ao salvar.
- Estende a lógica de sessão em `src/auth/session.js` para suportar `gardens` no usuário, incluindo seed inicial com exemplo de horta, inclusão em `buildSafeUser`, persistência em `updateAuthenticatedUserProfile` e retorno no `exportCurrentUserData` (campo `profile.gardens`).
- Corrige fluxo em `src/auth/AuthContext.js` para que `updateConsents` atualize o estado (`refreshAuthState`) após sucesso, evitando quebra de parsing e comportamentos inconsistentes.
- Normalização: ao salvar o perfil, `savedAddresses` e `gardens` são filtrados para remover itens vazios e nomes são padronizados quando ausentes.

### Testing
- `npm run build` executado com sucesso e gerou os assets de produção (`vite build` passou). ✅
- `npm run lint` não pôde ser concluído porque o repositório não possui arquivo de configuração do ESLint no ambiente (ESLint retornou erro de configuração). ⚠️
- Tentativa de validar a UI via script Playwright para capturar screenshot falhou porque o Chromium do container apresentou `SIGSEGV` ao iniciar; não foi possível gerar a imagem de verificação. ⚠️

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699cc3e85d54832caa00348036db3cff)