### PR TITLE
feat(admin): adiciona central unificada de gestão no painel

### DIFF
--- a/src/layouts/dashboard/NavConfig.js
+++ b/src/layouts/dashboard/NavConfig.js
@@ -12,7 +12,7 @@ const navConfig = [
     icon: getIcon('eva:pie-chart-2-fill'),
   },
   {
-    title: 'garden',
+    title: 'admin',
     path: '/dashboard/user',
     icon: getIcon('eva:people-fill'),
   },

--- a/src/pages/User.js
+++ b/src/pages/User.js
@@ -1,331 +1,321 @@
-import { filter } from 'lodash';
-import { sentenceCase } from 'change-case';
-import { useState } from 'react';
-import { Link as RouterLink } from 'react-router-dom';
-// material
+import { useMemo, useState } from 'react';
 import {
-  Card,
-  Table,
-  Stack,
+  Alert,
+  Box,
   Button,
-  Checkbox,
-  TableRow,
+  Card,
+  CardContent,
+  Chip,
+  Container,
+  Divider,
+  Grid,
+  LinearProgress,
+  List,
+  ListItem,
+  ListItemText,
+  MenuItem,
+  Stack,
+  Table,
   TableBody,
   TableCell,
-  Container,
-  Typography,
   TableContainer,
-  TablePagination,
+  TableHead,
+  TableRow,
+  TextField,
+  Typography,
 } from '@mui/material';
-import { YardTwoTone, RemoveRedEyeTwoTone } from '@mui/icons-material';
-import { styled } from '@mui/material/styles';
-import Switch from '@mui/material/Switch';
-import RestoreIcon from '@mui/icons-material/Restore';
-import Slider from '@mui/material/Slider';
-import { withStyles } from '@mui/styles';
-// components
 import Page from '../components/Page';
-import Label from '../components/Label';
-import Scrollbar from '../components/Scrollbar';
-import Iconify from '../components/Iconify';
-import SearchNotFound from '../components/SearchNotFound';
-import { UserListHead, UserListToolbar, UserMoreMenu } from '../sections/@dashboard/user';
-// mock
-import USERLIST from '../_mock/user';
 
-// ----------------------------------------------------------------------
+const accountStatusColor = {
+  ativa: 'success',
+  inativa: 'default',
+  bloqueada: 'error',
+  pendente: 'warning',
+};
 
