### PR TITLE
Fix splash-first rendering on login page

### DIFF
--- a/src/pages/Login.js
+++ b/src/pages/Login.js
@@ -137,9 +137,16 @@ export default function Login() {
   const rightLeafY = useTransform(scrollYProgress, [0, 1], [0, 10]);
   const cableWave = useTransform(scrollYProgress, [0, 0.25, 0.5, 0.75, 1], [0, 8, 0, -8, 0]);
 
+  if (showSplash) {
+    return (
+      <Page title="Login">
+        <HarvestSplashScreen durationSec={4} onComplete={() => setShowSplash(false)} />
+      </Page>
+    );
+  }
+
   return (
     <Page title="Login">
-      {showSplash && <HarvestSplashScreen durationSec={4} onComplete={() => setShowSplash(false)} />}
       <RootStyle>
         <HeaderStyle>
           <Logo />


### PR DESCRIPTION
### Motivation
- The login page was mounting the full login UI alongside the splash, preventing the splash from being the only initially visible content.

### Description
- Added an early return in `src/pages/Login.js` that renders only `HarvestSplashScreen` while `showSplash` is `true` so the splash appears first.
- Kept the existing callback `onComplete={() => setShowSplash(false)}` to restore the login UI after the splash finishes.

### Testing
- Ran `npm run lint`, which completed successfully with a pre-existing ESLint warning in `src/components/fx/HarvestSplashScreen.js` about a ref in an effect cleanup.
- Started the dev server with `npm run dev` and executed a Playwright script to capture screenshots of the splash and the login form after the splash, and both behaved as expected.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_699f0510160083289a2c13e256fc631c)