### PR TITLE
Garante splash screen antes do carregamento do site

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -12,15 +12,20 @@ import useAuth from './auth/useAuth';
 import CookieConsentBanner from './components/privacy/CookieConsentBanner';
 import HortelanPlayfulEffects from './components/fx/HortelanPlayfulEffects';
 import HarvestSplashScreen from './components/fx/HarvestSplashScreen';
+import { useState } from 'react';
 
 function AppContent() {
   const { consents } = useAuth();
+  const [splashFinished, setSplashFinished] = useState(false);
+
+  if (!splashFinished) {
+    return <HarvestSplashScreen onComplete={() => setSplashFinished(true)} />;
+  }
 
   return (
     <>
       <ScrollToTop />
       <BaseOptionChartStyle />
-      <HarvestSplashScreen />
       <HortelanPlayfulEffects />
       <Router />
       <CookieConsentBanner />

--- a/src/components/fx/HarvestSplashScreen.js
+++ b/src/components/fx/HarvestSplashScreen.js
@@ -2,7 +2,7 @@ import { useMemo, useRef, useState } from 'react';
 import { motion, useReducedMotion } from '../../lib/motionReact';
 import useGSAP from '../../hooks/useGSAP';
 
-export default function HarvestSplashScreen() {
+export default function HarvestSplashScreen({ onComplete }) {
   const rootRef = useRef(null);
   const shouldReduceMotion = useReducedMotion();
   const [hidden, setHidden] = useState(false);
@@ -101,6 +101,14 @@ export default function HarvestSplashScreen() {
     { dependencies: [hidden, shouldReduceMotion], scope: rootRef }
   );
 
+  useGSAP(
+    () => {
+      if (!hidden) return;
+      onComplete?.();
+    },
+    { dependencies: [hidden, onComplete] }
+  );
+
   if (hidden) return null;
 
   return (
@@ -130,7 +138,7 @@ export default function HarvestSplashScreen() {
             position: fixed;
             inset: 0;
             z-index: 2000;
-            pointer-events: none;
+            pointer-events: all;
           }
 
           .harvest-splash-overlay {


### PR DESCRIPTION
### Motivation
- Garantir que o usuário veja a tela splash antes de acessar o restante do site, bloqueando interação até a animação terminar.

### Description
- Altera `App` para renderizar apenas a `HarvestSplashScreen` no primeiro acesso usando `useState` e o callback `onComplete` para liberar o restante da aplicação.
- Adiciona `onComplete` à `HarvestSplashScreen` e dispara esse callback quando a splash termina (`hidden = true`).
- Ajusta a splash para bloquear interação durante a exibição alterando `pointer-events` para `all` e adiciona um pequeno efeito de sincronização via `useGSAP`.

### Testing
- Executado `npm run lint` e a checagem do `eslint` concluiu com sucesso.
- Iniciado o servidor de desenvolvimento com `npm run dev -- --host 0.0.0.0 --port 4173` e a aplicação mostrou a splash corretamente (validação visual manual).
- Captura de tela automatizada via Playwright foi executada para verificar o primeiro carregamento da splash e concluiu com sucesso.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699def825dd0832ca8cc66e79e6c0e5d)