### PR TITLE
feat(status): adicionar estado manual e alertas por planta na tela de status

### DIFF
--- a/src/pages/StatusPage.js
+++ b/src/pages/StatusPage.js
@@ -1,3 +1,4 @@
+import { useMemo, useState } from 'react';
 import SensorsIcon from '@mui/icons-material/Sensors';
 import RouterIcon from '@mui/icons-material/Router';
 import WarningAmberRoundedIcon from '@mui/icons-material/WarningAmberRounded';
@@ -12,6 +13,8 @@ import {
   Container,
   Grid,
   Stack,
+  ToggleButton,
+  ToggleButtonGroup,
   Typography,
 } from '@mui/material';
 import Page from '../components/Page';
@@ -51,6 +54,22 @@ const greenhouseAreas = [
       { id: 'S-102', type: 'sensor', name: 'Sensor Clima A', top: '62%', left: '42%' },
       { id: 'D-014', type: 'device', name: 'Bomba de Irrigação', top: '18%', left: '74%' },
     ],
+    plants: [
+      {
+        id: 'PL-001',
+        name: 'Tomate Italiano',
+        manualStatus: 'healthy',
+        sensorReadings: { moisture: 56, temperature: 24, conductivity: 1.7 },
+        alerts: [],
+      },
+      {
+        id: 'PL-002',
+        name: 'Manjericão',
+        manualStatus: 'attention',
+        sensorReadings: { moisture: 41, temperature: 28, conductivity: 1.2 },
+        alerts: ['Desenvolvimento lento observado na última inspeção visual'],
+      },
+    ],
     alerts: [],
   },
   {
@@ -62,6 +81,22 @@ const greenhouseAreas = [
       { id: 'S-205', type: 'sensor', name: 'Sensor Umidade B', top: '36%', left: '20%' },
       { id: 'D-118', type: 'device', name: 'Válvula Setor 2', top: '68%', left: '58%' },
     ],
+    plants: [
+      {
+        id: 'PL-031',
+        name: 'Alface Crespa',
+        manualStatus: 'attention',
+        sensorReadings: { moisture: 29, temperature: 31, conductivity: 0.8 },
+        alerts: ['Pontas queimadas em folhas externas'],
+      },
+      {
+        id: 'PL-032',
+        name: 'Rúcula',
+        manualStatus: 'healthy',
+        sensorReadings: null,
+        alerts: [],
+      },
+    ],
     alerts: ['Umidade do solo abaixo de 32% nas últimas 2h'],
   },
   {
@@ -72,6 +107,15 @@ const greenhouseAreas = [
     devices: [
       { id: 'S-307', type: 'sensor', name: 'Sensor Temperatura C', top: '48%', left: '30%' },
       { id: 'D-219', type: 'device', name: 'Exaustor Principal', top: '24%', left: '68%' },
+    ],
+    plants: [
+      {
+        id: 'PL-078',
+        name: 'Pimentão Vermelho',
+        manualStatus: 'critical',
+        sensorReadings: { moisture: 18, temperature: 39, conductivity: 2.8 },
+        alerts: ['Murcha severa e perda de turgor em 30% das plantas'],
+      },
     ],
     alerts: ['Temperatura acima de 38°C', 'Falha intermitente no exaustor principal'],
   },
@@ -85,13 +129,67 @@ const greenhouseAreas = [
       { id: 'D-333', type: 'device', name: 'Misturador', top: '42%', left: '64%' },
       { id: 'S-413', type: 'sensor', name: 'Sensor Umidade D', top: '70%', left: '82%' },
     ],
+    plants: [
+      {
+        id: 'PL-144',
+        name: 'Couve Manteiga',
+        manualStatus: 'healthy',
+        sensorReadings: { moisture: 62, temperature: 23, conductivity: 1.5 },
+        alerts: [],
+      },
+    ],
     alerts: [],
   },
 ];
 
+const manualStatusConfig = {
+  healthy: { label: 'Saudável', color: 'success' },
+  attention: { label: 'Atenção', color: 'warning' },
+  critical: { label: 'Crítico', color: 'error' },
+};
+
+const statusPriority = { healthy: 1, attention: 2, critical: 3 };
+
+function getSensorStatus(readings) {
+  if (!readings) return null;
+
+  const isCritical = readings.moisture < 25 || readings.temperature > 37 || readings.conductivity > 2.5;
+  if (isCritical) return 'critical';
+
+  const isAttention = readings.moisture < 40 || readings.temperature > 31 || readings.conductivity < 1;
+  if (isAttention) return 'attention';
+
+  return 'healthy';
+}
+
+function getPlantSensorAlerts(readings) {
+  if (!readings) return [];
+
+  const sensorAlerts = [];
+
+  if (readings.moisture < 40) sensorAlerts.push(`Umidade de solo baixa (${readings.moisture}%)`);
+  if (readings.temperature > 31) sensorAlerts.push(`Temperatura acima da faixa ideal (${readings.temperature}°C)`);
+  if (readings.conductivity < 1 || readings.conductivity > 2.5) {
+    sensorAlerts.push(`Condutividade fora da faixa recomendada (${readings.conductivity} mS/cm)`);
+  }
+
+  return sensorAlerts;
+}
+
 export default function StatusPage() {
+  const initialManualStatus = useMemo(
+    () =>
+      greenhouseAreas.flatMap((area) => area.plants).reduce((acc, plant) => {
+        acc[plant.id] = plant.manualStatus;
+        return acc;
+      }, {}),
+    []
+  );
+  const [manualPlantStatus, setManualPlantStatus] = useState(initialManualStatus);
+
   const totalDevices = greenhouseAreas.reduce((acc, area) => acc + area.devices.length, 0);
   const totalAlerts = greenhouseAreas.reduce((acc, area) => acc + area.alerts.length, 0);
+  const totalPlants = greenhouseAreas.reduce((acc, area) => acc + area.plants.length, 0);
 
   return (
     <Page title="Status por Área">
@@ -134,6 +232,16 @@ export default function StatusPage() {
                   <Typography variant="h3" color={totalAlerts > 0 ? 'error.main' : 'success.main'}>
                     {totalAlerts}
                   </Typography>
+                </CardContent>
+              </Card>
+            </Grid>
+            <Grid item xs={12} md={4}>
+              <Card>
+                <CardContent>
+                  <Typography variant="overline" color="text.secondary">
+                    Plantas acompanhadas
+                  </Typography>
+                  <Typography variant="h3">{totalPlants}</Typography>
                 </CardContent>
               </Card>
             </Grid>
@@ -236,6 +344,80 @@ export default function StatusPage() {
                           ))}
                         </Stack>
                       )}
