### PR TITLE
Add animated Harvester splash (SplashHarvestPro) with particles, SVG and styles; broaden Vite loader patterns

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,38 +1,15 @@
-// routes
-import { Analytics } from '@vercel/analytics/react';
-import Router from './routes';
-// theme
-import ThemeProvider from './theme';
-// components
-import ScrollToTop from './components/ScrollToTop';
-import { BaseOptionChartStyle } from './components/chart/BaseOptionChart';
-import GlobalErrorBoundary from './components/GlobalErrorBoundary';
-import { AuthProvider } from './auth/AuthContext';
-import useAuth from './auth/useAuth';
-import CookieConsentBanner from './components/privacy/CookieConsentBanner';
-
-function AppContent() {
-  const { consents } = useAuth();
-
-  return (
-    <>
-      <ScrollToTop />
-      <BaseOptionChartStyle />
-      <Router />
-      <CookieConsentBanner />
-      {consents?.analytics && <Analytics />}
-    </>
-  );
-}
+import React, { useState } from "react";
+import SplashHarvestPro from "./SplashHarvestPro";
 
 export default function App() {
-  return (
-    <GlobalErrorBoundary>
-      <ThemeProvider>
-        <AuthProvider>
-          <AppContent />
-        </AuthProvider>
-      </ThemeProvider>
-    </GlobalErrorBoundary>
+  const [showSplash, setShowSplash] = useState(true);
+
+  return showSplash ? (
+    <SplashHarvestPro onFinish={() => setShowSplash(false)} />
+  ) : (
+    <div style={{ padding: 40, fontFamily: "system-ui" }}>
+      <h1>Minha Home real</h1>
+      <p>Conteúdo da HomePage aqui...</p>
+    </div>
   );
 }

--- a/src/HarvesterSVG.js
+++ b/src/HarvesterSVG.js
@@ -1,0 +1,113 @@
+import React from "react";
+import { motion } from "framer-motion";
+
+export default function HarvesterSVG() {
+  return (
+    <svg width="460" height="300" viewBox="0 0 460 300" style={{ position: "absolute", left: 0, top: 0 }}>
+      <defs>
+        <linearGradient id="jdGreen" x1="0" x2="0" y1="0" y2="1">
+          <stop offset="0" stopColor="#2da25a" />
+          <stop offset="1" stopColor="#16683a" />
+        </linearGradient>
+
+        <linearGradient id="jdYellow" x1="0" x2="0" y1="0" y2="1">
+          <stop offset="0" stopColor="#f3cc3e" />
+          <stop offset="1" stopColor="#b98b10" />
+        </linearGradient>
+
+        <linearGradient id="metal" x1="0" x2="1">
+          <stop offset="0" stopColor="#e7ebf2" />
+          <stop offset="1" stopColor="#9aa3b2" />
+        </linearGradient>
+
+        <linearGradient id="glass" x1="0" x2="0" y1="0" y2="1">
+          <stop offset="0" stopColor="#8de2ff" stopOpacity="0.95" />
+          <stop offset="1" stopColor="#1c4f7d" stopOpacity="0.92" />
+        </linearGradient>
+
+        <radialGradient id="tire" cx="35%" cy="35%" r="70%">
+          <stop offset="0" stopColor="#6b7280" />
+          <stop offset="1" stopColor="#0b0f16" />
+        </radialGradient>
+
+        <filter id="drop" x="-30%" y="-30%" width="160%" height="160%">
+          <feDropShadow dx="0" dy="10" stdDeviation="8" floodColor="#000" floodOpacity="0.28" />
+        </filter>
+      </defs>
+
+      {/* sombra projetada no chão */}
+      <ellipse cx="250" cy="238" rx="170" ry="28" fill="rgba(0,0,0,0.22)" filter="url(#drop)" />
+
+      {/* HEADER (frente) */}
+      <g transform="translate(28,165)">
+        <rect x="0" y="8" width="188" height="66" rx="24" fill="url(#jdYellow)" stroke="rgba(90,70,8,0.55)" strokeWidth="4" />
+
+        {/* reel girando */}
+        <motion.g
+          style={{ originX: "78px", originY: "41px" }}
+          animate={{ rotate: 360 }}
+          transition={{ duration: 0.55, repeat: Infinity, ease: "linear" }}
+        >
+          <circle cx="78" cy="41" r="18" fill="#7c5c0c" opacity="0.92" />
+          {Array.from({ length: 8 }).map((_, i) => (
+            <rect
+              key={i}
+              x="76"
+              y="14"
+              width="4"
+              height="54"
+              rx="2"
+              fill="#2b1d05"
+              transform={`rotate(${i * 45} 78 41)`}
+            />
+          ))}
+        </motion.g>
+
+        {/* dentes */}
+        {Array.from({ length: 13 }).map((_, i) => (
+          <rect key={i} x={18 + i * 13} y="16" width="5" height="56" rx="3" fill="rgba(50,35,10,0.9)" transform="skewX(-10)" />
+        ))}
+      </g>
+
+      {/* Corpo principal */}
+      <g transform="translate(170,78)">
+        <rect x="0" y="0" width="248" height="142" rx="28" fill="url(#jdGreen)" stroke="rgba(10,40,20,0.65)" strokeWidth="4" />
+        <path d="M18 38 H230" stroke="rgba(255,255,255,0.25)" strokeWidth="4" />
+        <path d="M18 62 H230" stroke="rgba(0,0,0,0.20)" strokeWidth="3" />
+        <rect x="16" y="88" width="98" height="18" rx="9" fill="rgba(0,0,0,0.18)" />
+      </g>
+
+      {/* Cabine com reflexo */}
+      <g transform="translate(322,104)">
+        <rect x="0" y="0" width="92" height="76" rx="18" fill="url(#glass)" stroke="rgba(12,25,40,0.6)" strokeWidth="3" />
+        {/* reflexo */}
+        <polygon points="10,10 80,10 56,72" fill="rgba(255,255,255,0.22)" />
+        <path d="M12 18 H78" stroke="rgba(255,255,255,0.30)" strokeWidth="4" />
+        <path d="M14 36 H74" stroke="rgba(255,255,255,0.16)" strokeWidth="3" />
+      </g>
+
+      {/* Tubo */}
+      <g transform="translate(368,86) rotate(-12)">
+        <rect x="0" y="0" width="120" height="12" rx="8" fill="url(#metal)" />
+        <rect x="92" y="-18" width="48" height="12" rx="8" fill="url(#metal)" transform="rotate(25 92 -18)" />
+      </g>
+
+      {/* Rodas + “track” */}
+      <g>
+        <circle cx="258" cy="224" r="36" fill="url(#tire)" stroke="rgba(0,0,0,0.55)" strokeWidth="4" />
+        <circle cx="258" cy="224" r="16" fill="rgba(230,235,242,0.75)" />
+
+        <circle cx="366" cy="228" r="36" fill="url(#tire)" stroke="rgba(0,0,0,0.55)" strokeWidth="4" />
+        <circle cx="366" cy="228" r="16" fill="rgba(230,235,242,0.75)" />
+
+        <rect x="222" y="248" width="180" height="22" rx="11" fill="rgba(15,15,15,0.76)" />
+        {Array.from({ length: 10 }).map((_, i) => (
+          <rect key={i} x={230 + i * 17} y="252" width="10" height="14" rx="4" fill="rgba(255,255,255,0.12)" />
+        ))}
+      </g>
+
+      {/* ligação header -> corpo */}
+      <path d="M186 198 C150 196, 130 200, 110 218" stroke="rgba(0,0,0,0.35)" strokeWidth="8" fill="none" strokeLinecap="round" />
+    </svg>
+  );
+}

--- a/src/HomeMock.js
+++ b/src/HomeMock.js
@@ -1,0 +1,23 @@
+import React from "react";
+import { styles } from "./styles";
+
+export default function HomeMock() {
+  return (
+    <div style={styles.homeMock}>
+      <div style={styles.homeTop}>
+        <div style={styles.homeTitle}>Home</div>
+      </div>
+
+      <div style={styles.homeCards}>
+        {["Card 1", "Card 2", "Card 3"].map((t) => (
+          <div key={t} style={styles.card}>
+            <div style={styles.cardTitle}>{t}</div>
+            <div style={styles.cardBar} />
+          </div>
+        ))}
+      </div>
+
+      <div style={styles.homeBottomPill}>Bem-vindo! (prévia)</div>
+    </div>
+  );
+}

--- a/src/SplashHarvestPro.js
+++ b/src/SplashHarvestPro.js
@@ -1,0 +1,223 @@
+import React, { useEffect, useMemo, useRef, useState } from "react";
+import { motion, useMotionValue, useTransform, animate, useSpring } from "framer-motion";
+import HarvesterSVG from "./HarvesterSVG";
+import HomeMock from "./HomeMock";
+import useParticlesCanvas from "./useParticlesCanvas";
+import { styles } from "./styles";
+
+export default function SplashHarvestPro({ onFinish }) {
+  const [done, setDone] = useState(false);
+  const containerRef = useRef(null);
+
+  const p = useMotionValue(0);
+
+  // Spring só pra suavizar um pouco o recorte/blur
+  const pSpring = useSpring(p, { stiffness: 120, damping: 22, mass: 0.6 });
+
+  // dimensões responsivas
+  const [W, setW] = useState(() => (typeof window !== "undefined" ? window.innerWidth : 1200));
+  const [H, setH] = useState(() => (typeof window !== "undefined" ? window.innerHeight : 720));
+
+  useEffect(() => {
+    const onResize = () => {
+      setW(window.innerWidth);
+      setH(window.innerHeight);
+    };
+    window.addEventListener("resize", onResize);
+    return () => window.removeEventListener("resize", onResize);
+  }, []);
+
+  const harvX = useTransform(pSpring, [0, 1], [-460, W + 160]);
+  const cutX = useTransform(pSpring, [0, 1], [0, W]);
+
+  // blur dinâmico por velocidade (motion blur)
+  const prevX = useRef(0);
+  const blurMV = useMotionValue(0);
+
+  useEffect(() => {
+    const unsub = harvX.on("change", (x) => {
+      const dx = Math.abs(x - prevX.current);
+      prevX.current = x;
+      // dx ~ pixels por frame; escala para blur
+      const blur = Math.min(8, dx * 0.18);
+      blurMV.set(blur);
+    });
+    return () => unsub();
+  }, [harvX, blurMV]);
+
+  // Partículas (Canvas 2D)
+  const { canvasRef, emitAt } = useParticlesCanvas({
+    getSize: () => ({ width: W, height: H }),
+  });
+
+  useEffect(() => {
+    const controls = animate(p, 1, {
+      duration: 4.8,
+      ease: [0.2, 0.8, 0.2, 1],
+      onComplete: () => {
+        setDone(true);
+        setTimeout(() => onFinish?.(), 320);
+      },
+    });
+    return () => controls.stop();
+  }, [onFinish, p]);
+
+  // “soja procedural” full-screen (mais densa)
+  const plants = useMemo(() => {
+    const count = 2600;
+    const arr = [];
+    for (let i = 0; i < count; i++) {
+      const x = Math.random() * 100;
+      const y = Math.random() * 100;
+      const s = 0.55 + Math.random() * 2.2;
+      const o = 0.25 + Math.random() * 0.75;
+      const hue = 108 + Math.random() * 28;
+      const light = 22 + Math.random() * 18;
+      arr.push({ id: i, x, y, s, o, hue, light });
+    }
+    return arr;
+  }, []);
+
+  // Emite partículas próximo ao header (posição aproximada)
+  useEffect(() => {
+    const unsub = harvX.on("change", (x) => {
+      const px = x + 90; // header center approx
+      const py = H * 0.62; // altura do header
+      emitAt(px, py, 7);
+    });
+    return () => unsub();
+  }, [harvX, H, emitAt]);
+
+  return (
+    <div ref={containerRef} style={styles.root}>
+      {/* HOME por trás */}
+      <div style={styles.homeLayer}>
+        <HomeMock />
+      </div>
+
+      {/* Reveal da home conforme cutX aumenta */}
+      <motion.div
+        style={{
+          ...styles.revealMask,
+          clipPath: useTransform(cutX, (v) => `inset(0 ${Math.max(0, W - v)}px 0 0 round 0px)`),
+        }}
+      />
+
+      {/* Cena (full soja) */}
+      <div style={styles.scene}>
+        {/* Soja não colhida (direita do corte) */}
+        <motion.div
+          style={{
+            ...styles.soyMask,
+            clipPath: useTransform(cutX, (v) => `inset(0 0 0 ${Math.min(W, v)}px)`),
+          }}
+        >
+          <SoyPlantsFull plants={plants} />
+        </motion.div>
+
+        {/* Área colhida (esquerda do corte) */}
+        <motion.div
+          style={{
+            ...styles.cutMask,
+            clipPath: useTransform(cutX, (v) => `inset(0 ${Math.max(0, W - v)}px 0 0)`),
+          }}
+        >
+          <CutStubbleFull />
+        </motion.div>
+
+        {/* Motion blur no corte + sombra */}
+        <motion.div
+          style={{
+            ...styles.edgeShadow,
+            x: cutX,
+            filter: useTransform(blurMV, (b) => `blur(${Math.max(4, b * 0.9)}px)`),
+            opacity: useTransform(blurMV, (b) => Math.min(0.55, 0.25 + b * 0.05)),
+          }}
+        />
+
+        {/* Colheitadeira (com blur dinâmico) */}
+        <motion.div
+          style={{
+            ...styles.harvesterWrap,
+            x: harvX,
+            filter: useTransform(blurMV, (b) => `blur(${b}px)`),
+          }}
+        >
+          <HarvesterSVG />
+        </motion.div>
+
+        {/* Partículas (Canvas overlay) */}
+        <canvas ref={canvasRef} style={styles.particlesCanvas} />
+
+        {/* HUD */}
+        <div style={styles.hud}>
+          <div style={styles.loadingText}>Carregando…</div>
+          <div style={styles.progressOuter}>
+            <motion.div
+              style={{
+                ...styles.progressInner,
+                scaleX: useTransform(pSpring, [0, 1], [0, 1]),
+                transformOrigin: "0% 50%",
+              }}
+            />
+          </div>
+        </div>
+      </div>
+
+      {/* fade-out */}
+      <motion.div
+        style={styles.fade}
+        initial={{ opacity: 0 }}
+        animate={{ opacity: done ? 1 : 0 }}
+        transition={{ duration: 0.25 }}
+      />
+    </div>
+  );
+}
+
+/* ---------- Subcomponentes ---------- */
+
+function SoyPlantsFull({ plants }) {
+  return (
+    <div style={styles.fieldFull}>
+      <div style={styles.fieldBaseA} />
+      <div style={styles.fieldBaseB} />
+      <div style={styles.fieldVignette} />
+
+      {plants.map((p) => (
+        <div
+          key={p.id}
+          style={{
+            position: "absolute",
+            left: `${p.x}vw`,
+            top: `${p.y}vh`,
+            width: `${p.s * 9}px`,
+            height: `${p.s * 9}px`,
+            borderRadius: 999,
+            background: `hsla(${p.hue}, 48%, ${p.light}%, ${p.o})`,
+            boxShadow: `
+              0 0 0 ${p.s * 1.3}px hsla(${p.hue}, 55%, ${Math.max(12, p.light - 10)}%, ${p.o * 0.28}),
+              0 ${p.s * 2.2}px ${p.s * 2.4}px rgba(0,0,0,0.12)
+            `,
+            filter: `blur(${Math.max(0, 1.2 - p.s)}px)`,
+            transform: "translateZ(0)",
+          }}
+        />
+      ))}
+
+      <div style={styles.leafBlobA} />
+      <div style={styles.leafBlobB} />
+      <div style={styles.leafBlobC} />
+    </div>
+  );
+}
+
+function CutStubbleFull() {
+  return (
+    <div style={styles.cutFull}>
+      <div style={styles.stubbleRows} />
+      <div style={styles.stubbleNoise} />
+      <div style={styles.stubbleVignette} />
+    </div>
+  );
+}

--- a/src/components/fx/HarvestSplashScreen.js
+++ b/src/components/fx/HarvestSplashScreen.js
@@ -29,6 +29,14 @@ const styles = {
   },
   brandTitle: { fontWeight: 900, letterSpacing: 0.2 },
   brandSub: { opacity: 0.85, fontSize: 12, marginTop: 2 },
+  machineFallback: {
+    position: 'absolute',
+    width: 168,
+    height: 92,
+    bottom: '30%',
+    willChange: 'transform, left',
+    filter: 'drop-shadow(0 10px 18px rgba(0,0,0,0.35))',
+  },
 };
 
 const easeOutExpo = (x) => (x === 1 ? 1 : 1 - 2 ** (-10 * x));
