### PR TITLE
feat: nova splash de colheita (canvas) como overlay

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -18,10 +18,6 @@ function AppContent() {
   const { consents } = useAuth();
   const [splashFinished, setSplashFinished] = useState(false);
 
-  if (!splashFinished) {
-    return <HarvestSplashScreen onComplete={() => setSplashFinished(true)} />;
-  }
-
   return (
     <>
       <ScrollToTop />
@@ -30,6 +26,7 @@ function AppContent() {
       <Router />
       <CookieConsentBanner />
       {consents?.analytics && <Analytics />}
+      {!splashFinished && <HarvestSplashScreen onComplete={() => setSplashFinished(true)} />}
     </>
   );
 }


### PR DESCRIPTION
### Motivation
- Substituir a splash atual por uma versão visualmente rica que mostre o campo, plantas, colheitadeira e poeira com uma revelação sincronizada da interface.
- Evitar dependências externas no ambiente (Pixi / framer-motion) quando não disponíveis, mantendo comportamento e desempenho aceitáveis.

### Description
- Reescreve `src/components/fx/HarvestSplashScreen.js` para uma implementação procedural em `<canvas>` baseada em `requestAnimationFrame`, com geração de plantas, parallax, pista colhida e animação da máquina, e invocação de `onComplete` ao terminar a timeline.
- Altera `src/App.js` para sempre renderizar o app por baixo e exibir a splash como camada sobreposta até a conclusão (`!splashFinished && <HarvestSplashScreen .../>`).
- Mantém o efeito de revelação horizontal sincronizado com o progresso usando `clipPath` calculado a partir do progresso da animação.
- Adaptações feitas porque a instalação das bibliotecas originais falhou no ambiente, então a solução usa apenas APIs nativas do browser (canvas, RAF).

### Testing
- Executado `npm run build` com sucesso (build produzido sem erros).
- Executado `npm run dev` e servidor local iniciado com sucesso (Vite disponível e acessível durante validação).
- Tentativas de instalar `framer-motion` / `pixi.js` / `@pixi/particle-emitter` falharam com erro `403` no registry do ambiente, então a implementação foi ajustada (instalação não sucedida).
- Captura automatizada de tela (Playwright) foi gerada durante a validação inicial e está disponível como artefato; segunda tentativa encontrou crash do Chromium no ambiente.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_699e6feecc94832897c62a6b2edba694)