### PR TITLE
Adiciona links de redes sociais da Hortelan em áreas de suporte

### DIFF
--- a/src/layouts/dashboard/DashboardSidebar.js
+++ b/src/layouts/dashboard/DashboardSidebar.js
@@ -16,6 +16,12 @@ import useAuth from '../../auth/useAuth';
 
 // ----------------------------------------------------------------------
 
+const HORTELAN_SOCIAL_LINKS = [
+  { label: 'Instagram', href: 'https://www.instagram.com/hortelan_agtech/' },
+  { label: 'YouTube', href: 'https://www.youtube.com/@HortelanAgTechLtda' },
+  { label: 'E-mail', href: 'mailto:hortelanagtechltda@gmail.com' },
+];
+
 const DRAWER_WIDTH = 280;
 
 const RootStyle = styled('div')(({ theme }) => ({
@@ -95,16 +101,20 @@ export default function DashboardSidebar({ isOpenSidebar, onCloseSidebar }) {
 
           <Box sx={{ textAlign: 'center' }}>
             <Typography gutterBottom variant="h6">
-              Have some Questions or Problems?
+              Precisa de ajuda com a sua operação?
             </Typography>
             <Typography variant="body2" sx={{ color: 'text.secondary' }}>
-              Ask your questions here through our chatbot, we recommend documentation or support requests
+              Fale com o time Hortelan Agtech por nossos canais oficiais.
             </Typography>
           </Box>
 
-          <Button href="https://www.davidalexandrefernandes.com.br" target="_blank" variant="contained">
-            Contact us
-          </Button>
+          <Stack spacing={1.25} sx={{ width: 1 }}>
+            {HORTELAN_SOCIAL_LINKS.map((social) => (
+              <Button key={social.label} href={social.href} target="_blank" rel="noopener noreferrer" variant="contained" fullWidth>
+                {social.label}
+              </Button>
+            ))}
+          </Stack>
         </Stack>
       </Box>
     </Scrollbar>

--- a/src/pages/HelpCenter.js
+++ b/src/pages/HelpCenter.js
@@ -12,6 +12,7 @@ import {
   FormControlLabel,
   Grid,
   InputLabel,
+  Link,
   List,
   ListItem,
   ListItemText,
@@ -28,6 +29,9 @@ import HelpOutlineRoundedIcon from '@mui/icons-material/HelpOutlineRounded';
 import SupportAgentRoundedIcon from '@mui/icons-material/SupportAgentRounded';
 import HistoryRoundedIcon from '@mui/icons-material/HistoryRounded';
 import SensorsRoundedIcon from '@mui/icons-material/SensorsRounded';
+import InstagramIcon from '@mui/icons-material/Instagram';
+import YouTubeIcon from '@mui/icons-material/YouTube';
+import EmailRoundedIcon from '@mui/icons-material/EmailRounded';
 import Page from '../components/Page';
 import HortelanPromoBanner from '../components/HortelanPromoBanner';
 import GSAPTypingText from '../components/GSAPTypingText';
@@ -87,6 +91,27 @@ const statusColor = {
 const priorities = ['Baixa', 'Média', 'Alta', 'Crítica'];
 const categories = ['Conectividade', 'Automação', 'App/Web', 'Conta e acesso', 'Cobrança'];
 
+const socialChannels = [
+  {
+    label: 'Instagram',
+    href: 'https://www.instagram.com/hortelan_agtech/',
+    helper: '@hortelan_agtech',
+    icon: <InstagramIcon fontSize="small" />,
+  },
+  {
+    label: 'YouTube',
+    href: 'https://www.youtube.com/@HortelanAgTechLtda',
+    helper: '@HortelanAgTechLtda',
+    icon: <YouTubeIcon fontSize="small" />,
+  },
+  {
+    label: 'E-mail',
+    href: 'mailto:hortelanagtechltda@gmail.com',
+    helper: 'hortelanagtechltda@gmail.com',
+    icon: <EmailRoundedIcon fontSize="small" />,
+  },
+];
+
 export default function HelpCenter() {
   const [tab, setTab] = useState('central-ajuda');
   const [category, setCategory] = useState(categories[0]);
@@ -125,6 +150,32 @@ export default function HelpCenter() {
           </Box>
 
           <HortelanPromoBanner />
+
+          <Card>
+            <CardContent>
+              <Stack spacing={1.5}>
+                <Typography variant="h6">Canais oficiais Hortelan Agtech</Typography>
+                <Typography variant="body2" color="text.secondary">
+                  Para conteúdos técnicos, novidades e suporte comercial, acompanhe e fale com a Hortelan pelos canais abaixo.
+                </Typography>
+                <Stack direction={{ xs: 'column', sm: 'row' }} spacing={1.5} useFlexGap flexWrap="wrap">
+                  {socialChannels.map((channel) => (
+                    <Button
+                      key={channel.label}
+                      component={Link}
+                      href={channel.href}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      startIcon={channel.icon}
+                      variant="outlined"
+                    >
+                      {channel.label}: {channel.helper}
+                    </Button>
+                  ))}
+                </Stack>
+              </Stack>
+            </CardContent>
+          </Card>
 
           <Card>
             <CardContent>


### PR DESCRIPTION
### Motivation
- Tornar os canais oficiais da Hortelan Agtech (Instagram, YouTube e e-mail) facilmente acessíveis a usuários que buscam suporte ou informações.
- Promover contato direto a partir de áreas de suporte da aplicação para reduzir atrito no atendimento.
- Inserir essas referências em locais estratégicos já voltados a dúvidas e abertura de chamados.

### Description
- Adiciona `HORTELAN_SOCIAL_LINKS` em `src/layouts/dashboard/DashboardSidebar.js` e substitui o botão de contato por botões individuais linkados para Instagram, YouTube e e-mail, além de atualizar o texto do card para português.
- Introduz `socialChannels` em `src/pages/HelpCenter.js`, importa ícones (`InstagramIcon`, `YouTubeIcon`, `EmailRoundedIcon`) e adiciona um novo `Card` que exibe botões linkados com rótulos e helpers para cada canal.
- Usa componentes MUI (`Button`, `Link`, `Stack`, `Typography`) para manter aparência consistente e garante atributos de segurança `target="_blank" rel="noopener noreferrer"` nas ancoragens.

### Testing
- Executado `npm run lint` e o lint passou sem erros.
- Subida da aplicação com `npm run dev` (Vite) para validação visual e o servidor iniciou corretamente (Vite ready).
- Validação visual automatizada via Playwright que fez login e navegou até `/dashboard/help-center`, gerando a captura `artifacts/help-center-social-links.png` com os novos links visíveis.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_699e5311041c8328b4d98a9b9575f104)