### PR TITLE
feat: adicionar condições, histórico e tarefas por planta; corrigir StatusPage para build

### DIFF
--- a/src/pages/DashboardApp.js
+++ b/src/pages/DashboardApp.js
@@ -8,6 +8,7 @@ import {
   Button,
   Card,
   CardContent,
+  Checkbox,
   Chip,
   Container,
   FormControl,
@@ -97,6 +98,13 @@ const eventTypeOptions = [
   { value: 'colheita', label: 'Colheita' },
 ];
 
+const baseTasksByPhase = {
+  Germinação: ['Monitorar umidade diariamente', 'Verificar incidência de luz indireta'],
+  Crescimento: ['Adubar com composto orgânico', 'Inspecionar sinais de pragas'],
+  Floração: ['Ajustar irrigação para manter constância', 'Reforçar tutoramento dos ramos'],
+  Colheita: ['Planejar colheita escalonada', 'Registrar produtividade da semana'],
+};
+
 const sensorWidgets = [
   {
     title: 'Sensor de umidade do solo',
@@ -162,6 +170,7 @@ export default function DashboardApp() {
   const [novoEventoPorPlanta, setNovoEventoPorPlanta] = useState({});
   const [novaFotoPorPlanta, setNovaFotoPorPlanta] = useState({});
   const [novaObservacaoPorPlanta, setNovaObservacaoPorPlanta] = useState({});
+  const [novaTarefaPorPlanta, setNovaTarefaPorPlanta] = useState({});
 
   const opcoesEspecie = [
     'Alface Crespa',
@@ -196,6 +205,12 @@ export default function DashboardApp() {
         eventos: [],
         fotos: [],
         observacoes: [],
+        tarefas: (baseTasksByPhase[novaPlanta.faseCultivo] || []).map((titulo) => ({
+          id: faker.datatype.uuid(),
+          titulo,
+          concluida: false,
+          prioridade: 'média',
+        })),
       },
       ...prev,
     ]);
@@ -337,6 +352,54 @@ export default function DashboardApp() {
       ...prev,
       [plantaId]: { data: '', texto: '' },
     }));
+  };
+
+  const atualizarNovaTarefa = (plantaId, value) => {
+    setNovaTarefaPorPlanta((prev) => ({
+      ...prev,
+      [plantaId]: value,
+    }));
+  };
+
+  const adicionarTarefa = (plantaId) => {
+    const titulo = (novaTarefaPorPlanta[plantaId] || '').trim();
+    if (!titulo) return;
+
+    setPlantas((prev) =>
+      prev.map((planta) =>
+        planta.id === plantaId
+          ? {
+              ...planta,
+              tarefas: [
+                {
+                  id: faker.datatype.uuid(),
+                  titulo,
+                  concluida: false,
+                  prioridade: 'média',
+                },
+                ...planta.tarefas,
+              ],
+            }
+          : planta
+      )
+    );
+
+    atualizarNovaTarefa(plantaId, '');
+  };
+
+  const alternarTarefa = (plantaId, tarefaId) => {
+    setPlantas((prev) =>
+      prev.map((planta) =>
+        planta.id === plantaId
+          ? {
+              ...planta,
+              tarefas: planta.tarefas.map((tarefa) =>
+                tarefa.id === tarefaId ? { ...tarefa, concluida: !tarefa.concluida } : tarefa
+              ),
+            }
+          : planta
+      )
+    );
   };
 
   const janelaAtual = regionalSeasonality[region][novaPlanta.especie] || [];
