### PR TITLE
Atualiza aplicação para usar nova identidade visual (logo)

### DIFF
--- a/public/favicon/nav-logo.svg
+++ b/public/favicon/nav-logo.svg
@@ -1,36 +1,49 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" role="img" aria-label="Hortelan icon">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 760" role="img" aria-labelledby="title desc">
+  <title id="title">Hortelan AgTech Ltda logo</title>
+  <desc id="desc">Three green leaves with circuit-like details and Hortelan AgTech Ltda text.</desc>
   <defs>
     <linearGradient id="leafGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" stop-color="#b7e343"/>
-      <stop offset="48%" stop-color="#24bf57"/>
-      <stop offset="100%" stop-color="#02695b"/>
+      <stop offset="0%" stop-color="#B9E440"/>
+      <stop offset="45%" stop-color="#2ABF58"/>
+      <stop offset="100%" stop-color="#006A5A"/>
+    </linearGradient>
+    <linearGradient id="textGradient" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#005E50"/>
+      <stop offset="100%" stop-color="#0A7A64"/>
     </linearGradient>
     <style>
-      .trace { fill: none; stroke: #ecf8ef; stroke-width: 5.5; stroke-linecap: round; stroke-linejoin: round; }
-      .node { fill: #ecf8ef; }
+      .trace { fill: none; stroke: #eef8ef; stroke-width: 5; stroke-linecap: round; stroke-linejoin: round; opacity: 0.95; }
+      .node { fill: #eef8ef; }
+      .tagline { font: 500 56px "Inter", "Segoe UI", Arial, sans-serif; letter-spacing: 1px; fill: #1f866f; }
+      .brand { font: 700 112px "Inter", "Segoe UI", Arial, sans-serif; fill: url(#textGradient); }
     </style>
   </defs>
 
-  <path fill="url(#leafGradient)" d="M244 408c-23-108-87-187-200-187-3 84 41 163 132 193 28 10 53 7 68-6z"/>
-  <path fill="url(#leafGradient)" d="M277 408c23-108 87-187 199-187 4 84-41 163-132 193-28 10-53 7-67-6z"/>
-  <path fill="url(#leafGradient)" d="M260 417c4-123 59-226 139-276-108-11-198 103-205 276h66z"/>
+  <g transform="translate(30 20)">
+    <path fill="url(#leafGradient)" d="M348 440c-26-144-113-246-261-246-4 109 53 212 174 253 37 13 68 8 87-7z"/>
+    <path fill="url(#leafGradient)" d="M392 438c24-146 112-246 260-246 4 111-54 213-177 254-36 12-66 7-83-8z"/>
+    <path fill="url(#leafGradient)" d="M369 450c5-164 77-293 174-357-137-14-253 132-261 357h87z"/>
 
-  <path class="trace" d="M98 296c52 8 104 36 147 97"/>
-  <path class="trace" d="M128 254c46 9 88 35 118 82"/>
-  <path class="trace" d="M175 228c30 15 56 41 74 74"/>
-  <path class="trace" d="M414 298c-51 8-104 36-148 97"/>
-  <path class="trace" d="M384 255c-47 9-88 35-118 83"/>
-  <path class="trace" d="M336 229c-30 15-56 41-74 74"/>
+    <path class="trace" d="M145 286c64 6 132 41 186 122"/>
+    <path class="trace" d="M206 242c58 12 112 46 151 112"/>
+    <path class="trace" d="M302 220c36 18 66 50 86 90"/>
+    <path class="trace" d="M598 286c-64 6-132 41-186 122"/>
+    <path class="trace" d="M537 242c-58 12-112 46-151 112"/>
+    <path class="trace" d="M441 220c-36 18-66 50-86 90"/>
 
-  <circle class="node" cx="131" cy="254" r="7"/>
-  <circle class="node" cx="176" cy="228" r="7"/>
-  <circle class="node" cx="98" cy="296" r="7"/>
-  <circle class="node" cx="383" cy="255" r="7"/>
-  <circle class="node" cx="413" cy="298" r="7"/>
-  <circle class="node" cx="336" cy="229" r="7"/>
+    <circle class="node" cx="210" cy="243" r="7"/>
+    <circle class="node" cx="301" cy="220" r="7"/>
+    <circle class="node" cx="145" cy="286" r="7"/>
+    <circle class="node" cx="536" cy="244" r="7"/>
+    <circle class="node" cx="599" cy="286" r="7"/>
+    <circle class="node" cx="441" cy="221" r="7"/>
 
-  <path d="M392 148c38-2 72 17 85 51" fill="none" stroke="#67ca60" stroke-width="9" stroke-linecap="round"/>
-  <path d="M397 181c28 1 51 15 62 37" fill="none" stroke="#58c059" stroke-width="9" stroke-linecap="round"/>
-  <path d="M401 210c17 2 32 11 39 25" fill="none" stroke="#42b850" stroke-width="9" stroke-linecap="round"/>
-  <circle cx="376" cy="221" r="12" fill="#50bd58"/>
+    <path d="M643 142c52-3 95 24 112 67" fill="none" stroke="#65c95f" stroke-width="10" stroke-linecap="round"/>
+    <path d="M647 175c38 1 68 20 82 49" fill="none" stroke="#57bf58" stroke-width="10" stroke-linecap="round"/>
+    <path d="M653 208c24 3 42 16 51 32" fill="none" stroke="#3fb34f" stroke-width="10" stroke-linecap="round"/>
+    <circle cx="624" cy="218" r="14" fill="#50bc58"/>
+  </g>
+
+  <text x="400" y="620" text-anchor="middle" class="brand">Hortelan</text>
+  <text x="400" y="690" text-anchor="middle" class="tagline">AgTech Ltda</text>
 </svg>

--- a/public/static/nav-logo.svg
+++ b/public/static/nav-logo.svg
@@ -1,36 +1,49 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" role="img" aria-label="Hortelan icon">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 760" role="img" aria-labelledby="title desc">
+  <title id="title">Hortelan AgTech Ltda logo</title>
+  <desc id="desc">Three green leaves with circuit-like details and Hortelan AgTech Ltda text.</desc>
   <defs>
     <linearGradient id="leafGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" stop-color="#b7e343"/>
-      <stop offset="48%" stop-color="#24bf57"/>
-      <stop offset="100%" stop-color="#02695b"/>
+      <stop offset="0%" stop-color="#B9E440"/>
+      <stop offset="45%" stop-color="#2ABF58"/>
+      <stop offset="100%" stop-color="#006A5A"/>
+    </linearGradient>
+    <linearGradient id="textGradient" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#005E50"/>
+      <stop offset="100%" stop-color="#0A7A64"/>
     </linearGradient>
     <style>
-      .trace { fill: none; stroke: #ecf8ef; stroke-width: 5.5; stroke-linecap: round; stroke-linejoin: round; }
-      .node { fill: #ecf8ef; }
+      .trace { fill: none; stroke: #eef8ef; stroke-width: 5; stroke-linecap: round; stroke-linejoin: round; opacity: 0.95; }
+      .node { fill: #eef8ef; }
+      .tagline { font: 500 56px "Inter", "Segoe UI", Arial, sans-serif; letter-spacing: 1px; fill: #1f866f; }
+      .brand { font: 700 112px "Inter", "Segoe UI", Arial, sans-serif; fill: url(#textGradient); }
     </style>
   </defs>
 
-  <path fill="url(#leafGradient)" d="M244 408c-23-108-87-187-200-187-3 84 41 163 132 193 28 10 53 7 68-6z"/>
-  <path fill="url(#leafGradient)" d="M277 408c23-108 87-187 199-187 4 84-41 163-132 193-28 10-53 7-67-6z"/>
-  <path fill="url(#leafGradient)" d="M260 417c4-123 59-226 139-276-108-11-198 103-205 276h66z"/>
+  <g transform="translate(30 20)">
+    <path fill="url(#leafGradient)" d="M348 440c-26-144-113-246-261-246-4 109 53 212 174 253 37 13 68 8 87-7z"/>
+    <path fill="url(#leafGradient)" d="M392 438c24-146 112-246 260-246 4 111-54 213-177 254-36 12-66 7-83-8z"/>
+    <path fill="url(#leafGradient)" d="M369 450c5-164 77-293 174-357-137-14-253 132-261 357h87z"/>
 
-  <path class="trace" d="M98 296c52 8 104 36 147 97"/>
-  <path class="trace" d="M128 254c46 9 88 35 118 82"/>
-  <path class="trace" d="M175 228c30 15 56 41 74 74"/>
-  <path class="trace" d="M414 298c-51 8-104 36-148 97"/>
-  <path class="trace" d="M384 255c-47 9-88 35-118 83"/>
-  <path class="trace" d="M336 229c-30 15-56 41-74 74"/>
+    <path class="trace" d="M145 286c64 6 132 41 186 122"/>
+    <path class="trace" d="M206 242c58 12 112 46 151 112"/>
+    <path class="trace" d="M302 220c36 18 66 50 86 90"/>
+    <path class="trace" d="M598 286c-64 6-132 41-186 122"/>
+    <path class="trace" d="M537 242c-58 12-112 46-151 112"/>
+    <path class="trace" d="M441 220c-36 18-66 50-86 90"/>
 
-  <circle class="node" cx="131" cy="254" r="7"/>
-  <circle class="node" cx="176" cy="228" r="7"/>
-  <circle class="node" cx="98" cy="296" r="7"/>
-  <circle class="node" cx="383" cy="255" r="7"/>
-  <circle class="node" cx="413" cy="298" r="7"/>
-  <circle class="node" cx="336" cy="229" r="7"/>
+    <circle class="node" cx="210" cy="243" r="7"/>
+    <circle class="node" cx="301" cy="220" r="7"/>
+    <circle class="node" cx="145" cy="286" r="7"/>
+    <circle class="node" cx="536" cy="244" r="7"/>
+    <circle class="node" cx="599" cy="286" r="7"/>
+    <circle class="node" cx="441" cy="221" r="7"/>
 
-  <path d="M392 148c38-2 72 17 85 51" fill="none" stroke="#67ca60" stroke-width="9" stroke-linecap="round"/>
-  <path d="M397 181c28 1 51 15 62 37" fill="none" stroke="#58c059" stroke-width="9" stroke-linecap="round"/>
-  <path d="M401 210c17 2 32 11 39 25" fill="none" stroke="#42b850" stroke-width="9" stroke-linecap="round"/>
-  <circle cx="376" cy="221" r="12" fill="#50bd58"/>
+    <path d="M643 142c52-3 95 24 112 67" fill="none" stroke="#65c95f" stroke-width="10" stroke-linecap="round"/>
+    <path d="M647 175c38 1 68 20 82 49" fill="none" stroke="#57bf58" stroke-width="10" stroke-linecap="round"/>
+    <path d="M653 208c24 3 42 16 51 32" fill="none" stroke="#3fb34f" stroke-width="10" stroke-linecap="round"/>
+    <circle cx="624" cy="218" r="14" fill="#50bc58"/>
+  </g>
+
+  <text x="400" y="620" text-anchor="middle" class="brand">Hortelan</text>
+  <text x="400" y="690" text-anchor="middle" class="tagline">AgTech Ltda</text>
 </svg>

--- a/src/components/Logo.js
+++ b/src/components/Logo.js
@@ -11,7 +11,7 @@ Logo.propTypes = {
 };
 
 export default function Logo({ disabledLink = false, sx }) {
-  const logo = <Box component="img" src="/static/nav-logo.svg" sx={{ width: 40, height: 40, ...sx }} />;
+  const logo = <Box component="img" src="/static/hortelan-logo.svg" sx={{ width: 176, height: 'auto', display: 'block', ...sx }} />;
 
   // OR
   // const logo = (


### PR DESCRIPTION
### Motivation
- Atualizar a interface para a nova identidade visual da Hortelan substituindo o ícone/branding atual pelo novo desenho completo.

### Description
- Atualiza o componente `Logo` para carregar `public/static/hortelan-logo.svg` e ajusta as dimensões para exibição consistente (`width: 176`, `height: 'auto'`).
- Substitui os assets `public/static/nav-logo.svg` e `public/favicon/nav-logo.svg` pelo novo SVG com a marca completa (novo viewBox, gradientes e textos de marca). 
- Mantém compatibilidade com as referências existentes usando o novo asset completo onde antes era usado o ícone reduzido.

### Testing
- Executado `npm run build` com sucesso sem erros de build que impeçam a entrega.
- Levantado o servidor de desenvolvimento com `npm run dev -- --host 0.0.0.0 --port 4173` e verificada a aplicação rodando na porta exposta.
- Captura automatizada da página inicial feita com Playwright e salva em `browser:/tmp/codex_browser_invocations/a15a218b3e79d091/artifacts/artifacts/logo-update.png` para validação visual.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_699ee074fee4832891724700f0ee8f8a)