+
+                      <Stack spacing={2} sx={{ mt: 2 }}>
+                        <Typography variant="subtitle2">Status das plantas</Typography>
+                        {area.plants.map((plant) => {
+                          const manualStatus = manualPlantStatus[plant.id] || plant.manualStatus;
+                          const sensorStatus = getSensorStatus(plant.sensorReadings);
+                          const finalStatus =
+                            sensorStatus && statusPriority[sensorStatus] > statusPriority[manualStatus]
+                              ? sensorStatus
+                              : manualStatus;
+                          const plantAlerts = [...getPlantSensorAlerts(plant.sensorReadings), ...plant.alerts];
+
+                          return (
+                            <Card key={plant.id} variant="outlined" sx={{ borderColor: 'divider' }}>
+                              <CardContent sx={{ p: 2, '&:last-child': { pb: 2 } }}>
+                                <Stack spacing={1.2}>
+                                  <Stack direction="row" justifyContent="space-between" alignItems="center" flexWrap="wrap" gap={1}>
+                                    <Typography variant="body2" sx={{ fontWeight: 700 }}>
+                                      {plant.name}
+                                    </Typography>
+                                    <Chip
+                                      size="small"
+                                      color={manualStatusConfig[finalStatus].color}
+                                      label={`Condição atual: ${manualStatusConfig[finalStatus].label}`}
+                                    />
+                                  </Stack>
+
+                                  <ToggleButtonGroup
+                                    exclusive
+                                    size="small"
+                                    value={manualStatus}
+                                    onChange={(_, nextValue) => {
+                                      if (!nextValue) return;
+                                      setManualPlantStatus((prev) => ({ ...prev, [plant.id]: nextValue }));
+                                    }}
+                                  >
+                                    {Object.entries(manualStatusConfig).map(([status, config]) => (
+                                      <ToggleButton key={`${plant.id}-${status}`} value={status}>
+                                        {config.label}
+                                      </ToggleButton>
+                                    ))}
+                                  </ToggleButtonGroup>
+
+                                  {plant.sensorReadings ? (
+                                    <Stack direction="row" spacing={1} useFlexGap flexWrap="wrap">
+                                      <Chip size="small" variant="outlined" label={`Umidade: ${plant.sensorReadings.moisture}%`} />
+                                      <Chip size="small" variant="outlined" label={`Temperatura: ${plant.sensorReadings.temperature}°C`} />
+                                      <Chip
+                                        size="small"
+                                        variant="outlined"
+                                        label={`Condutividade: ${plant.sensorReadings.conductivity} mS/cm`}
+                                      />
+                                    </Stack>
+                                  ) : (
+                                    <Typography variant="caption" color="text.secondary">
+                                      Sem telemetria recente para esta planta.
+                                    </Typography>
+                                  )}
+
+                                  {plantAlerts.length > 0 && (
+                                    <Stack spacing={0.8}>
+                                      {plantAlerts.map((plantAlert) => (
+                                        <Alert key={`${plant.id}-${plantAlert}`} severity={finalStatus === 'critical' ? 'error' : 'warning'}>
+                                          {plantAlert}
+                                        </Alert>
+                                      ))}
+                                    </Stack>
+                                  )}
+                                </Stack>
+                              </CardContent>
+                            </Card>
+                          );
+                        })}
+                      </Stack>
                     </CardContent>
                   </Card>
                 </Grid>


### PR DESCRIPTION
### Motivation
- Permitir acompanhamento por planta com um estado manual (Saudável, Atenção, Crítico) para complementar telemetria automática. 
- Gerar indicadores e alertas derivados de leituras de sensores (umidade, temperatura, condutividade) para priorizar intervenções em campo.

### Description
- Adicionei campos de plantas por área e um KPI de `Plantas acompanhadas` na página de status em `src/pages/StatusPage.js`.
- Implementei `manualStatusConfig`, `getSensorStatus` e `getPlantSensorAlerts` para computar severidade baseada em telemetria e produzir mensagens amigáveis. 
- Incluí controle de alteração manual por planta usando `ToggleButtonGroup`/`ToggleButton` e estado local (`manualPlantStatus`) para persistência em sessão. 
- Exibição na UI de chips de telemetria, condição final (piora entre manual e sensor) e alertas combinados (sensores + observacionais).

### Testing
- Executei `npm run build` e a construção do bundle completou com sucesso. 
- Rodei `npm run dev -- --host 0.0.0.0 --port 4173` e a aplicação subiu localmente com sucesso para validação visual. 
- Capturei uma validação automática da rota `/dashboard/status` via Playwright; a execução com Chromium falhou por crash do browser no ambiente, mas a execução com Firefox concluiu e gerou a captura de tela de verificação.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699cdc4ba28c832cb586c093c1ec3872)