-const TABLE_HEAD = [
-  { id: 'name', label: 'Name Garden', alignRight: false },
-  { id: 'company', label: 'Logs', alignRight: false },
-  { id: 'role', label: 'Automatic Watering', alignRight: false },
-  { id: 'isVerified', label: 'Watch Live', alignRight: false },
-  { id: 'status', label: 'Status Garden', alignRight: false },
-  { id: 'Soil moisture', label: 'Select humidity', alignRight: false },
-  { id: '' },
+const users = [
+  { id: 1, nome: 'Ana Souza', perfil: 'Produtor', status: 'ativa', ultimoAcesso: 'Hoje 09:22' },
+  { id: 2, nome: 'Carlos Lima', perfil: 'Revenda', status: 'bloqueada', ultimoAcesso: 'Ontem 18:11' },
+  { id: 3, nome: 'Marina Melo', perfil: 'Consultora', status: 'inativa', ultimoAcesso: '12/02/2026 07:43' },
+  { id: 4, nome: 'Equipe Fazenda Sol', perfil: 'Empresa', status: 'pendente', ultimoAcesso: '11/02/2026 20:14' },
 ];
 
-// ----------------------------------------------------------------------
+const devices = [
+  { modelo: 'Hortelan Sense v2', firmware: '2.4.1', parque: 1240, problematicos: 28 },
+  { modelo: 'Hortelan Pump Pro', firmware: '1.9.8', parque: 890, problematicos: 12 },
+  { modelo: 'Hortelan Hub Mini', firmware: '3.1.0', parque: 642, problematicos: 41 },
+];
 
-const CustomTableCell = withStyles((theme) => ({
-  root: {
-    width: '400px',
-  },
-}))(TableCell);
+const cmsContent = [
+  { tipo: 'Artigo', titulo: '5 práticas para melhorar a umidade do solo', status: 'Publicado' },
+  { tipo: 'Guia', titulo: 'Guia de cultivo de alface hidropônica', status: 'Em revisão' },
+  { tipo: 'FAQ', titulo: 'Como resetar meu dispositivo IoT?', status: 'Publicado' },
+  { tipo: 'Onboarding', titulo: 'Primeiros 7 dias no Hortelan', status: 'Rascunho' },
+];
 
-function descendingComparator(a, b, orderBy) {
-  if (b[orderBy] < a[orderBy]) {
-    return -1;
-  }
-  if (b[orderBy] > a[orderBy]) {
-    return 1;
-  }
-  return 0;
-}
+const communityQueue = [
+  { item: 'Post “Insetos nas folhas”', acao: 'Moderar comentário', severidade: 'Média' },
+  { item: 'Comentário com ofensa', acao: 'Revisar denúncia', severidade: 'Alta' },
+  { item: 'Campanha “Colheita de Outono”', acao: 'Publicar destaque', severidade: 'Baixa' },
+];
 
-function getComparator(order, orderBy) {
-  return order === 'desc'
-    ? (a, b) => descendingComparator(a, b, orderBy)
-    : (a, b) => -descendingComparator(a, b, orderBy);
-}
+const storeSnapshot = [
+  { categoria: 'Sensores', produtos: 14, estoqueBaixo: 2, promocao: 'Kit irrigação -10%' },
+  { categoria: 'Nutrientes', produtos: 21, estoqueBaixo: 5, promocao: 'Frete grátis acima de R$250' },
+  { categoria: 'Acessórios', produtos: 32, estoqueBaixo: 4, promocao: 'Cupom BEMVINDO15' },
+];
 
-function applySortFilter(array, comparator, query) {
-  const stabilizedThis = array.map((el, index) => [el, index]);
-  stabilizedThis.sort((a, b) => {
-    const order = comparator(a[0], b[0]);
-    if (order !== 0) return order;
-    return a[1] - b[1];
-  });
-  if (query) {
-    return filter(array, (_user) => _user.name.toLowerCase().indexOf(query.toLowerCase()) !== -1);
-  }
-  return stabilizedThis.map((el) => el[0]);
+const billingSnapshot = {
+  planosAtivos: 1876,
+  cobrancasAbertas: 142,
+  inadimplentes: 34,
+  receitaMensal: 'R$ 428.900,00',
+};
+
+const observability = [
+  { metrica: 'Saúde dos serviços', valor: 98, detalhe: 'API, auth e IoT broker' },
+  { metrica: 'Erros frontend/backend', valor: 82, detalhe: 'Taxa de resolução em 24h' },
+  { metrica: 'Disponibilidade', valor: 99.7, detalhe: 'Últimos 30 dias' },
+  { metrica: 'Cobertura de logs', valor: 91, detalhe: 'Logs com rastreio por tenant' },
+];
+
+function SectionCard({ title, subtitle, children }) {
+  return (
+    <Card sx={{ height: '100%' }}>
+      <CardContent>
+        <Stack spacing={1.5} mb={2}>
+          <Typography variant="h6">{title}</Typography>
+          <Typography variant="body2" color="text.secondary">
+            {subtitle}
+          </Typography>
+        </Stack>
+        {children}
+      </CardContent>
+    </Card>
+  );
 }
 
 export default function User() {
-  const [page, setPage] = useState(0);
+  const [selectedSupportAction, setSelectedSupportAction] = useState('reset');
+  const [selectedUser, setSelectedUser] = useState(users[0].id);
 
-  const [order, setOrder] = useState('asc');
-
-  const [selected, setSelected] = useState([]);
-
-  const [orderBy, setOrderBy] = useState('name');
-
-  const [filterName, setFilterName] = useState('');
-
-  const [rowsPerPage, setRowsPerPage] = useState(5);
-
-  const handleRequestSort = (event, property) => {
-    const isAsc = orderBy === property && order === 'asc';
-    setOrder(isAsc ? 'desc' : 'asc');
-    setOrderBy(property);
-  };
-
-  const handleSelectAllClick = (event) => {
-    if (event.target.checked) {
-      const newSelecteds = USERLIST.map((n) => n.name);
-      setSelected(newSelecteds);
-      return;
-    }
-    setSelected([]);
-  };
-
-  const handleClick = (event, name) => {
-    const selectedIndex = selected.indexOf(name);
-    let newSelected = [];
-    if (selectedIndex === -1) {
-      newSelected = newSelected.concat(selected, name);
-    } else if (selectedIndex === 0) {
-      newSelected = newSelected.concat(selected.slice(1));
-    } else if (selectedIndex === selected.length - 1) {
-      newSelected = newSelected.concat(selected.slice(0, -1));
-    } else if (selectedIndex > 0) {
-      newSelected = newSelected.concat(selected.slice(0, selectedIndex), selected.slice(selectedIndex + 1));
-    }
-    setSelected(newSelected);
-  };
-
-  const handleChangePage = (event, newPage) => {
-    setPage(newPage);
-  };
-
-  const handleChangeRowsPerPage = (event) => {
-    setRowsPerPage(parseInt(event.target.value, 10));
-    setPage(0);
-  };
-
-  const handleFilterByName = (event) => {
-    setFilterName(event.target.value);
-  };
-
-  const emptyRows = page > 0 ? Math.max(0, (1 + page) * rowsPerPage - USERLIST.length) : 0;
-
-  const filteredUsers = applySortFilter(USERLIST, getComparator(order, orderBy), filterName);
-
-  const isUserNotFound = filteredUsers.length === 0;
-
-  const AntSwitch = styled(Switch)(({ theme }) => ({
-    width: 28,
-    height: 16,
-    padding: 0,
-    display: 'flex',
-    '&:active': {
-      '& .MuiSwitch-thumb': {
-        width: 15,
-      },
-      '& .MuiSwitch-switchBase.Mui-checked': {
-        transform: 'translateX(9px)',
-      },
-    },
-    '& .MuiSwitch-switchBase': {
-      padding: 2,
-      '&.Mui-checked': {
-        transform: 'translateX(12px)',
-        color: '#fff',
-        '& + .MuiSwitch-track': {
-          opacity: 1,
-          backgroundColor: theme.palette.mode === 'dark' ? '#177ddc' : '#1890ff',
-        },
-      },
-    },
-    '& .MuiSwitch-thumb': {
-      boxShadow: '0 2px 4px 0 rgb(0 35 11 / 20%)',
-      width: 12,
-      height: 12,
-      borderRadius: 6,
-      transition: theme.transitions.create(['width'], {
-        duration: 200,
-      }),
-    },
-    '& .MuiSwitch-track': {
-      borderRadius: 16 / 2,
-      opacity: 1,
-      backgroundColor:
-        theme.palette.mode === 'dark' ? 'rgba(255,255,255,.35)' : 'rgba(0,0,0,.25)',
-      boxSizing: 'border-box',
-    },
-  }));
-  
-  const marks = [
-    {
-      value: 10,
-      label: '10%',
-    },
-    {
-      value: 40,
-      label: '40%',
-    },
-    {
-      value: 60,
-      label: '60%',
-    },
-    {
-      value: 80,
-      label: '80%',
-    },
-  ];
-  
-  function valuetext(value) {
-    return `${value}%`;
-  }
+  const selectedUserData = useMemo(() => users.find((user) => user.id === selectedUser), [selectedUser]);
 
   return (
-    <Page title="User">
+    <Page title="Admin | Gestão operacional">
       <Container>
-        <Stack direction="row" alignItems="center" justifyContent="space-between" mb={5}>
-          <Typography variant="h4" gutterBottom>
-            Garden registration
+        <Stack spacing={1} mb={4}>
+          <Typography variant="h4">Central de Gestão (Admin)</Typography>
+          <Typography variant="body2" color="text.secondary">
+            Painel único para operação de usuários, dispositivos IoT, conteúdo, comunidade, loja,
+            faturamento e observabilidade.
           </Typography>
-          <Button variant="contained" component={RouterLink} to="#" startIcon={<Iconify icon="eva:plus-fill" />}>
-            New Garden
-          </Button>
         </Stack>
 
-        <Card>
-          <UserListToolbar numSelected={selected.length} filterName={filterName} onFilterName={handleFilterByName} />
-
-          <Scrollbar>
-            <TableContainer sx={{ minWidth: 800 }}>
-              <Table>
-                <UserListHead
-                  order={order}
-                  orderBy={orderBy}
-                  headLabel={TABLE_HEAD}
-                  rowCount={USERLIST.length}
-                  numSelected={selected.length}
-                  onRequestSort={handleRequestSort}
-                  onSelectAllClick={handleSelectAllClick}
-                />
-                <TableBody>
-                  {filteredUsers.slice(page * rowsPerPage, page * rowsPerPage + rowsPerPage).map((row) => {
-                    const { id, name, role, status, company, avatarUrl, isVerified } = row;
-                    const isItemSelected = selected.indexOf(name) !== -1;
-
-                    return (
-                      <TableRow
-                        hover
-                        key={id}
-                        tabIndex={-1}
-                        role="checkbox"
-                        selected={isItemSelected}
-                        aria-checked={isItemSelected}
-                      >
-                        <TableCell padding="checkbox">
-                          <Checkbox checked={isItemSelected} onChange={(event) => handleClick(event, name)} />
-                        </TableCell>
-                        <TableCell component="th" scope="row" padding="none">
-                          <Stack direction="row" alignItems="center" spacing={2}>
-                            <YardTwoTone alt={name} src={avatarUrl} />
-                            <Typography variant="subtitle2" noWrap>
-                              {name}
-                            </Typography>
-                          </Stack>
-                        </TableCell>
-                        <TableCell align="left">
-                          <RestoreIcon label='Logs' />
-                        </TableCell>
-                        <TableCell align="left">
-                          <Stack direction="row" spacing={1} alignItems="center">
-                            <Typography>Off</Typography>
-                              <AntSwitch defaultChecked inputProps={{ 'aria-label': 'ant design' }} />
-                            <Typography>On</Typography>
-                          </Stack>
-                        </TableCell>
-                        <TableCell align="left">
-                          <RemoveRedEyeTwoTone />
-                        </TableCell>
-                        <TableCell align="left">
-                          <Label variant="ghost" color={(status === 'Inactive' && 'error') || 'success'}>
-                            {sentenceCase(status)}
-                          </Label>
-                        </TableCell>
-                        <CustomTableCell >
-                          <Slider
-                            aria-label="Always visible"
-                            defaultValue={80}
-                            getAriaValueText={valuetext}
-                            step={10}
-                            marks={marks}
-                            valueLabelDisplay="on"
-                          />
-                        </CustomTableCell>
-
-                        <TableCell align="right">
-                          <UserMoreMenu />
-                        </TableCell>
+        <Grid container spacing={3}>
+          <Grid item xs={12}>
+            <SectionCard
+              title="18.1 Gestão de usuários"
+              subtitle="Listagem, status da conta e ações de suporte operacional."
+            >
+              <Stack spacing={2.5}>
+                <TableContainer>
+                  <Table size="small">
+                    <TableHead>
+                      <TableRow>
+                        <TableCell>Usuário</TableCell>
+                        <TableCell>Perfil</TableCell>
+                        <TableCell>Status</TableCell>
+                        <TableCell>Último acesso</TableCell>
+                        <TableCell>Ações</TableCell>
                       </TableRow>
-                    );
-                  })}
-                  {emptyRows > 0 && (
-                    <TableRow style={{ height: 53 * emptyRows }}>
-                      <TableCell colSpan={6} />
-                    </TableRow>
-                  )}
-                </TableBody>
+                    </TableHead>
+                    <TableBody>
+                      {users.map((user) => (
+                        <TableRow key={user.id} hover>
+                          <TableCell>{user.nome}</TableCell>
+                          <TableCell>{user.perfil}</TableCell>
+                          <TableCell>
+                            <Chip
+                              size="small"
+                              label={user.status}
+                              color={accountStatusColor[user.status]}
+                              variant="outlined"
+                            />
+                          </TableCell>
+                          <TableCell>{user.ultimoAcesso}</TableCell>
+                          <TableCell>
+                            <Stack direction="row" spacing={1}>
+                              <Button size="small" variant="outlined">
+                                {user.status === 'ativa' ? 'Desativar' : 'Ativar'}
+                              </Button>
+                              <Button size="small" variant="text">
+                                Verificar conta
+                              </Button>
+                            </Stack>
+                          </TableCell>
+                        </TableRow>
+                      ))}
+                    </TableBody>
+                  </Table>
+                </TableContainer>
 
-                {isUserNotFound && (
-                  <TableBody>
-                    <TableRow>
-                      <TableCell align="center" colSpan={6} sx={{ py: 3 }}>
-                        <SearchNotFound searchQuery={filterName} />
-                      </TableCell>
-                    </TableRow>
-                  </TableBody>
-                )}
-              </Table>
-            </TableContainer>
-          </Scrollbar>
+                <Divider />
 
-          <TablePagination
-            rowsPerPageOptions={[5, 10, 25]}
-            component="div"
-            count={USERLIST.length}
-            rowsPerPage={rowsPerPage}
-            page={page}
-            onPageChange={handleChangePage}
-            onRowsPerPageChange={handleChangeRowsPerPage}
-          />
-        </Card>
+                <Stack direction={{ xs: 'column', md: 'row' }} spacing={2} alignItems={{ md: 'center' }}>
+                  <TextField
+                    select
+                    label="Usuário para suporte"
+                    value={selectedUser}
+                    onChange={(event) => setSelectedUser(Number(event.target.value))}
+                    sx={{ minWidth: 280 }}
+                  >
+                    {users.map((user) => (
+                      <MenuItem key={user.id} value={user.id}>
+                        {user.nome}
+                      </MenuItem>
+                    ))}
+                  </TextField>
+                  <TextField
+                    select
+                    label="Ação"
+                    value={selectedSupportAction}
+                    onChange={(event) => setSelectedSupportAction(event.target.value)}
+                    sx={{ minWidth: 220 }}
+                  >
+                    <MenuItem value="reset">Reset de conta</MenuItem>
+                    <MenuItem value="bloqueio">Bloqueio preventivo</MenuItem>
+                    <MenuItem value="analise">Abrir análise de segurança</MenuItem>
+                  </TextField>
+                  <Button variant="contained">Executar suporte</Button>
+                </Stack>
+                <Alert severity="info">
+                  Conta selecionada: <strong>{selectedUserData?.nome}</strong> ({selectedUserData?.status}).
+                </Alert>
+              </Stack>
+            </SectionCard>
+          </Grid>
+
+          <Grid item xs={12} md={6}>
+            <SectionCard
+              title="18.2 Dispositivos e catálogo IoT"
+              subtitle="Modelos suportados, firmware, parque instalado e diagnóstico."
+            >
+              <List dense disablePadding>
+                {devices.map((device) => (
+                  <ListItem key={device.modelo} divider>
+                    <ListItemText
+                      primary={`${device.modelo} • Firmware ${device.firmware}`}
+                      secondary={`Parque instalado: ${device.parque} • Problemáticos: ${device.problematicos}`}
+                    />
+                    <Button size="small">Diagnóstico</Button>
+                  </ListItem>
+                ))}
+              </List>
+            </SectionCard>
+          </Grid>
+
+          <Grid item xs={12} md={6}>
+            <SectionCard
+              title="18.3 Gestão de conteúdo (CMS leve)"
+              subtitle="Artigos, dicas, guias, FAQs e conteúdo de onboarding."
+            >
+              <Stack spacing={1.2}>
+                {cmsContent.map((content) => (
+                  <Card key={content.titulo} variant="outlined" sx={{ p: 1.2 }}>
+                    <Typography variant="subtitle2">{content.titulo}</Typography>
+                    <Typography variant="caption" color="text.secondary">
+                      {content.tipo} • {content.status}
+                    </Typography>
+                  </Card>
+                ))}
+              </Stack>
+            </SectionCard>
+          </Grid>
+
+          <Grid item xs={12} md={6}>
+            <SectionCard
+              title="18.4 Gestão da comunidade"
+              subtitle="Moderação, denúncias, regras e destaques de campanhas."
+            >
+              <Stack spacing={1.2}>
+                {communityQueue.map((entry) => (
+                  <Box
+                    key={entry.item}
+                    sx={{ border: 1, borderColor: 'divider', borderRadius: 1, p: 1.5 }}
+                  >
+                    <Typography variant="subtitle2">{entry.item}</Typography>
+                    <Typography variant="body2" color="text.secondary">
+                      {entry.acao} • Severidade {entry.severidade}
+                    </Typography>
+                  </Box>
+                ))}
+              </Stack>
+            </SectionCard>
+          </Grid>
+
+          <Grid item xs={12} md={6}>
+            <SectionCard
+              title="18.5 Gestão da loja"
+              subtitle="Produtos, categorias, estoque, promoções, cupons e pedidos/logística."
+            >
+              <List dense disablePadding>
+                {storeSnapshot.map((category) => (
+                  <ListItem key={category.categoria} divider>
+                    <ListItemText
+                      primary={`${category.categoria} • ${category.produtos} produtos`}
+                      secondary={`Estoque baixo: ${category.estoqueBaixo} • Promoção: ${category.promocao}`}
+                    />
+                  </ListItem>
+                ))}
+              </List>
+              <Typography variant="caption" color="text.secondary">
+                Integração com ERP/frete planejada para a fase avançada.
+              </Typography>
+            </SectionCard>
+          </Grid>
+
+          <Grid item xs={12} md={6}>
+            <SectionCard
+              title="18.6 Assinaturas e faturamento"
+              subtitle="Planos, cobranças, inadimplência e relatórios financeiros operacionais."
+            >
+              <Stack spacing={1.5}>
+                <Typography variant="body2">Planos ativos: {billingSnapshot.planosAtivos}</Typography>
+                <Typography variant="body2">Cobranças em aberto: {billingSnapshot.cobrancasAbertas}</Typography>
+                <Typography variant="body2">Inadimplentes: {billingSnapshot.inadimplentes}</Typography>
+                <Typography variant="body2">Receita mensal: {billingSnapshot.receitaMensal}</Typography>
+                <Button variant="outlined" size="small">
+                  Exportar relatório operacional
+                </Button>
+              </Stack>
+            </SectionCard>
+          </Grid>
+
+          <Grid item xs={12}>
+            <SectionCard
+              title="18.7 Observabilidade da plataforma"
+              subtitle="Logs, saúde de serviços, erros FE/BE, métricas de uso e alertas de disponibilidade."
+            >
+              <Grid container spacing={2}>
+                {observability.map((item) => (
+                  <Grid key={item.metrica} item xs={12} md={3}>
+                    <Card variant="outlined" sx={{ p: 2 }}>
+                      <Stack spacing={1}>
+                        <Typography variant="subtitle2">{item.metrica}</Typography>
+                        <Typography variant="h5">{item.valor}%</Typography>
+                        <LinearProgress variant="determinate" value={item.valor} />
+                        <Typography variant="caption" color="text.secondary">
+                          {item.detalhe}
+                        </Typography>
+                      </Stack>
+                    </Card>
+                  </Grid>
+                ))}
+              </Grid>
+            </SectionCard>
+          </Grid>
+        </Grid>
       </Container>
     </Page>
   );


### PR DESCRIPTION
### Motivation
- Fornecer uma Central de Gestão (Admin) que consolida operações de usuários, dispositivos IoT, CMS, comunidade, loja, faturamento e observabilidade para suporte operacional e administração.
- Substituir a visão anterior da rota `/dashboard/user` por um painel voltado a operações administrativas e facilitar acesso pelo menu lateral.

### Description
- Substituí a página `src/pages/User.js` por uma nova implementação que organiza os blocos funcionais 18.1–18.7 com dados mock e controles UI (tabelas, listas, cartões, selects e ações de suporte). 
- Atualizei `src/layouts/dashboard/NavConfig.js` trocando o label de menu de `garden` para `admin` mantendo a mesma rota `/dashboard/user` para acesso ao novo painel. 
- A nova página expõe ações de suporte (reset, bloqueio, análise) e painéis de resumo para dispositivos, conteúdo, comunidade, loja, assinaturas/faturamento e observabilidade usando componentes MUI. 
- Nenhuma mudança de API foi adicionada; os dados exibidos são mocks locais preparados para integrar com back-end posteriormente. 

### Testing
- Executei `npm run build` com sucesso para validar o bundle de produção (build concluído). 
- Rodei `npm run dev -- --host 0.0.0.0 --port 4173` e verifiquei a interface localmente no navegador (servidor Vite iniciado). 
- Automatizei um teste visual com Playwright que realizou login 2FA demo e navegou até `/dashboard/user`, gerando uma captura de tela com sucesso. 
- Rodei `npm run lint` que falhou devido à ausência de arquivo de configuração do ESLint no ambiente, sem impactar o build funcional.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699cf5e05f7c832c9d93c209b4d8ea20)