### PR TITLE
feat: adicionar typing effect nos principais headers do dashboard

### DIFF
--- a/src/components/GSAPTypingText.js
+++ b/src/components/GSAPTypingText.js
@@ -1,0 +1,96 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+import PropTypes from 'prop-types';
+import { Box } from '@mui/material';
+import { motion } from '../lib/motionReact';
+
+export default function GSAPTypingText({
+  texts,
+  speed = 45,
+  eraseSpeed = 24,
+  holdDuration = 1500,
+  startDelay = 0,
+  className,
+  sx,
+}) {
+  const [displayedText, setDisplayedText] = useState('');
+  const [isDeleting, setIsDeleting] = useState(false);
+  const timeoutRef = useRef(null);
+  const normalizedTexts = useMemo(() => (texts?.length ? texts : ['']), [texts]);
+
+  useEffect(() => {
+    let textIndex = 0;
+    let charIndex = 0;
+    let deleting = false;
+
+    const loop = () => {
+      const word = normalizedTexts[textIndex] || '';
+
+      if (!deleting) {
+        charIndex += 1;
+        setDisplayedText(word.slice(0, charIndex));
+
+        if (charIndex >= word.length) {
+          deleting = true;
+          setIsDeleting(false);
+          timeoutRef.current = setTimeout(loop, holdDuration);
+          return;
+        }
+
+        setIsDeleting(false);
+        timeoutRef.current = setTimeout(loop, speed);
+        return;
+      }
+
+      charIndex -= 1;
+      setDisplayedText(word.slice(0, Math.max(charIndex, 0)));
+      setIsDeleting(true);
+
+      if (charIndex <= 0) {
+        deleting = false;
+        textIndex = (textIndex + 1) % normalizedTexts.length;
+      }
+
+      timeoutRef.current = setTimeout(loop, eraseSpeed);
+    };
+
+    timeoutRef.current = setTimeout(loop, startDelay);
+
+    return () => {
+      if (timeoutRef.current) clearTimeout(timeoutRef.current);
+    };
+  }, [eraseSpeed, holdDuration, normalizedTexts, speed, startDelay]);
+
+  return (
+    <Box className={className} sx={{ display: 'inline-flex', alignItems: 'center', ...sx }}>
+      <Box component="span" sx={{ whiteSpace: 'pre-wrap' }}>
+        {displayedText}
+      </Box>
+      <Box
+        component={motion.span}
+        aria-hidden
+        sx={{
+          ml: 0.4,
+          fontWeight: 700,
+          color: isDeleting ? 'warning.main' : 'primary.main',
+          animation: 'hortelan-caret-blink 0.8s step-end infinite',
+          '@keyframes hortelan-caret-blink': {
+            '0%, 45%': { opacity: 1 },
+            '50%, 100%': { opacity: 0 },
+          },
+        }}
+      >
+        |
+      </Box>
+    </Box>
+  );
+}
+
+GSAPTypingText.propTypes = {
+  className: PropTypes.string,
+  eraseSpeed: PropTypes.number,
+  holdDuration: PropTypes.number,
+  speed: PropTypes.number,
+  startDelay: PropTypes.number,
+  sx: PropTypes.object,
+  texts: PropTypes.arrayOf(PropTypes.string).isRequired,
+};

--- a/src/pages/HelpCenter.js
+++ b/src/pages/HelpCenter.js
@@ -30,6 +30,7 @@ import HistoryRoundedIcon from '@mui/icons-material/HistoryRounded';
 import SensorsRoundedIcon from '@mui/icons-material/SensorsRounded';
 import Page from '../components/Page';
 import HortelanPromoBanner from '../components/HortelanPromoBanner';
