### PR TITLE
feat: auto-detectar região e aplicar idioma inicial

### DIFF
--- a/public/static/icons/japao.svg
+++ b/public/static/icons/japao.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="16" viewBox="0 0 24 16" fill="none">
+  <rect width="24" height="16" rx="2" fill="white"/>
+  <circle cx="12" cy="8" r="4.2" fill="#BC002D"/>
+  <rect x="0.25" y="0.25" width="23.5" height="15.5" rx="1.75" stroke="#E5E7EB" stroke-width="0.5"/>
+</svg>

--- a/src/layouts/dashboard/LanguagePopover.js
+++ b/src/layouts/dashboard/LanguagePopover.js
@@ -10,11 +10,80 @@ const LANGS = [
   { value: 'pt', label: 'Português (Brasil)', icon: '/static/icons/brasil.svg', countries: ['BR'] },
   { value: 'es', label: 'Español', icon: '/static/icons/espanha.svg', countries: ['ES'] },
   { value: 'fr', label: 'Français', icon: '/static/icons/franca.svg', countries: ['FR'] },
+  { value: 'ja', label: '日本語', icon: '/static/icons/japao.svg', countries: ['JP'] },
 ];
+
+const COUNTRY_LANGUAGE_MAP = {
+  BR: 'pt',
+  PT: 'pt',
+  FR: 'fr',
+  BE: 'fr',
+  CA: 'en',
+  US: 'en',
+  GB: 'en',
+  AU: 'en',
+  NZ: 'en',
+  IE: 'en',
+  JP: 'ja',
+  ES: 'es',
+  MX: 'es',
+  AR: 'es',
+  CL: 'es',
+  CO: 'es',
+  PE: 'es',
+  UY: 'es',
+  PY: 'es',
+  BO: 'es',
+  VE: 'es',
+  EC: 'es',
+  CR: 'es',
+  PA: 'es',
+  GT: 'es',
+  HN: 'es',
+  SV: 'es',
+  NI: 'es',
+  DO: 'es',
+  DE: 'de',
+  AT: 'de',
+  CH: 'de',
+  IT: 'it',
+  NL: 'nl',
+  PL: 'pl',
+  SE: 'sv',
+  NO: 'no',
+  DK: 'da',
+  FI: 'fi',
+  CZ: 'cs',
+  GR: 'el',
+  TR: 'tr',
+  RO: 'ro',
+  HU: 'hu',
+  RU: 'ru',
+  UA: 'uk',
+  IL: 'iw',
+  SA: 'ar',
+  AE: 'ar',
+  EG: 'ar',
+  MA: 'ar',
+  DZ: 'ar',
+  IN: 'hi',
+  TH: 'th',
+  VN: 'vi',
+  ID: 'id',
+  KR: 'ko',
+  CN: 'zh-CN',
+  TW: 'zh-TW',
+};
+
+const GOOGLE_TRANSLATE_LANGUAGES = [
+  ...new Set([...LANGS.map((lang) => lang.value), ...Object.values(COUNTRY_LANGUAGE_MAP)]),
+].join(',');
 
 const mapCountryToLanguage = (countryCode) => {
   if (!countryCode) return 'pt';
   const upperCountryCode = countryCode.toUpperCase();
+  const mappedLanguage = COUNTRY_LANGUAGE_MAP[upperCountryCode];
+  if (mappedLanguage) return mappedLanguage;
   const language = LANGS.find((lang) => lang.countries.includes(upperCountryCode));
   return language?.value || 'pt';
 };
@@ -53,7 +122,7 @@ const ensureGoogleTranslate = () => {
         {
           pageLanguage: 'pt',
           autoDisplay: false,
-          includedLanguages: LANGS.map((lang) => lang.value).join(','),
+          includedLanguages: GOOGLE_TRANSLATE_LANGUAGES,
         },
         'google_translate_element'
       );


### PR DESCRIPTION
### Motivation
- Melhorar a experiência do usuário definindo automaticamente o idioma inicial com base na região de acesso (ex.: BR→pt, FR→fr, US→en, JP→ja) para evitar que usuários precisem selecionar manualmente o idioma.

### Description
- Adicionei mapeamento de países para idiomas em `src/layouts/dashboard/LanguagePopover.js` através de `COUNTRY_LANGUAGE_MAP` e passei a priorizar esse mapeamento na função `mapCountryToLanguage`.
- Incluí `ja` (japonês) na lista visível de idiomas (`LANGS`) e adicionei o ícone `public/static/icons/japao.svg` para o seletor.
- Ampliei a lista `includedLanguages` usada pelo widget do Google Translate para cobrir tanto os idiomas do seletor quanto os idiomas retornados pelo mapeamento de países, via `GOOGLE_TRANSLATE_LANGUAGES`.
- Mantive prioridade para preferência manual armazenada em `localStorage`, uso `ipapi.co` para detecção por IP quando não há preferência e fallback para o idioma do navegador ou `pt`.

### Testing
- Executado `npm run lint -- src/layouts/dashboard/LanguagePopover.js` com sucesso.
- Aplicação iniciada localmente com `npm run dev -- --host 0.0.0.0 --port 4173` para validação visual sem erros.
- Script de navegação gerado via Playwright (`mcp__browser_tools__run_playwright_script`) rodou e gerou capturas (`artifacts/dashboard-language.png`) confirmando renderização do seletor de idioma; todas as validações automáticas concluídas com sucesso.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699fcd95218c83289b147e251e8859cc)