### PR TITLE
fix: corrigir erros de compilação na StatusPage e adicionar painéis operacionais no Dashboard

### DIFF
--- a/src/pages/DashboardApp.js
+++ b/src/pages/DashboardApp.js
@@ -386,6 +386,38 @@ export default function DashboardApp() {
     };
   });
 
+  const statusSetores = [
+    { nome: 'Canteiro A', status: 'Saudável', color: 'success', detalhe: 'Irrigação e clima dentro da meta.' },
+    { nome: 'Canteiro B', status: 'Atenção', color: 'warning', detalhe: 'Queda de umidade prevista para as próximas 2h.' },
+    { nome: 'Canteiro C', status: 'Crítico', color: 'error', detalhe: 'Sensor de pH fora da faixa recomendada.' },
+  ];
+
+  const sensoresDestaque = [...sensorWidgets]
+    .sort((a, b) => Number(b.total) - Number(a.total))
+    .slice(0, 3)
+    .map((sensor) => ({
+      ...sensor,
+      leitura: `${sensor.total} ${sensor.title.includes('pH') || sensor.title.includes('EC') ? 'un.' : 'pontos'}`,
+    }));
+
+  const dispositivosAtivos = {
+    ativos: 18,
+    offline: 2,
+    automacoes: 9,
+  };
+
+  const proximasAcoes = [
+    'Programar irrigação do Canteiro B para 18:00.',
+    'Revisar dosagem de nutrientes no reservatório principal.',
+    'Validar cobertura de luminosidade na estufa até o fim da tarde.',
+  ];
+
+  const alertasRecentes = [
+    { severidade: 'warning', mensagem: 'Queda de umidade detectada no Canteiro B há 12 minutos.' },
+    { severidade: 'error', mensagem: 'Leitura de pH fora da faixa ideal no Canteiro C há 27 minutos.' },
+    { severidade: 'info', mensagem: 'Novo ciclo de irrigação concluído com sucesso no Canteiro A.' },
+  ];
+
   return (
     <Page title="Dashboard">
       <Container maxWidth="xl">
@@ -400,6 +432,110 @@ export default function DashboardApp() {
 
           <Grid item xs={12}>
             <BlockchainPanel />
+          </Grid>
+
+          <Grid item xs={12} md={6} lg={4}>
+            <Card sx={{ height: '100%' }}>
+              <CardContent>
+                <Typography variant="h6" sx={{ mb: 2 }}>
+                  Status dos setores
+                </Typography>
+                <Stack spacing={1.5}>
+                  {statusSetores.map((setor) => (
+                    <Box key={setor.nome}>
+                      <Stack direction="row" justifyContent="space-between" alignItems="center" sx={{ mb: 0.5 }}>
+                        <Typography variant="subtitle2">{setor.nome}</Typography>
+                        <Chip label={setor.status} color={setor.color} size="small" />
+                      </Stack>
+                      <Typography variant="body2" color="text.secondary">
+                        {setor.detalhe}
+                      </Typography>
+                    </Box>
+                  ))}
+                </Stack>
+              </CardContent>
+            </Card>
+          </Grid>
+
+          <Grid item xs={12} md={6} lg={4}>
+            <Card sx={{ height: '100%' }}>
+              <CardContent>
+                <Typography variant="h6" sx={{ mb: 2 }}>
+                  Sensores em destaque
+                </Typography>
+                <Stack spacing={1.5}>
+                  {sensoresDestaque.map((sensor) => (
+                    <Stack key={sensor.title} direction="row" justifyContent="space-between" alignItems="center">
+                      <Stack direction="row" spacing={1} alignItems="center">
+                        <Iconify icon={sensor.icon1} width={20} height={20} />
+                        <Typography variant="body2">{sensor.title}</Typography>
+                      </Stack>
+                      <Chip label={sensor.leitura} size="small" color={sensor.color} variant="outlined" />
+                    </Stack>
+                  ))}
+                </Stack>
+              </CardContent>
+            </Card>
+          </Grid>
+
+          <Grid item xs={12} md={6} lg={4}>
+            <AppWidgetSummary
+              title="Dispositivos ativos"
+              total={dispositivosAtivos.ativos}
+              color="success"
+              icon1="mdi:access-point-network"
+              sx={{ height: '100%' }}
+            />
+            <Card variant="outlined" sx={{ mt: 1.5 }}>
+              <CardContent sx={{ py: 1.5 }}>
+                <Stack direction="row" justifyContent="space-between">
+                  <Typography variant="body2" color="text.secondary">
+                    Offline
+                  </Typography>
+                  <Typography variant="subtitle2">{dispositivosAtivos.offline}</Typography>
+                </Stack>
+                <Stack direction="row" justifyContent="space-between" sx={{ mt: 0.5 }}>
+                  <Typography variant="body2" color="text.secondary">
+                    Automações ativas
+                  </Typography>
+                  <Typography variant="subtitle2">{dispositivosAtivos.automacoes}</Typography>
+                </Stack>
+              </CardContent>
+            </Card>
+          </Grid>
+
+          <Grid item xs={12} md={6}>
+            <Card sx={{ height: '100%' }}>
+              <CardContent>
+                <Typography variant="h6" sx={{ mb: 2 }}>
+                  Próximas ações recomendadas
+                </Typography>
+                <Stack spacing={1}>
+                  {proximasAcoes.map((acao) => (
+                    <Alert key={acao} severity="info" icon={<Iconify icon="mdi:clipboard-text-clock-outline" width={20} height={20} />}>
+                      {acao}
+                    </Alert>
+                  ))}
+                </Stack>
+              </CardContent>
+            </Card>
+          </Grid>
+
+          <Grid item xs={12} md={6}>
+            <Card sx={{ height: '100%' }}>
+              <CardContent>
+                <Typography variant="h6" sx={{ mb: 2 }}>
+                  Alertas recentes
+                </Typography>
+                <Stack spacing={1}>
+                  {alertasRecentes.map((alerta) => (
+                    <Alert key={alerta.mensagem} severity={alerta.severidade}>
+                      {alerta.mensagem}
+                    </Alert>
+                  ))}
+                </Stack>
+              </CardContent>
+            </Card>
           </Grid>
 
           <Grid item xs={12}>

--- a/src/pages/StatusPage.js
+++ b/src/pages/StatusPage.js
@@ -1,4 +1,3 @@
-import { useMemo, useState } from 'react';
 import { useEffect, useMemo, useState } from 'react';
 import SensorsIcon from '@mui/icons-material/Sensors';
 import RouterIcon from '@mui/icons-material/Router';
@@ -355,20 +354,6 @@ function getPlantSensorAlerts(readings) {
   return sensorAlerts;
 }
 
-export default function StatusPage() {
-  const initialManualStatus = useMemo(
-    () =>
-      greenhouseAreas.flatMap((area) => area.plants).reduce((acc, plant) => {
-        acc[plant.id] = plant.manualStatus;
-        return acc;
-      }, {}),
-    []
-  );
-  const [manualPlantStatus, setManualPlantStatus] = useState(initialManualStatus);
-
-  const totalDevices = greenhouseAreas.reduce((acc, area) => acc + area.devices.length, 0);
-  const totalAlerts = greenhouseAreas.reduce((acc, area) => acc + area.alerts.length, 0);
-  const totalPlants = greenhouseAreas.reduce((acc, area) => acc + area.plants.length, 0);
 const dateTimeFormatter = new Intl.DateTimeFormat('pt-BR', {
   dateStyle: 'short',
   timeStyle: 'medium',
@@ -482,6 +467,7 @@ export default function StatusPage() {
 
   const totalDevices = greenhouseAreas.reduce((acc, area) => acc + area.devices.length, 0);
   const totalAlerts = greenhouseAreas.reduce((acc, area) => acc + area.alerts.length, 0);
+  const totalPlants = greenhouseAreas.reduce((acc, area) => acc + area.plants.length, 0);
   const totalSensors = greenhouseAreas.reduce(
     (acc, area) => acc + area.devices.filter((device) => device.type === 'sensor').length,
     0
@@ -650,7 +636,6 @@ export default function StatusPage() {
               </Card>
             </Grid>
 
-            {greenhouseAreas.map((area) => {
             {filteredAreas.map((area) => {
               const config = areaStatusConfig[area.status];
               const scopedDevices = area.devices.filter((device) => {
@@ -733,10 +718,11 @@ export default function StatusPage() {
                       </Box>
 
                       <Stack spacing={1} sx={{ mt: 2 }}>
-                        {area.devices.map((device) => {
+                        {scopedDevices.map((device) => {
                           const connectionConfig = connectionStateConfig[device.connectionStatus];
                           const signalConfig = device.signalQuality ? signalQualityConfig[device.signalQuality] : null;
                           const isWireless = device.batteryLevel !== null;
+                          const measurement = measurementsByDevice[device.id];
 
                           return (
                             <Card key={`${area.id}-${device.id}`} variant="outlined" sx={{ bgcolor: 'background.default' }}>
@@ -788,17 +774,14 @@ export default function StatusPage() {
                                       variant="outlined"
                                     />
                                   </Stack>
+
+                                  <Typography variant="body2" color="text.secondary">
+                                    • {measurement ? getMeasurementLabel(device, measurement) : 'Sem leitura'} •{' '}
+                                    {measurement ? dateTimeFormatter.format(new Date(measurement.updatedAt)) : '-'}
+                                  </Typography>
                                 </Stack>
                               </CardContent>
                             </Card>
-                        {scopedDevices.map((device) => {
-                          const measurement = measurementsByDevice[device.id];
-
-                          return (
-                            <Typography key={`${area.id}-${device.id}`} variant="body2" color="text.secondary">
-                              • {device.id} — {device.name} • {measurement ? getMeasurementLabel(device, measurement) : 'Sem leitura'} •{' '}
-                              {measurement ? dateTimeFormatter.format(new Date(measurement.updatedAt)) : '-'}
-                            </Typography>
                           );
                         })}
                       </Stack>


### PR DESCRIPTION
### Motivation
- Corrigir falha de build e erro de compilação causados por duplicidade de imports e de declaração/export de `StatusPage` que impediam a inicialização correta da aplicação. 
- Restaurar a renderização correta do layout de status por área e manter a telemetria por dispositivo com leituras e timestamps. 
- Incluir a visão operacional no `DashboardApp` (cards de status, sensores em destaque, dispositivos e alertas) para oferecer um resumo rápido no dashboard.

### Description
- Unificou os imports de hooks React em uma única linha `import { useEffect, useMemo, useState } from 'react';` e removeu duplicidade que gerava erro. 
- Eliminou o bloco duplicado/corrompido da `StatusPage` e manteve uma única implementação funcional de `export default function StatusPage()`. 
- Corrigiu estrutura JSX inválida na listagem de áreas/dispositivos substituindo o `map` duplicado por `filteredAreas.map(...)` e reorganizando a renderização dos cartões de dispositivos para exibir leituras com `getMeasurementLabel` e `dateTimeFormatter`. 
- Reposicionou/garantiu helpers e utilitários (ex.: `dateTimeFormatter`, `randomNumberInRange`, `buildInitialMeasurements`, `getUpdatedMeasurement`) no escopo correto do arquivo para atualizar medições periodicamente. 
- Adicionou/possibilitou painéis operacionais em `src/pages/DashboardApp.js` com conjuntos de dados locais (`statusSetores`, `sensoresDestaque`, `dispositivosAtivos`, `proximasAcoes`, `alertasRecentes`) e componentes MUI para exibir esses cartões no topo do dashboard.

### Testing
- Executado `npm run build`, que terminou com sucesso após as correções (build concluído). 
- Subido o servidor em dev com `npm run dev -- --host 0.0.0.0 --port 4173`, que iniciou sem overlay de erro de compilação para a `StatusPage`. 
- Capturada uma screenshot automatizada da rota `/dashboard/status` com Playwright para validação visual, observando que a rota redireciona para login quando não autenticado (comportamento esperado).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699ce7f97308832caf927bcbbb67c9c4)