### PR TITLE
feat(profile): adicionar gestão de setores/áreas por horta

### DIFF
--- a/src/auth/session.js
+++ b/src/auth/session.js
@@ -50,6 +50,20 @@ const USERS = [
         gardenType: 'vaso',
         location: 'São Paulo/SP - Vila Mariana',
         photoURL: '',
+        sectors: [
+          {
+            id: 'sector-admin-1',
+            name: 'Canteiro 1',
+            dimensions: '2m x 1m',
+            sectorType: 'sol_pleno',
+          },
+          {
+            id: 'sector-admin-2',
+            name: 'Bancada A',
+            dimensions: '',
+            sectorType: 'meia_sombra',
+          },
+        ],
       },
     ],
   },
@@ -86,6 +100,12 @@ const buildSafeUser = (user) => ({
     gardenType: garden.gardenType || 'solo',
     location: garden.location || '',
     photoURL: garden.photoURL || '',
+    sectors: (garden.sectors || []).map((sector, sectorIndex) => ({
+      id: sector.id || `sector-${Date.now()}-${index}-${sectorIndex}`,
+      name: sector.name || `Setor ${sectorIndex + 1}`,
+      dimensions: sector.dimensions || '',
+      sectorType: sector.sectorType || 'sol_pleno',
+    })),
   })),
 });
 
@@ -642,6 +662,12 @@ export const updateAuthenticatedUserProfile = (payload) => {
       gardenType: garden.gardenType || 'solo',
       location: garden.location?.trim() || '',
       photoURL: garden.photoURL?.trim() || '',
+      sectors: (garden.sectors || []).map((sector, sectorIndex) => ({
+        id: sector.id || `sector-${Date.now()}-${index}-${sectorIndex}`,
+        name: sector.name?.trim() || `Setor ${sectorIndex + 1}`,
+        dimensions: sector.dimensions?.trim() || '',
+        sectorType: sector.sectorType || 'sol_pleno',
+      })),
     })),
   };
 


### PR DESCRIPTION
### Motivation

- Permitir que o usuário divida cada horta em áreas/setores para representar canteiros, bancadas, torres etc.;
- Dar aos setores atributos básicos: nome, dimensões (opcional) e tipo de incidência (luz total, meia sombra, indoor, estufa, etc.), além de permitir CRUD desses setores na UI do Perfil.

### Description

- Adiciona opções de tipo de setor em `src/pages/ProfileSettings.js` (`SECTOR_TYPE_OPTIONS`) e a factory `createEmptySector()` para criar setores vazios;
- Extende o `createEmptyGarden()` para inicializar `sectors` e altera a inicialização do formulário para garantir que cada horta tenha ao menos um setor;
- Implementa UI completa de CRUD de setores dentro do bloco de cada horta em `ProfileSettings.js`, incluindo campos para `Nome do setor`, `Dimensões` e `Tipo do setor`, além de botões para adicionar/remover setores;
- Normaliza e persiste setores ao salvar o perfil, removendo setores vazios e preenchendo nomes padrão (`Setor N`) quando necessário; e atualiza `src/auth/session.js` para incluir setores no seed do usuário, expô‑los via `buildSafeUser` e persistir setores em `updateAuthenticatedUserProfile`.

### Testing

- `npm run lint` foi executado mas falhou por falta de configuração de ESLint no ambiente (erro esperado relativo à ausência de arquivo de configuração);
- `npm run build` (produção) foi executado com sucesso e concluiu a build sem erros;
- Aplicação inicializada com `npm run dev` e um script Playwright navegou até `/dashboard/profile`, autenticou o usuário de demo e gerou uma screenshot de validação (`artifacts/profile-sectors.png`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699cc5d6a84c832c87cce17711711020)