### PR TITLE
Fix harvester visibility in splash screen

### DIFF
--- a/src/components/fx/HarvestSplashScreen.js
+++ b/src/components/fx/HarvestSplashScreen.js
@@ -197,15 +197,23 @@ export default function HarvestSplashScreen({ onComplete, durationSec = 14 }) {
         const machine = new PIXI.Container();
         machineLayer.addChild(machine);
         const body = new PIXI.Graphics();
-        body.roundRect(-70, -46, 140, 72, 16).fill({ color: 0xf2c94c, alpha: 1 });
-        body.roundRect(-70, -46, 140, 72, 16).stroke({ color: 0x5f4b10, width: 3, alpha: 0.9 });
+        body.beginFill(0xf2c94c, 1);
+        body.drawRoundedRect(-70, -46, 140, 72, 16);
+        body.endFill();
+        body.lineStyle(3, 0x5f4b10, 0.9);
+        body.drawRoundedRect(-70, -46, 140, 72, 16);
         machine.addChild(body);
 
         const header = new PIXI.Graphics();
-        header.roundRect(-125, 10, 120, 40, 14).fill({ color: 0xe2553a, alpha: 1 });
-        header.roundRect(-125, 10, 120, 40, 14).stroke({ color: 0x5a1f15, width: 3, alpha: 0.9 });
+        header.beginFill(0xe2553a, 1);
+        header.drawRoundedRect(-125, 10, 120, 40, 14);
+        header.endFill();
+        header.lineStyle(3, 0x5a1f15, 0.9);
+        header.drawRoundedRect(-125, 10, 120, 40, 14);
         for (let i = 0; i < 10; i += 1) {
-          header.rect(-115 + i * 12, 14, 2, 32).fill({ color: 0xffe6d2, alpha: 0.7 });
+          header.beginFill(0xffe6d2, 0.7);
+          header.drawRect(-115 + i * 12, 14, 2, 32);
+          header.endFill();
         }
         machine.addChild(header);
 


### PR DESCRIPTION
### Motivation
- The harvester graphic in the splash screen was not visible because the `PIXI.Graphics` chain-style drawing calls used in the file are incompatible with PIXI v7's API.
- The intent is to keep the existing splash animation and behavior while making the machine draw correctly at runtime.

### Description
- Replaced chain-style `Graphics` calls with PIXI v7-compatible APIs in `src/components/fx/HarvestSplashScreen.js`, using `beginFill`/`drawRoundedRect`/`lineStyle`/`drawRect`/`endFill` for the machine body and header drawing instead of `roundRect(...).fill()/stroke()` and `rect(...).fill()`.
- Kept the original visual layout, layers, plant sprites, animation ticker, harvested reveal logic, and particle emitter code unchanged; only the drawing calls were updated so the machine renders.
- Committed changes with a focused message: the file modified is `src/components/fx/HarvestSplashScreen.js` and the drawing logic around the machine/header was updated.

### Testing
- Ran `npm run build`, which completed successfully without runtime build errors.
- Started the dev server with `npm run dev -- --host 0.0.0.0 --port 4173` and verified the app served locally.
- Captured a visual validation screenshot using Playwright of the splash screen showing the harvester at `http://127.0.0.1:4173/`, saved as `splash-colheitadeira.png`, confirming the machine is now visible.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_699fb365718c8328b555b1647650b5c1)