### PR TITLE
Show splash before login screen

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -11,12 +11,9 @@ import { AuthProvider } from './auth/AuthContext';
 import useAuth from './auth/useAuth';
 import CookieConsentBanner from './components/privacy/CookieConsentBanner';
 import HortelanPlayfulEffects from './components/fx/HortelanPlayfulEffects';
-import HarvestSplashScreen from './components/fx/HarvestSplashScreen';
-import { useState } from 'react';
 
 function AppContent() {
   const { consents } = useAuth();
-  const [splashFinished, setSplashFinished] = useState(false);
 
   return (
     <>
@@ -26,7 +23,6 @@ function AppContent() {
       <Router />
       <CookieConsentBanner />
       {consents?.analytics && <Analytics />}
-      {!splashFinished && <HarvestSplashScreen onComplete={() => setSplashFinished(true)} />}
     </>
   );
 }

--- a/src/pages/Login.js
+++ b/src/pages/Login.js
@@ -1,4 +1,5 @@
 import { Link as RouterLink } from 'react-router-dom';
+import { useState } from 'react';
 // @mui
 import { alpha, keyframes, styled } from '@mui/material/styles';
 import { Card, Link, Container, Typography } from '@mui/material';
@@ -8,6 +9,7 @@ import useResponsive from '../hooks/useResponsive';
 // components
 import Page from '../components/Page';
 import Logo from '../components/Logo';
+import HarvestSplashScreen from '../components/fx/HarvestSplashScreen';
 // sections
 import { LoginForm } from '../sections/auth/login';
 import AuthSocial from '../sections/auth/AuthSocial';
@@ -123,6 +125,7 @@ const ContentStyle = styled('div')(({ theme }) => ({
 // ----------------------------------------------------------------------
 
 export default function Login() {
+  const [showSplash, setShowSplash] = useState(true);
   const smUp = useResponsive('up', 'sm');
 
   const mdUp = useResponsive('up', 'md');
@@ -136,6 +139,7 @@ export default function Login() {
 
   return (
     <Page title="Login">
+      {showSplash && <HarvestSplashScreen durationSec={4} onComplete={() => setShowSplash(false)} />}
       <RootStyle>
         <HeaderStyle>
           <Logo />


### PR DESCRIPTION
### Motivation
- Ensure the harvest splash appears only in the authentication flow instead of globally so it doesn't show on other routes (e.g. dashboard).
- Provide a clear order: splash first, then reveal the login UI to match the intended UX.

### Description
- Removed global splash rendering from `src/App.js` so the splash no longer appears for all routes.
- Added local state `showSplash` to `src/pages/Login.js` and render `HarvestSplashScreen` there until completion.
- Set the login splash `durationSec` to `4` seconds to speed up the transition to the login form.
- Modified imports accordingly by moving `HarvestSplashScreen` and adding `useState` in `src/pages/Login.js`.

### Testing
- Ran `npm run build` and the production build completed successfully.
- Launched the dev server with `npm run dev -- --host 0.0.0.0 --port 4173` and it started successfully.
- Executed an automated Playwright script to capture screenshots of the splash and the post-splash login state and the script completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_699ee05594b48328aa994fc046123f22)