### PR TITLE
ci: adiciona pipeline de CI/CD com deploy e Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,29 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: '/'
+    schedule:
+      interval: weekly
+      day: monday
+      time: '08:00'
+      timezone: 'America/Sao_Paulo'
+    open-pull-requests-limit: 10
+    labels:
+      - dependencies
+      - npm
+    commit-message:
+      prefix: 'chore(deps)'
+
+  - package-ecosystem: github-actions
+    directory: '/'
+    schedule:
+      interval: weekly
+      day: monday
+      time: '08:30'
+      timezone: 'America/Sao_Paulo'
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+      - github-actions
+    commit-message:
+      prefix: 'chore(ci)'

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,0 +1,65 @@
+name: CD - Deploy GitHub Pages
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'src/**'
+      - 'public/**'
+      - 'package.json'
+      - 'package-lock.json'
+      - 'vite.config.js'
+      - 'index.html'
+      - 'jsconfig.json'
+      - '.github/workflows/cd.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+
+      - name: Instalar dependências
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./dist
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,53 @@
+name: CI - Qualidade
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'src/**'
+      - 'public/**'
+      - 'package.json'
+      - 'package-lock.json'
+      - 'vite.config.js'
+      - 'index.html'
+      - 'jsconfig.json'
+      - '.github/workflows/ci.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'src/**'
+      - 'public/**'
+      - 'package.json'
+      - 'package-lock.json'
+      - 'vite.config.js'
+      - 'index.html'
+      - 'jsconfig.json'
+      - '.github/workflows/ci.yml'
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  quality:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Instalar dependências
+        run: npm ci
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Build
+        run: npm run build


### PR DESCRIPTION
### Motivation
- Automatizar validações mínimas necessárias (instalação de dependências, lint e build) e publicar no GitHub Pages apenas para mudanças relevantes. 
- Reduzir execução desnecessária de pipelines usando filtros por `paths` e controlar concorrência para evitar execuções duplicadas. 
- Manter dependências atualizadas automaticamente com o Dependabot para segurança e manutenção.

### Description
- Adiciona workflow de CI em `/.github/workflows/ci.yml` que roda em `pull_request` e `push` para `main` apenas quando arquivos relevantes mudarem e executa `npm ci`, `npm run lint` e `npm run build` com `node-version: 20` e `concurrency` configurado. 
- Adiciona workflow de CD em `/.github/workflows/cd.yml` que faz build e publica para GitHub Pages em `push` para `main` e permite `workflow_dispatch`, incluindo etapas de setup de Pages e upload do artefato. 
- Adiciona `/.github/dependabot.yml` para atualizar semanalmente dependências `npm` e `github-actions`, com limites de PRs, labels e padrão de commit. 
- Escopo das pipelines otimizado com `paths` para evitar runs em alterações não críticas.

### Testing
- Executado `npm run lint`, que falhou por ausência de arquivo de configuração do ESLint no repositório (comportamento esperado e mantido para sinalizar falta de configuração). 
- Executado `npm run build`, que completou com sucesso no ambiente de CI local. 
- Os workflows e o arquivo do Dependabot foram adicionados e commitados (`ci: adiciona pipeline de CI/CD e dependabot`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699d221fb214832c8939f5612f98d2cd)