### PR TITLE
feat: adicionar compartilhamento de horta (convites por e‑mail), RBAC e trilha de auditoria

### DIFF
--- a/src/auth/session.js
+++ b/src/auth/session.js
@@ -14,6 +14,49 @@ const RESET_TOKEN_EXPIRY_MINUTES = 30;
 const MFA_CODE_EXPIRY_MINUTES = 5;
 const TRUSTED_DEVICE_EXPIRY_DAYS = 30;
 
+const GARDEN_ROLE_DEFAULT_PERMISSIONS = {
+  owner: { automation: true, purchases: true, reports: true, community: true },
+  admin: { automation: true, purchases: true, reports: true, community: true },
+  operator: { automation: true, purchases: false, reports: true, community: false },
+  viewer: { automation: false, purchases: false, reports: true, community: true },
+};
+
+const normalizeGardenAccessControl = (accessControl = {}) => ({
+  ownerId: accessControl.ownerId || 'self',
+  inviteDraftEmail: accessControl.inviteDraftEmail || '',
+  inviteDraftRole: accessControl.inviteDraftRole || 'viewer',
+  pendingInvites: (accessControl.pendingInvites || []).map((invite, inviteIndex) => ({
+    id: invite.id || `invite-${Date.now()}-${inviteIndex}`,
+    email: invite.email || '',
+    role: invite.role || 'viewer',
+    status: invite.status || 'pending',
+    invitedBy: invite.invitedBy || 'Você',
+    createdAt: invite.createdAt || new Date().toISOString(),
+  })),
+  collaborators: (accessControl.collaborators || []).map((member, memberIndex) => {
+    const role = member.role || 'viewer';
+    return {
+      id: member.id || `collaborator-${Date.now()}-${memberIndex}`,
+      name: member.name || `Membro ${memberIndex + 1}`,
+      email: member.email || '',
+      role,
+      status: member.status || 'active',
+      invitedAt: member.invitedAt || new Date().toISOString(),
+      finePermissions: {
+        ...(GARDEN_ROLE_DEFAULT_PERMISSIONS[role] || GARDEN_ROLE_DEFAULT_PERMISSIONS.viewer),
+        ...(member.finePermissions || {}),
+      },
+    };
+  }),
+  auditLogs: (accessControl.auditLogs || []).map((entry, entryIndex) => ({
+    id: entry.id || `audit-${Date.now()}-${entryIndex}`,
+    action: entry.action || 'Ação registrada',
+    actor: entry.actor || 'Sistema',
+    target: entry.target || 'Horta',
+    createdAt: entry.createdAt || new Date().toISOString(),
+  })),
+});
+
 const USERS = [
   {
     id: 'admin-1',
@@ -106,6 +149,7 @@ const buildSafeUser = (user) => ({
       dimensions: sector.dimensions || '',
       sectorType: sector.sectorType || 'sol_pleno',
     })),
+    accessControl: normalizeGardenAccessControl(garden.accessControl),
   })),
 });
 
@@ -668,6 +712,7 @@ export const updateAuthenticatedUserProfile = (payload) => {
         dimensions: sector.dimensions?.trim() || '',
         sectorType: sector.sectorType || 'sol_pleno',
       })),
+      accessControl: normalizeGardenAccessControl(garden.accessControl),
     })),
   };
 


### PR DESCRIPTION
### Motivation

- Implementar compartilhamento de hortas com convite por e‑mail e aceite in‑app para permitir colaboração entre usuários. 
- Fornecer um modelo RBAC (Proprietário, Administrador da horta, Operador/cuidador, Visualizador) com permissões finas por funcionalidade. 
- Rastrear ações relevantes (convites, mudanças de papel, alterações de permissões) para suporte a auditoria operacional.

### Description

- Adicionada UI e lógica em `src/pages/ProfileSettings.js` para criar convites por e‑mail, listar convites pendentes, aceitar convites, gerenciar colaboradores, alterar papéis e editar permissões finas por colaborador, além de registrar entradas de auditoria; também inclui validação de e‑mail e prevenção de convites duplicados. 
- Introduzidos tipos e utilitários locais em `ProfileSettings.js`: `ROLE_OPTIONS`, `FINE_PERMISSION_OPTIONS`, `ROLE_DEFAULT_PERMISSIONS`, `createPermissionSet`, `createAuditEntry`, `normalizeAccessControl`, `updateGarden`, `handleInviteByEmail` e `handleAcceptInvite`, e novos blocos visuais (convites, membros, auditoria). 
- Adicionada normalização/persistência de `accessControl` no backend de sessão demo em `src/auth/session.js` via `normalizeGardenAccessControl`, e integrada em `buildSafeUser` e `updateAuthenticatedUserProfile` para manter convites, colaboradores, permissões e logs ao salvar/recuperar perfil. 
- Ao salvar o perfil, os dados de `accessControl` são normalizados (emails em caixa‑baixa, ids gerados, permissões aplicadas) para consistência entre UI e armazenamento local.

### Testing

- Executado `npm run build` com sucesso (produção gerada sem erros). 
- Executado um fluxo end‑to‑end automatizado via Playwright que autenticou com 2FA demo, navegou até `/dashboard/profile` e gerou um screenshot de verificação (`artifacts/profile-sharing-rbac.png`), com sucesso. 
- Executado `npm test` que saiu com sucesso porque o projeto não possui suite configurada. 
- Executado `npm run lint` que falhou por ausência de arquivo de configuração do ESLint no repositório (ambiente aponta que falta `ESLint configuration file`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699cf5a105b0832caceef4b66666543d)