### PR TITLE
chore: add frontend audit tooling, ESLint config and baseline fixes

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -1,0 +1,31 @@
+module.exports = {
+  root: true,
+  env: {
+    browser: true,
+    es2022: true,
+    node: true,
+  },
+  parserOptions: {
+    ecmaVersion: 'latest',
+    sourceType: 'module',
+  },
+  settings: {
+    react: {
+      version: 'detect',
+    },
+    'import/resolver': {
+      node: {
+        paths: ['src'],
+        extensions: ['.js', '.jsx'],
+      },
+    },
+  },
+  plugins: ['react', 'react-hooks', 'import'],
+  extends: ['eslint:recommended', 'plugin:react/recommended', 'plugin:react-hooks/recommended', 'prettier'],
+  rules: {
+    'react/react-in-jsx-scope': 'off',
+    'react/prop-types': 'off',
+    'import/no-unresolved': 'off',
+    'no-unused-vars': ['error', { argsIgnorePattern: '^_', varsIgnorePattern: '^_' }],
+  },
+};

--- a/docs/frontend-compliance-report.md
+++ b/docs/frontend-compliance-report.md
@@ -1,0 +1,37 @@
+# Frontend Compliance Report
+
+## Scope
+- Static linting for React/JS quality rules.
+- Build validation for Vite production bundle.
+- Heuristic audit for potential orphan files and duplicate code by normalized content hash.
+
+## Commands used
+- `npm run lint`
+- `npm run build`
+- `npm run audit:frontend`
+
+## Key findings
+
+### 1) Lint and React quality baseline
+- Added a project-level ESLint configuration (`.eslintrc.cjs`) to enable reproducible frontend quality checks.
+- Fixed detected issues:
+  - Added explicit `displayName` for `forwardRef` component (`Page`).
+  - Removed unused imports in theme toggle component (`ModeTheme`).
+  - Escaped unescaped JSX quotes in onboarding success message.
+
+### 2) Duplicated code
+- No duplicated JS/JSX files were found by normalized-content hash (`Duplicate-content groups: 0`).
+
+### 3) Potentially unused/orphan files
+- The audit identified **35 potential orphan files** (reachable-graph heuristic from `src/index.js`).
+- These files should be reviewed and removed only after functional confirmation in product flows.
+
+### 4) Build and architecture notes
+- Build passes, but bundle remains large (single chunk ~4.5 MB pre-gzip warning from Vite).
+- Recommended next steps:
+  1. Split heavy dashboard routes with `React.lazy` + route-based code splitting.
+  2. Use manual chunks in `vite.config.js` for large vendor libs.
+  3. Track bundle budget in CI and fail when exceeding thresholds.
+
+## Conclusion
+The project now has a repeatable quality gate for linting and structural audits, and currently builds successfully in production mode. Remaining compliance work is mainly focused on removing truly unused modules and reducing bundle size.

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "test": "echo \"No test runner configured\" && exit 0",
     "lint": "eslint --ext .js,.jsx ./src",
     "lint:fix": "eslint --fix --ext .js,.jsx ./src",
+    "audit:frontend": "node scripts/frontend-audit.mjs",
     "clear-all": "rm -rf build node_modules dist",
     "re-start": "rm -rf build node_modules dist && npm install && npm run dev",
     "re-build": "rm -rf build node_modules dist && npm install && npm run build",