+import GSAPTypingText from '../components/GSAPTypingText';
 
 const faqItems = [
   {
@@ -101,10 +102,25 @@ export default function HelpCenter() {
         <Stack spacing={3}>
           <Box>
             <Typography variant="h4" gutterBottom>
-              Central de ajuda e suporte
+              <GSAPTypingText
+                texts={[
+                  'Central de ajuda e suporte',
+                  'Suporte técnico especializado para sua horta conectada',
+                  'Resolva incidentes com contexto de sensores e automações',
+                ]}
+              />
             </Typography>
             <Typography color="text.secondary">
-              Consulte conteúdos de autoatendimento, abra chamados e acompanhe tickets com contexto técnico da sua horta.
+              <GSAPTypingText
+                texts={[
+                  'Consulte conteúdos de autoatendimento, abra chamados e acompanhe tickets com contexto técnico.',
+                  'Tenha acesso rápido a FAQ, histórico de tickets e suporte contextual em um só lugar.',
+                ]}
+                speed={28}
+                eraseSpeed={17}
+                holdDuration={1100}
+                startDelay={200}
+              />
             </Typography>
           </Box>
 

--- a/src/pages/Hortelan360.js
+++ b/src/pages/Hortelan360.js
@@ -20,6 +20,7 @@ import {
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import Page from '../components/Page';
 import { gamificationBlueprint, hortelanModules, releaseRoadmap, wowFeatures } from '../data/hortelanBlueprint';
+import GSAPTypingText from '../components/GSAPTypingText';
 
 export default function Hortelan360() {
   const [query, setQuery] = useState('');
@@ -37,9 +38,26 @@ export default function Hortelan360() {
     <Page title="Hortelan Agtech Ltda 360">
       <Container maxWidth="xl">
         <Stack spacing={3} sx={{ mb: 4 }}>
-          <Typography variant="h4">Hortelan Agtech Ltda — Blueprint completo da plataforma</Typography>
+          <Typography variant="h4">
+            <GSAPTypingText
+              texts={[
+                'Hortelan Agtech Ltda — Blueprint completo da plataforma',
+                'Arquitetura 360 para evolução contínua do produto',
+                'Planejamento estratégico com foco em entregas por releases',
+              ]}
+            />
+          </Typography>
           <Typography color="text.secondary">
-            Esta tela consolida as 30 frentes de produto solicitadas em uma arquitetura de entrega por releases.
+            <GSAPTypingText
+              texts={[
+                'Esta tela consolida 30 frentes de produto em uma arquitetura de entrega por releases.',
+                'Navegue por módulos, roadmap e funcionalidades WOW com visão executiva e operacional.',
+              ]}
+              speed={30}
+              eraseSpeed={18}
+              holdDuration={1100}
+              startDelay={200}
+            />
           </Typography>
           <Alert severity="success">Cobertura funcional: 30 módulos estratégicos + roteiro de releases + diferenciais WOW.</Alert>
         </Stack>

--- a/src/pages/Products.js
+++ b/src/pages/Products.js
@@ -32,6 +32,7 @@ import HortelanPromoBanner from '../components/HortelanPromoBanner';
 import useGSAP from '../hooks/useGSAP';
 import productCatalog, { categories } from '../data/productCatalog';
 import { motion, useScroll, useTransform } from '../lib/motionReact';
+import GSAPTypingText from '../components/GSAPTypingText';
 
 const sortMap = {
   preco: (a, b) => a.preco - b.preco,
@@ -170,10 +171,25 @@ export default function ProductsMarketplace() {
       <Container ref={rootRef}>
         <Stack spacing={1} sx={{ mb: 3 }}>
           <Typography className="gsap-hero-title" variant="h4">
-            Catálogo de produtos Hortelan Agtech Ltda
+            <GSAPTypingText
+              texts={[
+                'Catálogo de produtos Hortelan Agtech Ltda',
+                'Marketplace inteligente para sua operação agrícola',
+                'Compre insumos e automação com curadoria Hortelan',
+              ]}
+            />
           </Typography>
           <Typography className="gsap-hero-subtitle" color="text.secondary">
-            Explore sementes, substratos, fertilizantes, sensores, kits, irrigação e ferramentas com filtros avançados.
+            <GSAPTypingText
+              texts={[
+                'Explore sementes, substratos, fertilizantes e sensores com filtros avançados.',
+                'Descubra kits de irrigação e ferramentas validadas para estufa, indoor e hidroponia.',
+              ]}
+              speed={30}
+              eraseSpeed={18}
+              holdDuration={1200}
+              startDelay={200}
+            />
           </Typography>
         </Stack>
 


### PR DESCRIPTION
### Motivation
- Destacar títulos e subtítulos principais com um efeito de digitação (typing effect) para aumentar a percepção de produto e guiar a atenção do usuário nas páginas estratégicas do dashboard.

### Description
- Adicionado componente reutilizável `GSAPTypingText` em `src/components/GSAPTypingText.js` que implementa ciclo de digitar → pausar → apagar, cursor piscante e parâmetros configuráveis (`speed`, `eraseSpeed`, `holdDuration`, `startDelay`).
- Apliquei o componente nos cabeçalhos e subtítulos das páginas de destaque: `src/pages/Products.js`, `src/pages/HelpCenter.js` e `src/pages/Hortelan360.js` preservando as animações de entrada já existentes.
- Implementação local usa timeouts e estado React para evitar dependência externa (tentativa de instalar `gsap` falhou no ambiente), então o componente funciona sem alteração da árvore de dependências do projeto.
- Atualizei pequenas chamadas de props para valores de timing apropriados nas páginas onde o efeito foi aplicado.

### Testing
- Executado `npm run lint` e o lint passou com sucesso.
- Executado `npm run build` e a build de produção foi concluída com sucesso.
- Tentativa de instalar `gsap` com `npm install gsap@^3.12.5` retornou erro `403` no registro e por isso a versão final do componente não depende da lib; Playwright/screenshots falharam por crash do browser no ambiente (SIGSEGV) durante a captura, portanto não há screenshots automatizados anexados.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699dca464054832ca5ab414749d08806)