@@ -319,6 +327,37 @@ export default function HarvestSplashScreen({ onComplete, durationSec = 14 }) {
 
       <div style={styles.canvasLayer}>
         <div ref={pixiHostRef} style={{ position: 'absolute', inset: 0 }} />
+
+        <div
+          style={{
+            ...styles.machineFallback,
+            left: `calc(${Math.min(progress, 0.98) * 100}% - 84px)`,
+            transform: `translateY(${Math.sin(progress * Math.PI * 18) * 2}px)`,
+          }}
+          aria-hidden="true"
+        >
+          <svg viewBox="0 0 168 92" width="100%" height="100%">
+            <rect x="52" y="10" width="92" height="44" rx="10" fill="#f2c94c" stroke="#5f4b10" strokeWidth="3" />
+            <rect x="6" y="40" width="74" height="30" rx="10" fill="#e2553a" stroke="#5a1f15" strokeWidth="3" />
+            {Array.from({ length: 6 }).map((_, index) => (
+              <line
+                // eslint-disable-next-line react/no-array-index-key
+                key={index}
+                x1={18 + index * 10}
+                y1="44"
+                x2={18 + index * 10}
+                y2="66"
+                stroke="#ffd9b8"
+                strokeWidth="2"
+                opacity="0.8"
+              />
+            ))}
+            <circle cx="66" cy="76" r="12" fill="#233" />
+            <circle cx="124" cy="76" r="12" fill="#233" />
+            <circle cx="66" cy="76" r="5" fill="#ddd" />
+            <circle cx="124" cy="76" r="5" fill="#ddd" />
+          </svg>
+        </div>
 
         <div style={styles.brand}>
           <div style={styles.brandTitle}>Safra Vision</div>

--- a/src/styles.js
+++ b/src/styles.js
@@ -1,0 +1,96 @@
+export const styles = {
+  root: { position: "relative", width: "100vw", height: "100vh", overflow: "hidden", background: "#0b1220" },
+  scene: { position: "absolute", inset: 0 },
+
+  homeLayer: { position: "absolute", inset: 0, background: "#F7FAFC" },
+  revealMask: {
+    position: "absolute",
+    inset: 0,
+    background: "linear-gradient(90deg, rgba(255,255,255,0.00) 0%, rgba(255,255,255,0.18) 40%, rgba(255,255,255,0.00) 100%)",
+    pointerEvents: "none",
+    mixBlendMode: "overlay",
+  },
+
+  soyMask: { position: "absolute", inset: 0, pointerEvents: "none" },
+  cutMask: { position: "absolute", inset: 0, pointerEvents: "none" },
+
+  // Campo full-screen
+  fieldFull: { position: "absolute", inset: 0, background: "#1c4a22" },
+  fieldBaseA: {
+    position: "absolute",
+    inset: 0,
+    background:
+      "radial-gradient(circle at 20% 30%, rgba(70,160,85,0.55), rgba(0,0,0,0) 55%), radial-gradient(circle at 80% 65%, rgba(55,130,70,0.55), rgba(0,0,0,0) 58%), linear-gradient(180deg, #2e7d32 0%, #1f5d26 60%, #18481f 100%)",
+    filter: "saturate(1.10)",
+  },
+  fieldBaseB: {
+    position: "absolute",
+    inset: 0,
+    background:
+      "repeating-linear-gradient(115deg, rgba(0,0,0,0.00) 0px, rgba(0,0,0,0.00) 14px, rgba(0,0,0,0.08) 14px, rgba(0,0,0,0.08) 19px)",
+    opacity: 0.55,
+    mixBlendMode: "multiply",
+  },
+  fieldVignette: {
+    position: "absolute",
+    inset: 0,
+    background: "radial-gradient(circle at 50% 45%, rgba(0,0,0,0.0), rgba(0,0,0,0.35) 78%)",
+    pointerEvents: "none",
+  },
+
+  // Área colhida
+  cutFull: { position: "absolute", inset: 0, background: "linear-gradient(180deg, #8b5e34 0%, #6f4728 55%, #5a3a20 100%)" },
+  stubbleRows: {
+    position: "absolute",
+    inset: 0,
+    background:
+      "repeating-linear-gradient(115deg, rgba(255,255,255,0.00) 0px, rgba(255,255,255,0.00) 16px, rgba(0,0,0,0.18) 16px, rgba(0,0,0,0.18) 20px)",
+    opacity: 0.55,
+  },
+  stubbleNoise: {
+    position: "absolute",
+    inset: 0,
+    background:
+      "radial-gradient(circle at 20% 70%, rgba(0,0,0,0.16), rgba(0,0,0,0) 42%), radial-gradient(circle at 80% 30%, rgba(0,0,0,0.12), rgba(0,0,0,0) 46%)",
+    mixBlendMode: "multiply",
+  },
+  stubbleVignette: { position: "absolute", inset: 0, background: "radial-gradient(circle at 50% 50%, rgba(0,0,0,0), rgba(0,0,0,0.22) 78%)" },
+
+  leafBlobA: { position: "absolute", left: "8vw", top: "58vh", width: 340, height: 250, background: "radial-gradient(circle at 30% 40%, rgba(10,30,12,0.35), rgba(0,0,0,0) 62%)", filter: "blur(2px)" },
+  leafBlobB: { position: "absolute", left: "66vw", top: "44vh", width: 420, height: 300, background: "radial-gradient(circle at 30% 40%, rgba(10,30,12,0.32), rgba(0,0,0,0) 65%)", filter: "blur(2px)" },
+  leafBlobC: { position: "absolute", left: "30vw", top: "20vh", width: 520, height: 380, background: "radial-gradient(circle at 30% 40%, rgba(0,0,0,0.18), rgba(0,0,0,0) 62%)", filter: "blur(3px)" },
+
+  // Corte (com blur dinâmico aplicado no componente)
+  edgeShadow: { position: "absolute", top: 0, bottom: 0, width: 22, background: "linear-gradient(90deg, rgba(0,0,0,0.28), rgba(0,0,0,0))", pointerEvents: "none" },
+
+  // Harvester wrap
+  harvesterWrap: { position: "absolute", top: "50vh", left: 0, width: 460, height: 300, pointerEvents: "none" },
+
+  // Canvas particles
+  particlesCanvas: { position: "absolute", inset: 0, pointerEvents: "none" },
+
+  // HUD
+  hud: {
+    position: "absolute",
+    left: 34,
+    top: 26,
+    zIndex: 5,
+    color: "#0F172A",
+    fontFamily: "ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial",
+  },
+  loadingText: { fontSize: 18, fontWeight: 800, opacity: 0.92, textShadow: "0 1px 0 rgba(255,255,255,0.35)" },
+  progressOuter: { marginTop: 10, width: 420, height: 14, borderRadius: 999, background: "rgba(226,232,240,0.95)", overflow: "hidden", boxShadow: "0 10px 28px rgba(0,0,0,0.10)" },
+  progressInner: { height: "100%", width: "100%", borderRadius: 999, background: "linear-gradient(90deg, #3AA66A, #6FCF97)" },
+
+  fade: { position: "absolute", inset: 0, background: "#FFFFFF", pointerEvents: "none" },
+
+  // Home mock
+  homeMock: { position: "absolute", inset: 0, background: "#F7FAFC", fontFamily: "ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial" },
+  homeTop: { height: 90, background: "#fff", borderBottom: "1px solid rgba(15,23,42,0.08)", display: "flex", alignItems: "center", padding: "0 40px" },
+  homeTitle: { fontSize: 40, fontWeight: 900, color: "#0F172A" },
+  homeCards: { padding: 40, display: "grid", gap: 22, width: 420 },
+  card: { background: "#fff", border: "2px solid rgba(15,23,42,0.08)", borderRadius: 22, padding: 20, boxShadow: "0 14px 28px rgba(0,0,0,0.06)" },
+  cardTitle: { fontSize: 18, fontWeight: 800, color: "#111827" },
+  cardBar: { marginTop: 14, height: 26, borderRadius: 16, background: "rgba(226,232,240,0.8)" },
+  homeBottomPill: { position: "absolute", left: 40, bottom: 40, padding: "12px 18px", borderRadius: 999, background: "#fff", border: "2px solid rgba(15,23,42,0.08)", color: "#334155", fontWeight: 800, boxShadow: "0 14px 28px rgba(0,0,0,0.06)", width: "fit-content" },
+};

--- a/src/useParticlesCanvas.js
+++ b/src/useParticlesCanvas.js
@@ -1,0 +1,79 @@
+import { useEffect, useRef, useCallback } from "react";
+
+export default function useParticlesCanvas({ getSize }) {
+  const canvasRef = useRef(null);
+  const rafRef = useRef(null);
+  const partsRef = useRef([]);
+  const lastRef = useRef(performance.now());
+
+  const emitAt = useCallback((x, y, count = 6) => {
+    const parts = partsRef.current;
+    for (let i = 0; i < count; i++) {
+      parts.push({
+        x: x + (Math.random() - 0.5) * 18,
+        y: y + (Math.random() - 0.5) * 14,
+        vx: -60 - Math.random() * 120,
+        vy: -30 + Math.random() * 60,
+        life: 0.6 + Math.random() * 0.7,
+        size: 1.2 + Math.random() * 3.2,
+      });
+    }
+    // limita pra não explodir
+    if (parts.length > 700) parts.splice(0, parts.length - 700);
+  }, []);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+
+    const ctx = canvas.getContext("2d");
+
+    const tick = (now) => {
+      const dt = Math.min(0.033, (now - lastRef.current) / 1000);
+      lastRef.current = now;
+
+      const { width, height } = getSize();
+      canvas.width = Math.floor(width * devicePixelRatio);
+      canvas.height = Math.floor(height * devicePixelRatio);
+      canvas.style.width = `${width}px`;
+      canvas.style.height = `${height}px`;
+      ctx.setTransform(devicePixelRatio, 0, 0, devicePixelRatio, 0, 0);
+
+      ctx.clearRect(0, 0, width, height);
+
+      const parts = partsRef.current;
+
+      // update
+      for (const p of parts) {
+        p.x += p.vx * dt;
+        p.y += p.vy * dt;
+        p.vy += 60 * dt; // gravidade
+        p.life -= dt;
+      }
+
+      // draw
+      ctx.globalCompositeOperation = "lighter";
+      for (const p of parts) {
+        if (p.life <= 0) continue;
+        const a = Math.max(0, Math.min(1, p.life / 1.2));
+        ctx.fillStyle = `rgba(${Math.floor(170 + 40 * (1 - a))}, ${Math.floor(150 + 30 * (1 - a))}, ${Math.floor(
+          110 + 20 * (1 - a)
+        )}, ${0.9 * a})`;
+        ctx.beginPath();
+        ctx.arc(p.x, p.y, p.size, 0, Math.PI * 2);
+        ctx.fill();
+      }
+      ctx.globalCompositeOperation = "source-over";
+
+      // cull
+      partsRef.current = parts.filter((p) => p.life > 0 && p.x > -200 && p.y < height + 200);
+
+      rafRef.current = requestAnimationFrame(tick);
+    };
+
+    rafRef.current = requestAnimationFrame(tick);
+    return () => cancelAnimationFrame(rafRef.current);
+  }, [getSize]);
+
+  return { canvasRef, emitAt };
+}

