### PR TITLE
Atualiza branding para nome completo Hortelan Agtech Ltda

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,11 +13,11 @@
   <link href="https://fonts.googleapis.com/css2?family=Public+Sans:wght@400;500;600;700&display=swap" rel="stylesheet">
   <!-- Using Local Font -->
   <link rel="stylesheet" type="text/css" href="/fonts/index.css" />
-  <title>Hortelan V2.0</title>
+  <title>Hortelan Agtech Ltda V2.0</title>
   <meta name="description"
     content="" />
   <meta name="keywords" content="" />
-  <meta name="author" content="Hortelan Systems v2" />
+  <meta name="author" content="Hortelan Agtech Ltda Systems v2" />
   <script type="text/javascript">
     ;window.NREUM||(NREUM={});NREUM.init={distributed_tracing:{enabled:true},privacy:{cookies_enabled:true},ajax:{deny_list:["bam.nr-data.net"]}};
     ;NREUM.loader_config={accountID:"4197438",trustKey:"4197438",agentID:"1588876114",licenseKey:"NRJS-609f58495589ee2a009",applicationID:"1588876114"};

--- a/public/index.html
+++ b/public/index.html
@@ -13,11 +13,11 @@
   <link href="https://fonts.googleapis.com/css2?family=Public+Sans:wght@400;500;600;700&display=swap" rel="stylesheet">
   <!-- Using Local Font -->
   <link rel="stylesheet" type="text/css" href="%PUBLIC_URL%/fonts/index.css" />
-  <title>Hortelan V2.0</title>
+  <title>Hortelan Agtech Ltda V2.0</title>
   <meta name="description"
     content="" />
   <meta name="keywords" content="" />
