### PR TITLE
fix: ensure SPA routes resolve on Vercel

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,8 +1,9 @@
 {
+  "version": 2,
   "outputDirectory": "build",
   "rewrites": [
     {
-      "source": "/(.*)",
+      "source": "/:path*",
       "destination": "/index.html"
     }
   ]


### PR DESCRIPTION
### Motivation
- Ensure deep links (for example `/dashboard/app`) are served by the SPA entrypoint instead of returning a 404 from Vercel by adjusting the deployment routing rules.

### Description
- Updated `vercel.json` to include `"version": 2` and replaced the rewrite source `"/(.*)"` with the wildcard `"/:path*"` so all paths are rewritten to `/index.html`.

### Testing
- Ran `npm run build` which completed successfully and produced the production build artifacts.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699d50a289bc832c9b07ff80ac9599f9)