### PR TITLE
Implementa módulo institucional multiunidade e Relatórios institucionais

### DIFF
--- a/src/data/hortelanBlueprint.js
+++ b/src/data/hortelanBlueprint.js
@@ -291,10 +291,13 @@ export const hortelanModules = [
     title: 'Módulo Educacional/Institucional',
     tags: ['Release 3', 'B2B/B2G'],
     features: [
-      'Gestão de múltiplas hortas por instituição',
-      'Usuários por turma/equipe e dashboard por unidade',
-      'Metas coletivas e relatórios ESG/pedagógicos',
-      'Permissões para professores/gestores e certificados',
+      '24.1 Gestão de múltiplas unidades: escolas, condomínios, empresas e projetos sociais',
+      '24.1 Painel consolidado com várias hortas por unidade/instituição',
+      '24.2 Perfis institucionais: coordenador, monitor, operador local e visualizador/gestor',
+      '24.3 Relatórios institucionais de engajamento e uso de recursos',
+      '24.3 Indicadores de produção/colheita e sustentabilidade/educação por unidade e rede',
+      '24.4 Módulo educacional (fase futura): trilhas de atividades e conteúdo pedagógico',
+      '24.4 Registro de atividades em sala/projeto e evidências para acompanhamento',
     ],
   },
   {

--- a/src/layouts/dashboard/NavConfig.js
+++ b/src/layouts/dashboard/NavConfig.js
@@ -63,6 +63,7 @@ const navConfig = [
     path: '/dashboard/assinaturas',
     icon: getIcon('eva:credit-card-fill'),
   },
+  {
     title: 'central de ajuda',
     path: '/dashboard/suporte',
     icon: getIcon('eva:question-mark-circle-fill'),

--- a/src/pages/Reports.js
+++ b/src/pages/Reports.js
@@ -133,6 +133,44 @@ const historyTypeLabel = {
   photo: 'Foto',
 };
 
+const institutionalUnits = [
+  {
+    unit: 'Escola Municipal Aurora',
+    profile: 'Coordenador',
+    gardens: 6,
+    activeParticipants: 128,
+    resourcesUsage: 'Água 1.240 L • Energia 93 kWh',
+    productionHarvest: '84 kg colhidos no mês',
+    sustainabilityEducation: '12 oficinas • 96% de presença média',
+  },
+  {
+    unit: 'Condomínio Jardim das Flores',
+    profile: 'Operador local',
+    gardens: 4,
+    activeParticipants: 42,
+    resourcesUsage: 'Água 690 L • Energia 41 kWh',
+    productionHarvest: '38 kg colhidos no mês',
+    sustainabilityEducation: '8 mutirões • 72 famílias envolvidas',
+  },
+  {
+    unit: 'Projeto Social Semeando Futuro',
+    profile: 'Monitor',
+    gardens: 5,
+    activeParticipants: 67,
+    resourcesUsage: 'Água 910 L • Energia 58 kWh',
+    productionHarvest: '53 kg colhidos no mês',
+    sustainabilityEducation: '15 aulas práticas • 4 trilhas ativas',
+  },
+];
+
+const institutionalProfiles = ['Coordenador', 'Monitor', 'Operador local', 'Visualizador/Gestor'];
+
+const educationalModuleFutureScope = [
+  'Trilhas de atividades por faixa etária e objetivo pedagógico',
+  'Conteúdo pedagógico alinhado à BNCC e metas ESG institucionais',
+  'Registro de atividades em sala/projeto com fotos, presença e evidências',
+];
+
 function downloadFile(content, filename, mimeType) {
   const blob = new Blob([content], { type: mimeType });
   const url = URL.createObjectURL(blob);
@@ -262,6 +300,7 @@ export default function Reports() {
                 <Tab value="operacional" label="Relatórios operacionais" />
                 <Tab value="cultivo" label="Relatórios de cultivo" />
                 <Tab value="manutencao" label="Relatórios de manutenção" />
+                <Tab value="institucional" label="Relatórios institucionais" />
                 <Tab value="historico" icon={<TimelineRoundedIcon />} iconPosition="start" label="Histórico unificado" />
               </Tabs>
 
@@ -334,6 +373,62 @@ export default function Reports() {
                     </Grid>
                   ))}
                 </Grid>
+              )}
+
+              {tab === 'institucional' && (
+                <Stack spacing={2}>
+                  <Alert severity="success">
+                    Visão institucional com múltiplas unidades (escolas, condomínios, empresas e projetos sociais) em um painel consolidado.
+                  </Alert>
+
+                  <Card variant="outlined">
+                    <CardContent>
+                      <Stack spacing={1}>
+                        <Typography variant="h6">Perfis institucionais</Typography>
+                        <Stack direction="row" spacing={1} flexWrap="wrap" useFlexGap>
+                          {institutionalProfiles.map((profile) => (
+                            <Chip key={profile} label={profile} color="primary" variant="outlined" />
+                          ))}
+                        </Stack>
+                      </Stack>
+                    </CardContent>
+                  </Card>
+
+                  <Grid container spacing={2}>
+                    {institutionalUnits.map((row) => (
+                      <Grid item xs={12} md={4} key={row.unit}>
+                        <Card variant="outlined" sx={{ height: '100%' }}>
+                          <CardContent>
+                            <Stack spacing={1}>
+                              <Typography variant="h6">{row.unit}</Typography>
+                              <Chip label={`Perfil responsável: ${row.profile}`} size="small" sx={{ alignSelf: 'flex-start' }} />
+                              <Typography>Hortas monitoradas: {row.gardens}</Typography>
+                              <Typography>Engajamento: {row.activeParticipants} participantes ativos</Typography>
+                              <Typography>Uso de recursos: {row.resourcesUsage}</Typography>
+                              <Typography>Produção/colheita: {row.productionHarvest}</Typography>
+                              <Typography>Sustentabilidade/educação: {row.sustainabilityEducation}</Typography>
+                            </Stack>
+                          </CardContent>
+                        </Card>
+                      </Grid>
+                    ))}
+                  </Grid>
+
+                  <Card variant="outlined">
+                    <CardContent>
+                      <Typography variant="h6" gutterBottom>
+                        Módulo educacional (fase futura)
+                      </Typography>
+                      <List dense>
+                        {educationalModuleFutureScope.map((item) => (
+                          <ListItem key={item} sx={{ px: 0 }}>
+                            <ListItemText primary={`• ${item}`} />
+                          </ListItem>
+                        ))}
+                      </List>
+                    </CardContent>
+                  </Card>
+                </Stack>
               )}
 
               {tab === 'historico' && (


### PR DESCRIPTION
### Motivation
- Consolidar suporte a instituições com múltiplas unidades (escolas, condomínios, empresas, projetos sociais) e permitir visões agregadas por rede/unidade.
- Fornecer perfis institucionais (coordenador, monitor, operador local, visualizador/gestor) e relatórios específicos de engajamento, uso de recursos, produção/colheita e sustentabilidade/educação.
- Registrar o escopo futuro do módulo educacional (trilhas, conteúdo pedagógico e registro de atividades) para planejamento de releases.

### Description
- Atualiza o blueprint do Hortelan 360 em `src/data/hortelanBlueprint.js` para incluir os itens 24.1–24.4 (gestão multiunidade, painel consolidado, perfis, relatórios e escopo educacional futuro). 
- Adiciona a aba `Relatórios institucionais` em `src/pages/Reports.js` com dados de exemplo (`institutionalUnits`), chips de `institutionalProfiles`, cards com métricas por unidade e bloco com o escopo do `educationalModuleFutureScope` (trilhas, conteúdo e registro de atividades). 
- Corrige um erro de sintaxe no menu lateral em `src/layouts/dashboard/NavConfig.js` que impedia a compilação do app. 

### Testing
- `npm run build` foi executado com sucesso e gerou o bundle de produção sem erros.
- `npm test` foi executado e retornou o resultado padrão do projeto (nenhuma suíte de testes configurada) com status de saída 0.
- `npm run lint` falhou devido à ausência de um arquivo de configuração do ESLint no repositório, que é uma limitação de configuração e não bloqueia a entrega das mudanças.
- Validei a interface em execução local e capturei uma screenshot automatizada da aba institucional em `artifacts/institutional-reports.png` (script Playwright).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699cf8d95d68832c913200fb667a12a2)