### PR TITLE
feat: day/night interactive plant growth scene (motion + GSAP-style)

### DIFF
--- a/src/components/fx/HortelanPlayfulEffects.js
+++ b/src/components/fx/HortelanPlayfulEffects.js
@@ -1,141 +1,393 @@
-import { useMemo } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { motion, useReducedMotion, useScroll, useSpring, useTransform } from '../../lib/motionReact';
+import useGSAP from '../../hooks/useGSAP';
 
-const ORBITERS = ['🛰️', '📡', '🤖', '🧠', '🌿', '💧'];
+const TOTAL_PLANTS = 7;
+const TOTAL_RAINDROPS = 34;
+const TOTAL_STARS = 28;
+
+function getTimeMode() {
+  const hour = new Date().getHours();
+  return hour >= 6 && hour < 18 ? 'day' : 'night';
+}
 
 export default function HortelanPlayfulEffects() {
   const shouldReduceMotion = useReducedMotion();
+  const scope = useRef(null);
+  const [timeMode] = useState(getTimeMode);
+  const [interactionEnergy, setInteractionEnergy] = useState(0);
+  const isDay = timeMode === 'day';
   const { scrollYProgress } = useScroll();
 
-  const progressScale = useSpring(scrollYProgress, {
-    stiffness: 160,
-    damping: 28,
-    mass: 0.3,
-  });
+  const smoothEnergy = useSpring(interactionEnergy, { stiffness: 130, damping: 26, mass: 0.45 });
 
-  const overlayOpacity = useTransform(scrollYProgress, [0, 1], [0.12, 0.26]);
-  const heartbeatScale = useTransform(scrollYProgress, [0, 1], [1, 1.08]);
+  const scrollScale = useSpring(scrollYProgress, { stiffness: 140, damping: 30, mass: 0.3 });
 
-  const heartPoints = useMemo(
-    () => [
-      { position: { top: 96, left: 20 }, label: 'Saúde da horta: estável', delay: 0 },
-      { position: { top: 126, right: 24 }, label: 'Saúde da horta: vigorosa', delay: 0.2 },
-      { position: { bottom: 26, left: 18 }, label: 'Saúde da horta: hidratada', delay: 0.4 },
-    ],
+  const skyBlend = useTransform(scrollYProgress, [0, 1], isDay ? [0.12, 0.4] : [0.18, 0.5]);
+  const rainOpacity = useTransform(smoothEnergy, [0, 1], isDay ? [0.03, 0.9] : [0.04, 0.12]);
+  const plantGrowth = useTransform(smoothEnergy, [0, 1], isDay ? [0.48, 1.08] : [0.94, 1.08]);
+
+  useEffect(() => {
+    if (shouldReduceMotion) return undefined;
+
+    const increaseEnergy = (boost = 0.08) => {
+      setInteractionEnergy((value) => Math.min(1, value + boost));
+    };
+
+    const onPointerMove = () => increaseEnergy(0.02);
+    const onPointerDown = () => increaseEnergy(0.18);
+    const onWheel = () => increaseEnergy(0.12);
+    const onKeyDown = () => increaseEnergy(0.1);
+
+    window.addEventListener('pointermove', onPointerMove);
+    window.addEventListener('pointerdown', onPointerDown);
+    window.addEventListener('wheel', onWheel, { passive: true });
+    window.addEventListener('keydown', onKeyDown);
+
+    const decay = window.setInterval(() => {
+      setInteractionEnergy((value) => Math.max(0, value - 0.035));
+    }, 350);
+
+    return () => {
+      window.removeEventListener('pointermove', onPointerMove);
+      window.removeEventListener('pointerdown', onPointerDown);
+      window.removeEventListener('wheel', onWheel);
+      window.removeEventListener('keydown', onKeyDown);
+      window.clearInterval(decay);
+    };
+  }, [shouldReduceMotion]);
+
+
+  useGSAP(
+    ({ selector }) => {
+      if (shouldReduceMotion) return undefined;
+
+      const animations = [];
+      const randomBetween = (min, max) => min + Math.random() * (max - min);
+      const animate = (element, keyframes, options) => {
+        if (!element) return;
+        const animation = element.animate(keyframes, options);
+        animations.push(animation);
+      };
+
+      if (isDay) {
+        selector('.fx-sun-core').forEach((element) => {
+          animate(
+            element,
+            [{ transform: 'scale(1)' }, { transform: 'scale(1.07)' }, { transform: 'scale(1)' }],
+            { duration: 2400, easing: 'ease-in-out', iterations: Infinity }
+          );
+        });
+
+        selector('.fx-cloud').forEach((element, index) => {
+          animate(
+            element,
+            [{ transform: 'translateX(0px)' }, { transform: 'translateX(24px)' }, { transform: 'translateX(0px)' }],
+            { duration: 7000 + index * 500, easing: 'ease-in-out', iterations: Infinity }
+          );
+        });
+      } else {
+        selector('.fx-moon').forEach((element) => {
+          animate(
+            element,
+            [
+              { boxShadow: '0 0 34px rgba(196, 215, 255, 0.72)' },
+              { boxShadow: '0 0 42px rgba(229, 238, 255, 0.85)' },
+              { boxShadow: '0 0 34px rgba(196, 215, 255, 0.72)' },
+            ],
+            { duration: 2600, easing: 'ease-in-out', iterations: Infinity }
+          );
+        });
+
+        selector('.fx-star').forEach((element) => {
+          animate(
+            element,
+            [
+              { opacity: randomBetween(0.35, 0.8), transform: 'scale(0.9)' },
+              { opacity: 1, transform: 'scale(1.2)' },
+              { opacity: randomBetween(0.35, 0.9), transform: 'scale(0.85)' },
+            ],
+            { duration: randomBetween(1100, 2200), easing: 'ease-in-out', iterations: Infinity }
+          );
+        });
+
+        selector('.fx-plant-night').forEach((element) => {
+          animate(
+            element,
+            [
+              { transform: 'rotate(-4deg)' },
+              { transform: 'rotate(4deg)' },
+              { transform: 'rotate(-3deg)' },
+            ],
+            {
+              duration: randomBetween(1800, 2800),
+              easing: 'ease-in-out',
+              iterations: Infinity,
+            }
+          );
+        });
+      }
+
+      selector('.fx-rain-drop').forEach((element, index) => {
+        animate(
+          element,
+          [
+            { transform: 'translateY(-40%) rotate(14deg)', opacity: isDay ? 0.12 : 0.07 },
+            { transform: 'translateY(170%) rotate(14deg)', opacity: isDay ? 0.9 : 0.35 },
+          ],
+          {
+            duration: isDay ? 900 : 1400,
+            easing: 'linear',
+            iterations: Infinity,
+            delay: index * 30,
+          }
+        );
+      });
+
+      return () => {
+        animations.forEach((animation) => animation.cancel());
+      };
+    },
+    { dependencies: [isDay, shouldReduceMotion], scope }
+  );
+
+  const plants = useMemo(
+    () => Array.from({ length: TOTAL_PLANTS }, (_, index) => ({ id: `plant-${index}`, height: 32 + index * 8 })),
     []
   );
 
-  if (shouldReduceMotion) {
-    return null;
-  }
+  const raindrops = useMemo(() => Array.from({ length: TOTAL_RAINDROPS }, (_, index) => index), []);
+  const stars = useMemo(() => Array.from({ length: TOTAL_STARS }, (_, index) => index), []);
+
+  if (shouldReduceMotion) return null;
 
   return (
-    <>
-      <div className="hortelan-scroll-progress-track" aria-hidden="true">
-        <motion.div className="hortelan-scroll-progress-bar" style={{ scaleX: progressScale }} />
+    <motion.div ref={scope} className={`hortelan-fx-scene ${timeMode}`} style={{ '--sky-overlay': skyBlend }} aria-hidden="true">
+      <div className="fx-progress-track">
+        <motion.div className="fx-progress-value" style={{ scaleX: scrollScale }} />
       </div>
 
-      <motion.div className="hortelan-atmosphere-layer" style={{ opacity: overlayOpacity }} aria-hidden="true">
-        {ORBITERS.map((symbol, index) => (
-          <motion.span
-            key={symbol}
-            className="hortelan-orbiter"
-            style={{
-              left: '50%',
-              top: '18%',
-              fontSize: `${1.05 + index * 0.09}rem`,
-            }}
-            animate={{ rotate: 360 }}
-            transition={{
-              repeat: Infinity,
-              ease: 'linear',
-              duration: 10 + index * 2,
-              delay: index * 0.12,
-            }}
-          >
-            <span style={{ display: 'inline-block', transform: `translateX(${78 + index * 18}px)` }}>{symbol}</span>
-          </motion.span>
+      <div className="fx-sky-body">
+        {isDay ? (
+          <>
+            <div className="fx-sun-core" />
+            <div className="fx-cloud fx-cloud-a" />
+            <div className="fx-cloud fx-cloud-b" />
+          </>
+        ) : (
+          <>
+            <div className="fx-moon" />
+            {stars.map((star) => (
+              <span
+                key={`star-${star}`}
+                className="fx-star"
+                style={{ left: `${4 + ((star * 31) % 94)}%`, top: `${5 + ((star * 23) % 52)}%` }}
+              />
+            ))}
+          </>
+        )}
+      </div>
+
+      <motion.div className="fx-rain-layer" style={{ opacity: rainOpacity }}>
+        {raindrops.map((drop) => (
+          <span
+            key={`rain-${drop}`}
+            className="fx-rain-drop"
+            style={{ left: `${3 + ((drop * 17) % 96)}%`, animationDelay: `${(drop % 9) * 0.08}s` }}
+          />
         ))}
       </motion.div>
 
-      <div className="hortelan-heartbeat-layer" aria-hidden="true">
-        {heartPoints.map((point) => (
-          <motion.span
-            key={point.label}
-            className="hortelan-heartbeat-point"
-            role="img"
-            aria-label={point.label}
-            style={{ ...point.position, scale: heartbeatScale }}
-            animate={{ scale: [0.95, 1.18, 1] }}
-            transition={{ duration: 1.6, repeat: Infinity, ease: 'easeInOut', delay: point.delay }}
+      <div className="fx-soil" />
+
+      <div className="fx-plants-row">
+        {plants.map((plant, index) => (
+          <motion.div
+            key={plant.id}
+            className={`fx-plant ${!isDay ? 'fx-plant-night' : ''}`}
+            style={{
+              left: `${8 + index * 12}%`,
+              height: `${plant.height}px`,
+              scaleY: plantGrowth,
+              opacity: isDay ? undefined : 0.95,
+            }}
           >
-            ❤️
-          </motion.span>
+            <span className="stem" />
+            <span className="leaf leaf-left" />
+            <span className="leaf leaf-right" />
+          </motion.div>
         ))}
       </div>
 
       <style>
         {`
-          .hortelan-scroll-progress-track {
+          .hortelan-fx-scene {
+            position: fixed;
+            inset: 0;
+            pointer-events: none;
+            z-index: 1200;
+            overflow: hidden;
+          }
+
+          .fx-progress-track {
             position: fixed;
             top: 0;
             left: 0;
+            height: 4px;
             width: 100%;
-            height: 5px;
-            z-index: 1500;
-            pointer-events: none;
-            background: rgba(255, 255, 255, 0.2);
-            backdrop-filter: blur(8px);
+            background: rgba(255, 255, 255, 0.16);
           }
 
-          .hortelan-scroll-progress-bar {
+          .fx-progress-value {
+            width: 100%;
             height: 100%;
-            width: 100%;
-            transform-origin: 0% 50%;
-            background: linear-gradient(90deg, #7bc96f, #17b978, #12b0c9, #6f8cff);
-            box-shadow: 0 0 14px rgba(23, 185, 120, 0.75);
+            transform-origin: left center;
+            background: linear-gradient(90deg, #76d275, #12b0c9, #6f8cff);
           }
 
-          .hortelan-atmosphere-layer {
-            position: fixed;
-            inset: 0;
-            z-index: 1496;
-            pointer-events: none;
-            overflow: hidden;
-            background: radial-gradient(circle at 10% 20%, rgba(111, 140, 255, 0.2), transparent 42%),
-              radial-gradient(circle at 80% 30%, rgba(23, 185, 120, 0.2), transparent 40%),
-              radial-gradient(circle at 35% 75%, rgba(18, 176, 201, 0.18), transparent 46%);
-          }
-
-          .hortelan-orbiter {
+          .fx-sky-body {
             position: absolute;
-            filter: drop-shadow(0 2px 8px rgba(18, 176, 201, 0.4));
-            opacity: 0.85;
+            inset: 0 0 17% 0;
+            background: linear-gradient(180deg, ${isDay ? '#89ccff 0%, #e7f6ff 70%' : '#081636 0%, #1d2f63 70%'});
           }
 
-          .hortelan-heartbeat-layer {
-            position: fixed;
+          .fx-sky-body::after {
+            content: '';
+            position: absolute;
             inset: 0;
-            z-index: 1497;
-            pointer-events: none;
+            background: radial-gradient(circle at 50% 0%, rgba(255, 255, 255, var(--sky-overlay)), transparent 52%);
           }
 
-          .hortelan-heartbeat-point {
-            position: fixed;
-            font-size: clamp(1.1rem, 1.2vw, 1.35rem);
-            filter: drop-shadow(0 0 10px rgba(255, 53, 102, 0.4));
-            opacity: 0.95;
+          .fx-sun-core,
+          .fx-moon {
+            position: absolute;
+            border-radius: 50%;
+            top: 8%;
+            left: 12%;
+            width: clamp(90px, 10vw, 140px);
+            aspect-ratio: 1;
+          }
+
+          .fx-sun-core {
+            background: radial-gradient(circle at 40% 38%, #fffef0, #ffd35f 72%);
+            box-shadow: 0 0 70px rgba(255, 197, 79, 0.85);
+          }
+
+          .fx-moon {
+            left: auto;
+            right: 14%;
+            background: radial-gradient(circle at 35% 35%, #ffffff, #d4dded 74%);
+            box-shadow: 0 0 34px rgba(196, 215, 255, 0.72);
+          }
+
+          .fx-cloud {
+            position: absolute;
+            border-radius: 999px;
+            background: rgba(255, 255, 255, 0.72);
+            filter: blur(1px);
+          }
+
+          .fx-cloud-a {
+            top: 16%;
+            right: 20%;
+            width: 150px;
+            height: 50px;
+          }
+
+          .fx-cloud-b {
+            top: 27%;
+            right: 8%;
+            width: 120px;
+            height: 38px;
+            opacity: 0.84;
+          }
+
+          .fx-star {
+            position: absolute;
+            width: 4px;
+            height: 4px;
+            border-radius: 50%;
+            background: #f9fdff;
+            box-shadow: 0 0 8px rgba(244, 252, 255, 0.8);
+          }
+
+          .fx-rain-layer {
+            position: absolute;
+            inset: 14% 0 20% 0;
+          }
+
+          .fx-rain-drop {
+            position: absolute;
+            width: 2px;
+            height: 64px;
+            background: linear-gradient(to bottom, rgba(212, 245, 255, 0), rgba(139, 230, 255, 0.9));
+            transform: rotate(14deg);
+          }
+
+          .fx-soil {
+            position: absolute;
+            left: 0;
+            right: 0;
+            bottom: 0;
+            height: 22%;
+            background: linear-gradient(180deg, #61402b, #2b1a12);
+            box-shadow: inset 0 8px 24px rgba(0, 0, 0, 0.45);
+          }
+
+          .fx-plants-row {
+            position: absolute;
+            inset: auto 0 8% 0;
+            height: 26%;
+          }
+
+          .fx-plant {
+            position: absolute;
+            bottom: 0;
+            width: 18px;
+            transform-origin: center bottom;
+          }
+
+          .fx-plant .stem {
+            position: absolute;
+            bottom: 0;
+            left: 50%;
+            width: 4px;
+            height: 100%;
+            transform: translateX(-50%);
+            border-radius: 999px;
+            background: linear-gradient(180deg, #8fd469, #2f8c2d);
+          }
+
+          .fx-plant .leaf {
+            position: absolute;
+            width: 16px;
+            height: 9px;
+            background: linear-gradient(180deg, #98e27d, #4ea83f);
+            border-radius: 100% 10% 100% 10%;
+            top: 30%;
+          }
+
+          .fx-plant .leaf-left {
+            right: 8px;
+            transform: rotate(-28deg);
+          }
+
+          .fx-plant .leaf-right {
+            left: 8px;
+            transform: rotate(28deg) scaleX(-1);
+          }
+
+          .night .fx-soil {
+            background: linear-gradient(180deg, #3c2b22, #150d12);
           }
 
           @media (prefers-reduced-motion: reduce) {
-            .hortelan-scroll-progress-track,
-            .hortelan-atmosphere-layer,
-            .hortelan-heartbeat-layer {
+            .hortelan-fx-scene {
               display: none;
             }
           }
         `}
       </style>
-    </>
+    </motion.div>
   );
 }


### PR DESCRIPTION
### Motivation
- Criar uma cena ambiental interativa que mostre `sol` durante o dia e `lua` à noite, com chuva e plantas crescendo/oscileando conforme a interação do usuário.
- Fornecer animações sensíveis a preferências de movimento (`prefers-reduced-motion`) e integrá-las com o sistema de animação já usado no projeto (`useGSAP` / scoped DOM animations).

### Description
- Reescreve `src/components/fx/HortelanPlayfulEffects.js` para uma cena fixa que detecta `day`/`night` via hora local e renderiza elementos de céu, solo, chuva, nuvens, sol/lua, estrelas e uma fileira de plantas controláveis por animação.
- Adiciona um sistema de energia de interação que aumenta com `pointermove`, `pointerdown`, `wheel` e `keydown` e decai ao longo do tempo, expondo valores suavizados via `useSpring` para controlar `rainOpacity` e `plantGrowth`.
- Implementa orquestração de animações usando o hook `useGSAP` com Web Animations (scoped DOM `element.animate` loops) para pulso do sol, deriva de nuvens, brilho da lua, cintilação de estrelas, balanço noturno das plantas e ciclo contínuo de gotas de chuva, mantendo fallback quando `useReducedMotion` estiver ativo.
- Atualiza CSS inline dentro do componente para suportar ambos os modos (dia/noite), solo fértil e estilos das plantas; mantém `prefers-reduced-motion` para desativar por completo a cena quando solicitado.

### Testing
- `npm run lint -- src/components/fx/HortelanPlayfulEffects.js` — passou com sucesso.
- `npm run build` — build de produção completado com sucesso após ajustes (informações de chunk grandes foram exibidas como aviso, sem quebrar a build).
- Tentativa de captura visual via Playwright falhou devido a crash do Chromium no ambiente (`SIGSEGV`), portanto não há screenshot gerado aqui.
- Nota: foi tentativa inicial de instalar `gsap` mas o `npm install gsap` falhou por política/403 no ambiente; por isso as animações foram implementadas com a API de animação da Web (scoped) via `useGSAP` para evitar dependência extra.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699dc51b6bb8832ca67f77aed00ebff9)