### PR TITLE
Atualiza credenciais de acesso de demonstração mockado

### DIFF
--- a/src/auth/session.js
+++ b/src/auth/session.js
@@ -68,8 +68,8 @@ const normalizeGardenAccessControl = (accessControl = {}) => ({
 const USERS = [
   {
     id: 'admin-1',
-    email: 'admin@hortelan.com',
-    password: 'admin123',
+    email: 'davidfernandes@hortelanagtech.com',
+    password: 'admin',
     name: 'Administrador Hortelan',
     role: 'administrator',
     photoURL: '',
@@ -221,7 +221,7 @@ const INITIAL_PASSWORD_HISTORY = [
   {
     id: `pwd-history-${Date.now()}`,
     userId: 'admin-1',
-    userEmail: 'admin@hortelan.com',
+    userEmail: 'davidfernandes@hortelanagtech.com',
     changedAt: new Date().toISOString(),
     method: 'seed',
     changedBy: 'system',
@@ -679,8 +679,8 @@ export const loginWithEmailAndPassword = ({
 
 export const loginWithSocialProvider = ({ provider, remember, trustDevice, deviceName }) => {
   const providerMap = {
-    google: 'admin@hortelan.com',
-    apple: 'admin@hortelan.com',
+    google: 'davidfernandes@hortelanagtech.com',
+    apple: 'davidfernandes@hortelanagtech.com',
   };
 
   const email = providerMap[provider];

--- a/src/pages/Login.js
+++ b/src/pages/Login.js
@@ -175,7 +175,7 @@ export default function Login() {
 
             <Typography sx={{ color: 'text.secondary', mb: 1 }}>Use seu e-mail e senha para continuar.</Typography>
             <Typography sx={{ color: 'text.secondary', mb: 5 }}>
-              Acesso de demonstração: <strong>admin@hortelan.com</strong> / <strong>admin123</strong>.
+              Acesso de demonstração: <strong>davidfernandes@hortelanagtech.com</strong> / <strong>admin</strong>.
             </Typography>
 
             <AuthSocial />


### PR DESCRIPTION
### Motivation
- Atualizar o acesso de demonstração mockado para usar o e-mail e senha fornecidos e manter consistência dos dados de sessão e exibição.

### Description
- Atualizei o usuário mock em `src/auth/session.js` para `email: davidfernandes@hortelanagtech.com` e `password: admin`.
- Ajustei `INITIAL_PASSWORD_HISTORY.userEmail` em `src/auth/session.js` para o novo e-mail.
- Atualizei o mapeamento de login social em `src/auth/session.js` (`loginWithSocialProvider`) para apontar para o novo e-mail.
- Altereis o texto exibido na tela de login em `src/pages/Login.js` para mostrar as novas credenciais de demonstração.

### Testing
- Rodei `npx eslint src/pages/Login.js src/auth/session.js` e a verificação de lint concluiu sem erros.
- Iniciei a aplicação com `npm run dev -- --host 0.0.0.0 --port 4173` e o servidor Vite subiu corretamente.
- Capturei uma screenshot automatizada da página de login via Playwright para validar visualmente que as credenciais exibidas foram atualizadas.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_699ee01b9b7483288d6682402bb7ee1e)