### PR TITLE
Add scoped hero/parallax/storytelling animations to Products page

### DIFF
--- a/src/components/HortelanPromoBanner.js
+++ b/src/components/HortelanPromoBanner.js
@@ -1,10 +1,11 @@
 import PropTypes from 'prop-types';
 import { Box } from '@mui/material';
 
-export default function HortelanPromoBanner({ sx }) {
+export default function HortelanPromoBanner({ sx, className }) {
   return (
     <Box
       component="img"
+      className={className}
       src="/static/logos.png"
       alt="Banner Hortelan Agtech Ltda - Tecnologia Sustentável para Hortas Inteligentes"
       sx={{
@@ -19,9 +20,11 @@ export default function HortelanPromoBanner({ sx }) {
 }
 
 HortelanPromoBanner.propTypes = {
+  className: PropTypes.string,
   sx: PropTypes.object,
 };
 
 HortelanPromoBanner.defaultProps = {
+  className: undefined,
   sx: {},
 };

--- a/src/hooks/useGSAP.js
+++ b/src/hooks/useGSAP.js
@@ -1,0 +1,21 @@
+import { useLayoutEffect } from 'react';
+
+export default function useGSAP(callback, options = {}) {
+  const { dependencies = [], scope } = options;
+
+  useLayoutEffect(() => {
+    const ctx = {
+      selector: (selector) => {
+        if (!scope?.current) return [];
+        return Array.from(scope.current.querySelectorAll(selector));
+      },
+      root: scope?.current || null,
+    };
+
+    const cleanup = callback(ctx);
+    return () => {
+      if (typeof cleanup === 'function') cleanup();
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, dependencies);
+}


### PR DESCRIPTION
### Motivation
- Provide fine-grained, section-scoped animations for the Products page (hero, promo banner parallax, and storytelling cards) while avoiding global side-effects and enabling continuation/transitions in special sections.

### Description
- Added a small scoped animation hook `src/hooks/useGSAP.js` that provides a `selector`/`root` API and lifecycle cleanup for animations bound to a local `ref` scope.
- Enhanced `src/pages/Products.js` to wire a `rootRef` and orchestrate controlled animations using the Web Animations API, an `IntersectionObserver` for storytelling card reveals, and a scroll handler to produce a gentle parallax effect for the promo banner; animations target elements via class names (`gsap-hero-*`, `gsap-category-chip`, `gsap-story-*`).
- Updated `src/components/HortelanPromoBanner.js` to accept a `className` prop so the banner can be targeted by the animations without changing other usages.

### Testing
- Ran linting with `npx eslint src/pages/Products.js src/components/HortelanPromoBanner.js src/hooks/useGSAP.js` and it completed successfully.
- Built the project with `npm run build` and the build finished successfully.
- Started the dev server and executed an automated Playwright navigation that reached `/dashboard/products` and produced a screenshot artifact showing the animated sections (smoke navigation and visual check succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699d59a454a4832c99082dd600a99cb8)