-  <meta name="author" content="Hortelan Systems v2" />
+  <meta name="author" content="Hortelan Agtech Ltda Systems v2" />
   <script type="text/javascript">
     ;window.NREUM||(NREUM={});NREUM.init={distributed_tracing:{enabled:true},privacy:{cookies_enabled:true},ajax:{deny_list:["bam.nr-data.net"]}};
     ;NREUM.loader_config={accountID:"4197438",trustKey:"4197438",agentID:"1588876114",licenseKey:"NRJS-609f58495589ee2a009",applicationID:"1588876114"};

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,6 +1,6 @@
 {
-  "short_name": "Hortelan V2",
-  "name": "Hortelan V2.0 Systems ",
+  "short_name": "Hortelan Agtech Ltda V2",
+  "name": "Hortelan Agtech Ltda V2.0 Systems ",
   "icons": [
     {
       "src": "favicon/nav-logo.svg",

--- a/src/components/HortelanPromoBanner.js
+++ b/src/components/HortelanPromoBanner.js
@@ -6,7 +6,7 @@ export default function HortelanPromoBanner({ sx }) {
     <Box
       component="img"
       src="/static/logos.png"
-      alt="Banner Hortelan - Tecnologia Sustentável para Hortas Inteligentes"
+      alt="Banner Hortelan Agtech Ltda - Tecnologia Sustentável para Hortas Inteligentes"
       sx={{
         width: '100%',
         display: 'block',

--- a/src/components/Page.js
+++ b/src/components/Page.js
@@ -9,7 +9,7 @@ import { Box } from '@mui/material';
 const Page = forwardRef(({ children, title = '', meta, ...other }, ref) => (
   <>
     <Helmet>
-      <title>{`${title} | Hortelan`}</title>
+      <title>{`${title} | Hortelan Agtech Ltda`}</title>
       {meta}
     </Helmet>
 

--- a/src/pages/Blog.js
+++ b/src/pages/Blog.js
@@ -210,7 +210,7 @@ export default function Blog() {
     <Page title="Dashboard: Comunidade">
       <Container maxWidth="xl">
         <Typography variant="h4" gutterBottom>
-          Comunidade Hortelan
+          Comunidade Hortelan Agtech Ltda
         </Typography>
         <Typography variant="body2" color="text.secondary" mb={3}>
           Perfil público, publicações, perguntas e respostas, reputação e moderação comunitária.

--- a/src/pages/DashboardApp.js
+++ b/src/pages/DashboardApp.js
@@ -1060,7 +1060,7 @@ export default function DashboardApp() {
     <Page title="Dashboard">
       <Container maxWidth="xl">
         <Typography variant="h4" sx={{ mb: 5 }}>
-          Welcome User to the Hortelan System
+          Welcome User to the Hortelan Agtech Ltda System
         </Typography>
 
         <HortelanPromoBanner sx={{ mb: 4 }} />

--- a/src/pages/Hortelan360.js
+++ b/src/pages/Hortelan360.js
@@ -34,10 +34,10 @@ export default function Hortelan360() {
   );
 
   return (
-    <Page title="Hortelan 360">
+    <Page title="Hortelan Agtech Ltda 360">
       <Container maxWidth="xl">
         <Stack spacing={3} sx={{ mb: 4 }}>
-          <Typography variant="h4">Hortelan AgTech — Blueprint completo da plataforma</Typography>
+          <Typography variant="h4">Hortelan Agtech Ltda — Blueprint completo da plataforma</Typography>
           <Typography color="text.secondary">
             Esta tela consolida as 30 frentes de produto solicitadas em uma arquitetura de entrega por releases.
           </Typography>

--- a/src/pages/Login.js
+++ b/src/pages/Login.js
@@ -184,7 +184,7 @@ export default function Login() {
               <Cable sx={{ transform: `scaleX(1) rotate(${cableWave}deg)` }} />
             </DecorativeScene>
             <Typography variant="h3" sx={{ px: 5, mt: 10, mb: 5 }}>
-              Olá, bem-vindo de volta ao Hortelan
+              Olá, bem-vindo de volta à Hortelan Agtech Ltda
             </Typography>
             <img src="/static/illustrations/illustration_login.png" alt="login" style={{ position: 'relative', zIndex: 2 }} />
           </SectionStyle>
@@ -193,7 +193,7 @@ export default function Login() {
         <Container maxWidth="sm">
           <ContentStyle>
             <Typography variant="h4" gutterBottom>
-              Entrar no Hortelan
+              Entrar na Hortelan Agtech Ltda
             </Typography>
 
             <Typography sx={{ color: 'text.secondary', mb: 1 }}>Use seu e-mail e senha para continuar.</Typography>

--- a/src/pages/Onboarding.js
+++ b/src/pages/Onboarding.js
@@ -223,7 +223,7 @@ export default function Onboarding() {
       <Container maxWidth="md">
         <Stack spacing={3}>
           <Box>
-            <Typography variant="h4">Onboarding guiado Hortelan</Typography>
+            <Typography variant="h4">Onboarding guiado Hortelan Agtech Ltda</Typography>
             <Typography variant="body2" color="text.secondary">
               Passo a passo para criar sua primeira horta, cadastrar plantas, parear dispositivo e ativar automações.
             </Typography>

--- a/src/pages/Products.js
+++ b/src/pages/Products.js
@@ -123,10 +123,10 @@ export default function ProductsMarketplace() {
   ];
 
   return (
-    <Page title="Marketplace Hortelan">
+    <Page title="Marketplace Hortelan Agtech Ltda">
       <Container>
         <Stack spacing={1} sx={{ mb: 3 }}>
-          <Typography variant="h4">Catálogo de produtos Hortelan</Typography>
+          <Typography variant="h4">Catálogo de produtos Hortelan Agtech Ltda</Typography>
           <Typography color="text.secondary">
             Explore sementes, substratos, fertilizantes, sensores, kits, irrigação e ferramentas com filtros avançados.
           </Typography>
@@ -268,7 +268,7 @@ export default function ProductsMarketplace() {
                     {selectedProduct.descricaoTecnica}
                   </Typography>
                   <Typography variant="body2" color="primary" sx={{ mb: 2 }}>
-                    Compatibilidade Hortelan: {selectedProduct.compatibilidadeHortelan}
+                    Compatibilidade Hortelan Agtech Ltda: {selectedProduct.compatibilidadeHortelan}
                   </Typography>
                   <Stack direction="row" spacing={1} flexWrap="wrap" sx={{ mb: 2 }}>
                     <Chip icon={<Inventory2Icon />} label={`Estoque: ${selectedProduct.estoque}`} />

--- a/src/pages/Register.js
+++ b/src/pages/Register.js
@@ -79,7 +79,7 @@ export default function Register() {
         {mdUp && (
           <SectionStyle>
             <Typography variant="h3" sx={{ px: 5, mt: 10, mb: 5 }}>
-              Crie sua conta na Hortelan
+              Crie sua conta na Hortelan Agtech Ltda
             </Typography>
             <img
               alt="register"

--- a/src/pages/Reports.js
+++ b/src/pages/Reports.js
@@ -209,15 +209,15 @@ export default function Reports() {
       ...cultivationRows.map((row) => `cultivo,-,${row.plant},produtividade_kg,${row.productivityKg}`),
     ];
 
-    downloadFile(csvLines.join('\n'), `relatorio-hortelan-${new Date().toISOString().slice(0, 10)}.csv`, 'text/csv;charset=utf-8;');
+    downloadFile(csvLines.join('\n'), `relatorio-hortelan-agtech-ltda-${new Date().toISOString().slice(0, 10)}.csv`, 'text/csv;charset=utf-8;');
   };
 
   const exportPdfSummary = () => {
     const summaryHtml = `
       <html>
-        <head><title>Resumo de Relatórios Hortelan</title></head>
+        <head><title>Resumo de Relatórios Hortelan Agtech Ltda</title></head>
         <body style="font-family: Arial, sans-serif; padding: 24px;">
-          <h1>Resumo de Relatórios Hortelan</h1>
+          <h1>Resumo de Relatórios Hortelan Agtech Ltda</h1>
           <p>Gerado em ${new Date().toLocaleString('pt-BR')}.</p>
           <h2>Operacional</h2>
           <ul>


### PR DESCRIPTION
### Motivation
- Garantir que o nome jurídico completo da empresa seja exibido de forma consistente na aplicação e nos metadados públicos para alinhamento de branding e comunicação.
- Substituir referências abreviadas por `Hortelan Agtech Ltda` em títulos de página, textos visíveis e arquivos públicos para evitar ambiguidade institucional.

### Description
- Atualiza o sufixo padrão do título de páginas em `src/components/Page.js` para usar `Hortelan Agtech Ltda` em vez de `Hortelan`.
- Altera textos visíveis em várias telas (Login, Register, Onboarding, Products, Reports, Blog, Dashboard e Hortelan360) para incluir `Hortelan Agtech Ltda` onde aplicável.
- Atualiza metadados públicos em `index.html`, `public/index.html` e `public/manifest.json` para refletir o nome completo da empresa.
- Ajusta o `alt` do banner promocional em `src/components/HortelanPromoBanner.js` e nomes de arquivos/headers de exportação em `src/pages/Reports.js` (CSV/PDF) e textos de compatibilidade em `src/pages/Products.js`.

### Testing
- Rodei a build de produção com `npm run build` e a build completou com sucesso (artefatos gerados).
- Iniciei o servidor de desenvolvimento com `npm run dev -- --host 0.0.0.0 --port 4173` e a aplicação subiu corretamente para validação visual.
- Capturei uma captura de tela da página inicial após as alterações para validação visual (`artifacts/home-branding.png`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699d36408988832ca6ad3938552993b3)