--- a/vite.config.js
+++ b/vite.config.js
@@ -5,7 +5,7 @@ export default defineConfig({
   plugins: [react()],
   esbuild: {
     loader: 'jsx',
-    include: /src\/.*\.js$/,
+    include: /src\/.*\.[jt]sx?$/,
     exclude: [],
   },
   optimizeDeps: {


### PR DESCRIPTION
### Motivation

- Introduce a richer animated splash experience with a harvest-themed animation, particle effects and a masked reveal of the home UI. 
- Provide a lightweight mock home so the animation can preview the reveal behavior before the real app wiring is restored. 
- Improve build tooling to accept TypeScript/JSX style file extensions for esbuild processing.

### Description

- Adds a new `SplashHarvestPro` component that drives an animated harvester reveal using `framer-motion`, a canvas particle system, and a responsive cut/mask animation. 
- Adds `HarvesterSVG.js` (decorative, animated SVG), `useParticlesCanvas.js` (particle emitter and canvas renderer), `HomeMock.js` (simple mocked home UI) and `styles.js` (centralized styles used by the splash and mocks). 
- Updates `App.js` to show the new splash and transition to a placeholder home once the animation completes. 
- Enhances the existing `components/fx/HarvestSplashScreen.js` to include a moving machine fallback SVG for environments where the PIXI implementation might not run. 
- Updates `vite.config.js` to broaden the `esbuild.include` pattern to `/.src\/.*\.[jt]sx?$/` so `.ts`, `.tsx`, `.js`, and `.jsx` files are covered by the loader.

### Testing

- Started the dev server with `npm run dev` and confirmed the splash mounts and the mock home is revealed after the animation completes. 
- Performed a production build with `vite build` and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_699fb483bdf88328840985cb083e1764)