--- a/scripts/frontend-audit.mjs
+++ b/scripts/frontend-audit.mjs
@@ -1,0 +1,135 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import crypto from 'node:crypto';
+
+const root = process.cwd();
+const srcDir = path.join(root, 'src');
+const entryFile = path.join(srcDir, 'index.js');
+const exts = ['.js', '.jsx'];
+const IGNORE_ORPHAN_PATTERNS = [
+  '/_mock/',
+  '/setupTests.js',
+  '/entry-server.js',
+  '/serviceWorker.js',
+  '/data/',
+];
+
+function listFiles(dir) {
+  const output = [];
+  const entries = fs.readdirSync(dir, { withFileTypes: true });
+  for (const entry of entries) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      output.push(...listFiles(full));
+      continue;
+    }
+    if (exts.includes(path.extname(entry.name))) {
+      output.push(full);
+    }
+  }
+  return output;
+}
+
+function findExistingFile(basePath) {
+  if (fs.existsSync(basePath) && fs.statSync(basePath).isFile()) return basePath;
+  for (const ext of exts) {
+    if (fs.existsSync(`${basePath}${ext}`)) return `${basePath}${ext}`;
+  }
+  for (const ext of exts) {
+    const indexFile = path.join(basePath, `index${ext}`);
+    if (fs.existsSync(indexFile)) return indexFile;
+  }
+  return null;
+}
+
+function extractImports(content) {
+  const imports = [];
+  const re = /(?:import|export)\s+(?:[^'"\n]+?\s+from\s+)?['"]([^'"]+)['"]/g;
+  let match;
+  while ((match = re.exec(content))) {
+    imports.push(match[1]);
+  }
+  return imports;
+}
+
+function toProjectPath(filePath) {
+  return path.relative(root, filePath).replaceAll(path.sep, '/');
+}
+
+const files = listFiles(srcDir);
+const fileSet = new Set(files.map((f) => path.resolve(f)));
+
+const graph = new Map();
+for (const file of files) {
+  const content = fs.readFileSync(file, 'utf8');
+  const imports = extractImports(content);
+  const resolved = [];
+
+  for (const spec of imports) {
+    if (spec.startsWith('.')) {
+      const target = findExistingFile(path.resolve(path.dirname(file), spec));
+      if (target && fileSet.has(path.resolve(target))) {
+        resolved.push(path.resolve(target));
+      }
+      continue;
+    }
+
+    if (spec.startsWith('src/')) {
+      const target = findExistingFile(path.join(root, spec));
+      if (target && fileSet.has(path.resolve(target))) {
+        resolved.push(path.resolve(target));
+      }
+    }
+  }
+
+  graph.set(path.resolve(file), resolved);
+}
+
+const visited = new Set();
+const queue = [path.resolve(entryFile)];
+
+while (queue.length) {
+  const current = queue.shift();
+  if (!current || visited.has(current) || !graph.has(current)) continue;
+  visited.add(current);
+  for (const dep of graph.get(current) ?? []) {
+    if (!visited.has(dep)) queue.push(dep);
+  }
+}
+
+const orphanFiles = files
+  .map((f) => path.resolve(f))
+  .filter((f) => !visited.has(f))
+  .map((f) => toProjectPath(f))
+  .filter((f) => !IGNORE_ORPHAN_PATTERNS.some((pattern) => f.endsWith(pattern) || f.includes(pattern)));
+
+const hashMap = new Map();
+for (const file of files) {
+  const content = fs.readFileSync(file, 'utf8');
+  const normalized = content.replace(/\s+/g, ' ').trim();
+  const hash = crypto.createHash('sha1').update(normalized).digest('hex');
+  const bucket = hashMap.get(hash) ?? [];
+  bucket.push(toProjectPath(file));
+  hashMap.set(hash, bucket);
+}
+
+const duplicateGroups = [...hashMap.values()].filter((group) => group.length > 1);
+
+console.log('Frontend audit summary');
+console.log('======================');
+console.log(`Scanned files: ${files.length}`);
+console.log(`Reachable files from src/index.js: ${visited.size}`);
+console.log(`Potential orphan files: ${orphanFiles.length}`);
+
+if (orphanFiles.length) {
+  console.log('\nPotential orphan files (review before removal):');
+  orphanFiles.forEach((file) => console.log(`- ${file}`));
+}
+
+console.log(`\nDuplicate-content groups: ${duplicateGroups.length}`);
+if (duplicateGroups.length) {
+  duplicateGroups.forEach((group, idx) => {
+    console.log(`\nGroup ${idx + 1}:`);
+    group.forEach((file) => console.log(`- ${file}`));
+  });
+}

--- a/src/components/Page.js
+++ b/src/components/Page.js
@@ -19,6 +19,8 @@ const Page = forwardRef(({ children, title = '', meta, ...other }, ref) => (
   </>
 ));
 
+Page.displayName = 'Page';
+
 Page.propTypes = {
   children: PropTypes.node.isRequired,
   title: PropTypes.string,

--- a/src/layouts/dashboard/ModeTheme.js
+++ b/src/layouts/dashboard/ModeTheme.js
@@ -1,7 +1,4 @@
-import * as React from 'react';
 import { styled } from '@mui/material/styles';
-import FormGroup from '@mui/material/FormGroup';
-import FormControlLabel from '@mui/material/FormControlLabel';
 import Switch from '@mui/material/Switch';
 
 const MaterialUISwitch = styled(Switch)(({ theme }) => ({
@@ -52,7 +49,5 @@ const MaterialUISwitch = styled(Switch)(({ theme }) => ({
 }));
 
 export default function ModeTheme() {
-  return (
-        <MaterialUISwitch sx={{ m: 1 }} defaultChecked /> 
-  );
+  return <MaterialUISwitch sx={{ m: 1 }} defaultChecked />;
 }

--- a/src/pages/Onboarding.js
+++ b/src/pages/Onboarding.js
@@ -449,7 +449,7 @@ export default function Onboarding() {
                   ))}
                   {automationCreated.map((item) => (
                     <Alert key={item} severity="success" variant="outlined">
-                      Automação "{item}" criada com sucesso.
+                      Automação &quot;{item}&quot; criada com sucesso.
                     </Alert>
                   ))}
                 </Stack>


### PR DESCRIPTION
### Motivation
- Introduzir uma validação repetível de qualidade frontend e detecção de código possivelmente não utilizado para manter conformidade e reduzir dívida técnica.
- Permitir auditoria automática de arquivos órfãos e duplicados antes de remoções manuais por meio de um script replicável.

### Description
- Adiciona configuração de ESLint em `/.eslintrc.cjs` para estabelecer regras mínimas de qualidade React/hooks e resolver imports relativos a `src`.
- Registra `audit:frontend` em `package.json` e inclui o script `scripts/frontend-audit.mjs` que constrói um grafo de imports a partir de `src/index.js`, lista arquivos potencialmente órfãos e agrupa arquivos com conteúdo duplicado por hash normalizado.
- Documenta os achados e recomendações em `docs/frontend-compliance-report.md` com instruções e próximos passos (code-splitting, manual chunks, orçamento de bundle).
- Aplica correções rápidas necessárias para passar a validação: define `Page.displayName` em `src/components/Page.js`, remove imports não usados e simplifica retorno em `src/layouts/dashboard/ModeTheme.js`, e escapa aspas em JSX em `src/pages/Onboarding.js` para atender `react/no-unescaped-entities`.

### Testing
- Executado `npm run lint` para validação estática do código e a verificação concluiu com sucesso após as correções (`npm run lint` ✅).
- Executado `npm run audit:frontend` que listou arquivos potencialmente órfãos e reportou `Duplicate-content groups: 0` (`npm run audit:frontend` ✅).
- Executado `npm run build` com Vite para checar bundle de produção e o build completou com sucesso; foram mantidos avisos sobre tamanho de chunk e anotações de terceiros (`npm run build` ✅, com warnings sobre chunk-size).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699d474c935c832ca1372b580b64d8f7)