@@ -582,6 +645,30 @@ export default function DashboardApp() {
                       const draftEvento = novoEventoPorPlanta[planta.id] || { tipo: '', data: '', detalhes: '' };
                       const draftFoto = novaFotoPorPlanta[planta.id] || { data: '', url: '', legenda: '' };
                       const draftObservacao = novaObservacaoPorPlanta[planta.id] || { data: '', texto: '' };
+                      const draftTarefa = novaTarefaPorPlanta[planta.id] || '';
+                      const tarefasPendentes = planta.tarefas.filter((tarefa) => !tarefa.concluida);
+                      const ultimoEvento = planta.eventos[0];
+                      const ultimaFoto = planta.fotos[0];
+                      const condicoes = [
+                        {
+                          label: `Fase: ${planta.faseCultivo}`,
+                          color: planta.faseCultivo === 'Colheita' ? 'success' : 'info',
+                        },
+                        {
+                          label: `${tarefasPendentes.length} tarefa(s) pendente(s)`,
+                          color: tarefasPendentes.length > 0 ? 'warning' : 'success',
+                        },
+                        {
+                          label: ultimoEvento
+                            ? `Último cuidado: ${eventTypeOptions.find((option) => option.value === ultimoEvento.tipo)?.label || 'Registro manual'}`
+                            : 'Sem cuidado registrado',
+                          color: ultimoEvento ? 'primary' : 'default',
+                        },
+                        {
+                          label: ultimaFoto ? `Última foto em ${ultimaFoto.data}` : 'Sem foto de evolução',
+                          color: ultimaFoto ? 'secondary' : 'default',
+                        },
+                      ];
 
                       const timeline = [
                         ...planta.eventos.map((evento) => ({
@@ -624,9 +711,20 @@ export default function DashboardApp() {
                             </Stack>
 
                             <Grid container spacing={2} sx={{ mt: 0.5 }}>
+                              <Grid item xs={12}>
+                                <Typography variant="subtitle2" sx={{ mb: 1 }}>
+                                  Condições atuais relacionadas à planta
+                                </Typography>
+                                <Stack direction="row" spacing={1} flexWrap="wrap" useFlexGap>
+                                  {condicoes.map((item) => (
+                                    <Chip key={item.label} size="small" label={item.label} color={item.color} variant="outlined" />
+                                  ))}
+                                </Stack>
+                              </Grid>
+
                               <Grid item xs={12} md={4}>
                                 <Typography variant="subtitle2" sx={{ mb: 1 }}>
-                                  Registro de eventos
+                                  Histórico de cuidados
                                 </Typography>
                                 <Stack spacing={1}>
                                   <FormControl size="small" fullWidth>
@@ -661,6 +759,19 @@ export default function DashboardApp() {
                                   <Button size="small" variant="contained" onClick={() => adicionarEvento(planta.id)}>
                                     Salvar evento
                                   </Button>
+                                  {planta.eventos.length > 0 ? (
+                                    <Stack spacing={0.75}>
+                                      {planta.eventos.slice(0, 3).map((evento) => (
+                                        <Typography key={evento.id} variant="caption" color="text.secondary">
+                                          {evento.data} • {eventTypeOptions.find((option) => option.value === evento.tipo)?.label || evento.tipo}
+                                        </Typography>
+                                      ))}
+                                    </Stack>
+                                  ) : (
+                                    <Typography variant="caption" color="text.secondary">
+                                      Nenhum cuidado registrado até o momento.
+                                    </Typography>
+                                  )}
                                 </Stack>
                               </Grid>
 
@@ -697,7 +808,50 @@ export default function DashboardApp() {
 
                               <Grid item xs={12} md={4}>
                                 <Typography variant="subtitle2" sx={{ mb: 1 }}>
-                                  Observações do usuário
+                                  Próximas tarefas
+                                </Typography>
+                                <Stack spacing={1}>
+                                  <TextField
+                                    size="small"
+                                    label="Nova tarefa"
+                                    value={draftTarefa}
+                                    onChange={(event) => atualizarNovaTarefa(planta.id, event.target.value)}
+                                  />
+                                  <Button size="small" variant="contained" onClick={() => adicionarTarefa(planta.id)}>
+                                    Adicionar tarefa
+                                  </Button>
+                                  {planta.tarefas.length > 0 ? (
+                                    <Stack spacing={0.25}>
+                                      {planta.tarefas.slice(0, 4).map((tarefa) => (
+                                        <Stack key={tarefa.id} direction="row" spacing={0.5} alignItems="center">
+                                          <Checkbox
+                                            size="small"
+                                            checked={tarefa.concluida}
+                                            onChange={() => alternarTarefa(planta.id, tarefa.id)}
+                                          />
+                                          <Typography
+                                            variant="caption"
+                                            color="text.secondary"
+                                            sx={{ textDecoration: tarefa.concluida ? 'line-through' : 'none' }}
+                                          >
+                                            {tarefa.titulo}
+                                          </Typography>
+                                        </Stack>
+                                      ))}
+                                    </Stack>
+                                  ) : (
+                                    <Typography variant="caption" color="text.secondary">
+                                      Nenhuma tarefa cadastrada.
+                                    </Typography>
+                                  )}
+                                </Stack>
+                              </Grid>
+                            </Grid>
+
+                            <Card variant="outlined" sx={{ mt: 2 }}>
+                              <CardContent>
+                                <Typography variant="subtitle2" sx={{ mb: 1 }}>
+                                  Observações de evolução
                                 </Typography>
                                 <Stack spacing={1}>
                                   <TextField
@@ -720,8 +874,8 @@ export default function DashboardApp() {
                                     Salvar observação
                                   </Button>
                                 </Stack>
-                              </Grid>
-                            </Grid>
+                              </CardContent>
+                            </Card>
 
                             <Card variant="outlined" sx={{ mt: 2, bgcolor: 'background.neutral' }}>
                               <CardContent>

--- a/src/pages/StatusPage.js
+++ b/src/pages/StatusPage.js
@@ -1,4 +1,3 @@
-import { useMemo, useState } from 'react';
 import { useEffect, useMemo, useState } from 'react';
 import SensorsIcon from '@mui/icons-material/Sensors';
 import RouterIcon from '@mui/icons-material/Router';
@@ -329,50 +328,11 @@ const manualStatusConfig = {
 
 const statusPriority = { healthy: 1, attention: 2, critical: 3 };
 
-function getSensorStatus(readings) {
-  if (!readings) return null;
-
-  const isCritical = readings.moisture < 25 || readings.temperature > 37 || readings.conductivity > 2.5;
-  if (isCritical) return 'critical';
-
-  const isAttention = readings.moisture < 40 || readings.temperature > 31 || readings.conductivity < 1;
-  if (isAttention) return 'attention';
-
-  return 'healthy';
-}
-
-function getPlantSensorAlerts(readings) {
-  if (!readings) return [];
-
-  const sensorAlerts = [];
-
-  if (readings.moisture < 40) sensorAlerts.push(`Umidade de solo baixa (${readings.moisture}%)`);
-  if (readings.temperature > 31) sensorAlerts.push(`Temperatura acima da faixa ideal (${readings.temperature}°C)`);
-  if (readings.conductivity < 1 || readings.conductivity > 2.5) {
-    sensorAlerts.push(`Condutividade fora da faixa recomendada (${readings.conductivity} mS/cm)`);
-  }
-
-  return sensorAlerts;
-}
-
-export default function StatusPage() {
-  const initialManualStatus = useMemo(
-    () =>
-      greenhouseAreas.flatMap((area) => area.plants).reduce((acc, plant) => {
-        acc[plant.id] = plant.manualStatus;
-        return acc;
-      }, {}),
-    []
-  );
-  const [manualPlantStatus, setManualPlantStatus] = useState(initialManualStatus);
-
-  const totalDevices = greenhouseAreas.reduce((acc, area) => acc + area.devices.length, 0);
-  const totalAlerts = greenhouseAreas.reduce((acc, area) => acc + area.alerts.length, 0);
-  const totalPlants = greenhouseAreas.reduce((acc, area) => acc + area.plants.length, 0);
 const dateTimeFormatter = new Intl.DateTimeFormat('pt-BR', {
   dateStyle: 'short',
   timeStyle: 'medium',
 });
+
 
 const randomNumberInRange = (min, max, decimalPlaces = 1) => {
   const multiplier = 10 ** decimalPlaces;
@@ -450,6 +410,32 @@ const getUpdatedMeasurement = (previousMeasurement) => {
   return { ...previousMeasurement, online: toggledOnline, updatedAt: new Date().toISOString() };
 };
 
+function getSensorStatus(readings) {
+  if (!readings) return null;
+
+  const isCritical = readings.moisture < 25 || readings.temperature > 37 || readings.conductivity > 2.5;
+  if (isCritical) return 'critical';
+
+  const isAttention = readings.moisture < 40 || readings.temperature > 31 || readings.conductivity < 1;
+  if (isAttention) return 'attention';
+
+  return 'healthy';
+}
+
+function getPlantSensorAlerts(readings) {
+  if (!readings) return [];
+
+  const sensorAlerts = [];
+
+  if (readings.moisture < 40) sensorAlerts.push(`Umidade de solo baixa (${readings.moisture}%)`);
+  if (readings.temperature > 31) sensorAlerts.push(`Temperatura acima da faixa ideal (${readings.temperature}°C)`);
+  if (readings.conductivity < 1 || readings.conductivity > 2.5) {
+    sensorAlerts.push(`Condutividade fora da faixa recomendada (${readings.conductivity} mS/cm)`);
+  }
+
+  return sensorAlerts;
+}
+
 export default function StatusPage() {
   const [measurementsByDevice, setMeasurementsByDevice] = useState(() => buildInitialMeasurements());
   const [lastRefreshAt, setLastRefreshAt] = useState(new Date().toISOString());
@@ -486,6 +472,7 @@ export default function StatusPage() {
     (acc, area) => acc + area.devices.filter((device) => device.type === 'sensor').length,
     0
   );
+  const totalPlants = greenhouseAreas.reduce((acc, area) => acc + area.plants.length, 0);
 
   return (
     <Page title="Status por Área">
@@ -650,7 +637,6 @@ export default function StatusPage() {
               </Card>
             </Grid>
 
-            {greenhouseAreas.map((area) => {
             {filteredAreas.map((area) => {
               const config = areaStatusConfig[area.status];
               const scopedDevices = area.devices.filter((device) => {
@@ -791,6 +777,8 @@ export default function StatusPage() {
                                 </Stack>
                               </CardContent>
                             </Card>
+                          );
+                        })}
                         {scopedDevices.map((device) => {
                           const measurement = measurementsByDevice[device.id];
 


### PR DESCRIPTION
### Motivation
- Implementar no dashboard de plantas as views solicitadas: Condições atuais, Histórico de cuidados, Próximas tarefas e suporte a Fotos e evolução. 
- Restaurar a integridade do build corrigindo problemas estruturais em `StatusPage` que impediam a compilação.

### Description
- Em `src/pages/DashboardApp.js` foi adicionada a gestão de tarefas por planta com `baseTasksByPhase`, campos de entrada e funções `atualizarNovaTarefa`, `adicionarTarefa` e `alternarTarefa`, além do `Checkbox` no import e renderização das tarefas na UI. 
- Também foi incluído um bloco de "Condições atuais relacionadas à planta" (chips com fase, pendências, último cuidado e última foto), resumo do histórico de cuidados (exibição dos últimos eventos) e uma seção separada para "Observações de evolução" mantendo a timeline existente. 
- No cadastro de nova planta `adicionarPlanta` agora popula tarefas iniciais conforme `faseCultivo`, e o modelo de planta passou a conter `tarefas`, preservando `eventos`, `fotos` e `observacoes`. 
- Em `src/pages/StatusPage.js` foram corrigidos imports duplicados e uma duplicidade/export incorreto do componente `StatusPage`, realocado e restaurado o `dateTimeFormatter` e ajustados trechos JSX/iterações (uso de `filteredAreas` e fechamento correto de blocos) para permitir a construção da aplicação.

### Testing
- Executei o linter com `npm run lint -- src/pages/DashboardApp.js`, que falhou por ausência de arquivo de configuração do ESLint no ambiente (resultado: falha). 
- Executei `npm run build` e a build de produção completou com sucesso (resultado: sucesso). 
- Rodei o servidor de desenvolvimento (`npm run dev`) e o Vite inicializou (resultado: servidor pronto). 
- Tentei validar via script de browser (`playwright`) para gerar capturas, mas a execução falhou no ambiente por um `SIGSEGV` ao iniciar o Chromium, portanto testes e screenshot end-to-end não puderam ser concluídos (resultado: falha de ambiente).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699ce804e67c832c8670d5ce68d1ae4c)