### PR TITLE
feat: intensify motion and gsap-like animations across Hortelan 360

### DIFF
--- a/src/hooks/useGSAP.js
+++ b/src/hooks/useGSAP.js
@@ -1,10 +1,72 @@
 import { useLayoutEffect } from 'react';
 
+function toDurationMs(seconds) {
+  if (typeof seconds !== 'number') return 700;
+  return seconds * 1000;
+}
+
+function buildKeyframes(fromVars = {}, toVars = {}) {
+  const from = {};
+  const to = {};
+
+  const applyFrame = (target, vars) => {
+    Object.entries(vars).forEach(([key, value]) => {
+      if (['duration', 'repeat', 'yoyo', 'ease', 'stagger', 'delay'].includes(key)) return;
+      if (key === 'x') {
+        target.transform = `${target.transform || ''} translateX(${typeof value === 'number' ? `${value}px` : value})`.trim();
+      } else if (key === 'y') {
+        target.transform = `${target.transform || ''} translateY(${typeof value === 'number' ? `${value}px` : value})`.trim();
+      } else if (key === 'scale') {
+        target.transform = `${target.transform || ''} scale(${value})`.trim();
+      } else {
+        target[key] = value;
+      }
+    });
+  };
+
+  applyFrame(from, fromVars);
+  applyFrame(to, toVars);
+  return [from, to];
+}
+
 export default function useGSAP(callback, options = {}) {
   const { dependencies = [], scope } = options;
 
   useLayoutEffect(() => {
+    const animations = [];
+
+    const animateElement = (element, fromVars, toVars, withFrom) => {
+      if (!element || typeof element.animate !== 'function') return;
+      const [fromFrame, toFrame] = withFrom ? buildKeyframes(fromVars, toVars) : buildKeyframes({}, fromVars);
+      const vars = withFrom ? toVars : fromVars;
+      const animation = element.animate([fromFrame, toFrame], {
+        duration: toDurationMs(vars.duration),
+        iterations: vars.repeat === -1 ? Infinity : 1,
+        direction: vars.yoyo ? 'alternate' : 'normal',
+        easing: vars.ease || 'ease-out',
+        fill: 'forwards',
+        delay: typeof vars.delay === 'number' ? vars.delay * 1000 : 0,
+      });
+      animations.push(animation);
+    };
+
+    const miniGsap = {
+      to(targets, vars) {
+        const list = Array.isArray(targets) ? targets : [targets];
+        list.forEach((item, index) => {
+          animateElement(item, { ...vars, delay: (vars.stagger || 0) * index + (vars.delay || 0) }, null, false);
+        });
+      },
+      fromTo(targets, fromVars, toVars) {
+        const list = Array.isArray(targets) ? targets : [targets];
+        list.forEach((item, index) => {
+          animateElement(item, fromVars, { ...toVars, delay: (toVars.stagger || 0) * index + (toVars.delay || 0) }, true);
+        });
+      },
+    };
+
     const ctx = {
+      gsap: miniGsap,
       selector: (selector) => {
         if (!scope?.current) return [];
         return Array.from(scope.current.querySelectorAll(selector));
@@ -13,7 +75,9 @@ export default function useGSAP(callback, options = {}) {
     };
 
     const cleanup = callback(ctx);
+
     return () => {
+      animations.forEach((animation) => animation.cancel());
       if (typeof cleanup === 'function') cleanup();
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/src/pages/Hortelan360.js
+++ b/src/pages/Hortelan360.js
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react';
+import { useMemo, useRef, useState } from 'react';
 import {
   Accordion,
   AccordionDetails,
@@ -18,12 +18,18 @@ import {
   Typography,
 } from '@mui/material';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
+import { motion } from '../lib/motionReact';
+import useGSAP from '../hooks/useGSAP';
 import Page from '../components/Page';
 import { gamificationBlueprint, hortelanModules, releaseRoadmap, wowFeatures } from '../data/hortelanBlueprint';
 import GSAPTypingText from '../components/GSAPTypingText';
 
+const MotionCard = motion(Card);
+const MotionAccordion = motion(Accordion);
+
 export default function Hortelan360() {
   const [query, setQuery] = useState('');
+  const sceneRef = useRef(null);
 
   const filteredModules = useMemo(
     () =>
@@ -34,38 +40,126 @@ export default function Hortelan360() {
     [query]
   );
 
+
+  useGSAP(
+    ({ gsap, selector }) => {
+      const floating = selector('.floating-orb');
+      floating.forEach((item, index) => {
+        gsap.to(item, {
+          y: index % 2 === 0 ? -20 : 24,
+          x: index % 2 === 0 ? 18 : -16,
+          duration: 4 + index,
+          repeat: -1,
+          yoyo: true,
+          ease: 'sine.inOut',
+        });
+      });
+
+      gsap.fromTo(
+        selector('.wow-chip'),
+        { scale: 0.95, opacity: 0.7 },
+        {
+          scale: 1.04,
+          opacity: 1,
+          repeat: -1,
+          yoyo: true,
+          ease: 'sine.inOut',
+          duration: 1.6,
+          stagger: 0.08,
+        }
+      );
+
+      gsap.fromTo(
+        selector('.release-card'),
+        { y: 24, opacity: 0 },
+        {
+          y: 0,
+          opacity: 1,
+          duration: 0.8,
+          stagger: 0.09,
+          ease: 'power3.out',
+        }
+      );
+
+      gsap.fromTo(
+        selector('.module-accordion'),
+        { y: 18, opacity: 0 },
+        {
+          y: 0,
+          opacity: 1,
+          duration: 0.6,
+          stagger: 0.03,
+          ease: 'power2.out',
+        }
+      );
+    },
+    { dependencies: [filteredModules.length], scope: sceneRef }
+  );
+
   return (
     <Page title="Hortelan Agtech Ltda 360">
-      <Container maxWidth="xl">
-        <Stack spacing={3} sx={{ mb: 4 }}>
-          <Typography variant="h4">
-            <GSAPTypingText
-              texts={[
-                'Hortelan Agtech Ltda — Blueprint completo da plataforma',
-                'Arquitetura 360 para evolução contínua do produto',
-                'Planejamento estratégico com foco em entregas por releases',
-              ]}
-            />
-          </Typography>
-          <Typography color="text.secondary">
-            <GSAPTypingText
-              texts={[
-                'Esta tela consolida 30 frentes de produto em uma arquitetura de entrega por releases.',
-                'Navegue por módulos, roadmap e funcionalidades WOW com visão executiva e operacional.',
-              ]}
-              speed={30}
-              eraseSpeed={18}
-              holdDuration={1100}
-              startDelay={200}
-            />
-          </Typography>
-          <Alert severity="success">Cobertura funcional: 30 módulos estratégicos + roteiro de releases + diferenciais WOW.</Alert>
+      <Container maxWidth="xl" ref={sceneRef} sx={{ position: 'relative', overflow: 'hidden', pb: 3 }}>
+        {[1, 2, 3].map((orb) => (
+          <Box
+            key={orb}
+            className="floating-orb"
+            sx={{
+              position: 'absolute',
+              width: 180 + orb * 60,
+              height: 180 + orb * 60,
+              borderRadius: '50%',
+              filter: 'blur(48px)',
+              opacity: 0.24,
+              top: `${8 + orb * 14}%`,
+              left: orb % 2 === 0 ? '75%' : '-6%',
+              zIndex: 0,
+              background: orb % 2 === 0 ? 'primary.main' : 'success.main',
+            }}
+          />
+        ))}
+
+        <Stack spacing={3} sx={{ mb: 4, position: 'relative', zIndex: 2 }}>
+          <motion.div initial={{ opacity: 0, y: 26 }} animate={{ opacity: 1, y: 0 }} transition={{ duration: 0.8 }}>
+            <Typography variant="h4">
+              <GSAPTypingText
+                texts={[
+                  'Hortelan Agtech Ltda — Blueprint completo da plataforma',
+                  'Arquitetura 360 para evolução contínua do produto',
+                  'Planejamento estratégico com foco em entregas por releases',
+                ]}
+              />
+            </Typography>
+          </motion.div>
+
+          <motion.div initial={{ opacity: 0, y: 24 }} animate={{ opacity: 1, y: 0 }} transition={{ duration: 0.9, delay: 0.15 }}>
+            <Typography color="text.secondary">
+              <GSAPTypingText
+                texts={[
+                  'Esta tela consolida 30 frentes de produto em uma arquitetura de entrega por releases.',
+                  'Navegue por módulos, roadmap e funcionalidades WOW com visão executiva e operacional.',
+                ]}
+                speed={30}
+                eraseSpeed={18}
+                holdDuration={1100}
+                startDelay={200}
+              />
+            </Typography>
+          </motion.div>
+
+          <motion.div initial={{ opacity: 0, scale: 0.96 }} animate={{ opacity: 1, scale: 1 }} transition={{ duration: 0.5, delay: 0.25 }}>
+            <Alert severity="success">Cobertura funcional: 30 módulos estratégicos + roteiro de releases + diferenciais WOW.</Alert>
+          </motion.div>
         </Stack>
 
-        <Grid container spacing={3} sx={{ mb: 2 }}>
+        <Grid container spacing={3} sx={{ mb: 2, position: 'relative', zIndex: 2 }}>
           {releaseRoadmap.map((release) => (
             <Grid item xs={12} md={6} lg={3} key={release.name}>
-              <Card>
+              <MotionCard
+                className="release-card"
+                whileHover={{ y: -10, rotateX: 2.5, rotateY: -1.5 }}
+                transition={{ type: 'spring', stiffness: 180, damping: 18 }}
+                sx={{ height: '100%', backdropFilter: 'blur(8px)' }}
+              >
                 <CardContent>
                   <Typography variant="h6" gutterBottom>
                     {release.name}
@@ -81,33 +175,52 @@ export default function Hortelan360() {
                     ))}
                   </List>
                 </CardContent>
-              </Card>
+              </MotionCard>
             </Grid>
           ))}
         </Grid>
 
-        <Card sx={{ mb: 3 }}>
+        <MotionCard
+          sx={{ mb: 3, position: 'relative', zIndex: 2 }}
+          initial={{ opacity: 0, y: 24 }}
+          whileInView={{ opacity: 1, y: 0 }}
+          viewport={{ once: true, amount: 0.2 }}
+          transition={{ duration: 0.7 }}
+        >
           <CardContent>
             <Typography variant="h6" sx={{ mb: 2 }}>
               Funcionalidades WOW para diferenciação
             </Typography>
             <Stack direction="row" flexWrap="wrap" gap={1}>
               {wowFeatures.map((feature) => (
-                <Chip key={feature} label={feature} color="primary" variant="outlined" />
+                <Chip key={feature} className="wow-chip" label={feature} color="primary" variant="outlined" />
               ))}
             </Stack>
           </CardContent>
-        </Card>
+        </MotionCard>
 
-        <Card sx={{ mb: 3 }}>
+        <MotionCard
+          sx={{ mb: 3, position: 'relative', zIndex: 2 }}
+          initial={{ opacity: 0, y: 24 }}
+          whileInView={{ opacity: 1, y: 0 }}
+          viewport={{ once: true, amount: 0.2 }}
+          transition={{ duration: 0.7 }}
+        >
           <CardContent>
             <Typography variant="h6" sx={{ mb: 2 }}>
               Programa de gamificação (detalhado)
             </Typography>
             <Grid container spacing={2}>
-              {gamificationBlueprint.map((pillar) => (
+              {gamificationBlueprint.map((pillar, index) => (
                 <Grid item xs={12} md={6} key={pillar.id}>
-                  <Card variant="outlined" sx={{ height: '100%' }}>
+                  <MotionCard
+                    variant="outlined"
+                    sx={{ height: '100%' }}
+                    initial={{ opacity: 0, x: index % 2 === 0 ? -16 : 16 }}
+                    whileInView={{ opacity: 1, x: 0 }}
+                    viewport={{ once: true, amount: 0.3 }}
+                    transition={{ duration: 0.55, delay: index * 0.06 }}
+                  >
                     <CardContent>
                       <Typography variant="subtitle1" sx={{ mb: 1 }}>
                         {pillar.id} {pillar.title}
@@ -120,24 +233,32 @@ export default function Hortelan360() {
                         ))}
                       </List>
                     </CardContent>
-                  </Card>
+                  </MotionCard>
                 </Grid>
               ))}
             </Grid>
           </CardContent>
-        </Card>
+        </MotionCard>
 
         <TextField
           fullWidth
           placeholder="Buscar módulo, tag ou funcionalidade..."
           value={query}
           onChange={(event) => setQuery(event.target.value)}
-          sx={{ mb: 3 }}
+          sx={{ mb: 3, position: 'relative', zIndex: 2 }}
         />
 
-        <Box>
-          {filteredModules.map((module) => (
-            <Accordion key={module.id} defaultExpanded={module.id <= 3}>
+        <Box sx={{ position: 'relative', zIndex: 2 }}>
+          {filteredModules.map((module, index) => (
+            <MotionAccordion
+              className="module-accordion"
+              key={module.id}
+              defaultExpanded={module.id <= 3}
+              initial={{ opacity: 0, y: 10 }}
+              whileInView={{ opacity: 1, y: 0 }}
+              viewport={{ once: true, amount: 0.3 }}
+              transition={{ duration: 0.35, delay: index * 0.015 }}
+            >
               <AccordionSummary expandIcon={<ExpandMoreIcon />}>
                 <Stack direction="row" spacing={1.5} alignItems="center" sx={{ flexWrap: 'wrap' }}>
                   <Typography variant="subtitle1">
@@ -157,7 +278,7 @@ export default function Hortelan360() {
                   ))}
                 </List>
               </AccordionDetails>
-            </Accordion>
+            </MotionAccordion>
           ))}
         </Box>
       </Container>


### PR DESCRIPTION
### Motivation
- Make the Hortelan 360 page much more immersive using heavy motion + GSAP-style effects across the UI. 
- Provide a robust motion layer and a GSAP-like hook so components can use `initial`, `animate`, `whileHover`, `whileInView`, transitions, transforms and timeline-style calls without forcing new external dependencies. 
- Avoid blocking the work when `framer-motion`/`gsap` installs fail by shipping lightweight internal implementations that emulate the required behaviors. 

### Description
- Reworked the internal motion API in `src/lib/motionReact.js` to support `initial`, `animate`, `whileHover`, `whileInView`, `viewport` triggers, transform props (`x`, `y`, `scale`, `rotate`, etc.) and transition timing with an IntersectionObserver-based in-view trigger. 
- Implemented a GSAP-like mini API in `src/hooks/useGSAP.js` that exposes `gsap.to` and `gsap.fromTo` backed by the Web Animations API and supporting `repeat`, `yoyo`, `stagger`, `delay`, `ease`, and automatic cleanup. 
- Upgraded `src/pages/Hortelan360.js` to use the new motion primitives and GSAP hook to add floating atmosphere orbs, animated release cards with 3D hover, pulsing WOW chips, staggered module reveals, motion-driven section transitions, and refined layout/styling for a cinematic experience. 
- Kept changes self-contained so existing components can progressively adopt richer motion without adding `framer-motion` or `gsap` as hard dependencies. 

### Testing
- Ran linter with `npm run lint` and it completed successfully. 
- Built a production bundle with `npm run build` and the build finished successfully. 
- Started the dev server with `npm run dev -- --host 0.0.0.0 --port 4173` and the server came up (Vite ready). 
- Performed an automated visual validation via Playwright that logged in and captured a screenshot of `/dashboard/hortelan-360`, and the run completed successfully (artifact saved).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699df278b0f0832c8befb7e34fc5d328)