### PR TITLE
Redireciona para login após splash screen

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,5 +1,6 @@
 import React, { useState } from "react";
 import SplashHarvestPro from "./SplashHarvestPro";
+import Router from "./routes";
 
 export default function App() {
   const [showSplash, setShowSplash] = useState(true);
@@ -7,9 +8,6 @@ export default function App() {
   return showSplash ? (
     <SplashHarvestPro onFinish={() => setShowSplash(false)} />
   ) : (
-    <div style={{ padding: 40, fontFamily: "system-ui" }}>
-      <h1>Minha Home real</h1>
-      <p>Conteúdo da HomePage aqui...</p>
-    </div>
+    <Router />
   );
 }

--- a/src/index.js
+++ b/src/index.js
@@ -11,6 +11,7 @@ import App from './App';
 import * as serviceWorker from './serviceWorker';
 import { tryLoadAndStartRecorder } from '@alwaysmeticulous/recorder-loader';
 import { initReliabilityTelemetry } from './services/platformReliability';
+import { AuthProvider } from './auth/AuthContext';
 
 // ----------------------------------------------------------------------
 
@@ -58,9 +59,11 @@ Sentry.init({
 
 const appTree = (
   <HelmetProvider>
-    <BrowserRouter>
-      <App />
-    </BrowserRouter>
+    <AuthProvider>
+      <BrowserRouter>
+        <App />
+      </BrowserRouter>
+    </AuthProvider>
   </HelmetProvider>
 );
 


### PR DESCRIPTION
### Motivation
- Garantir que, ao terminar a splash screen, a aplicação navegue para as rotas reais (incluindo `/login`) em vez de exibir a home mockada. 
- Evitar erros de autenticação no fluxo de roteamento fornecendo o contexto de autenticação durante o bootstrap da aplicação.

### Description
- Substitui a home mock em `src/App.js` para renderizar o `Router` após o término da splash screen (arquivo `src/App.js`).
- Adiciona import e envolve a árvore da aplicação com `AuthProvider` em `src/index.js` para fornecer o contexto de autenticação às rotas (arquivo `src/index.js`).
- Pequena reorganização do bootstrap da aplicação para manter `BrowserRouter` dentro do `AuthProvider`.

### Testing
- Executado `npm run build` com sucesso, sem erros de build.
- Executado script automático com Playwright que navegou para `/`, aguardou a splash e verificou que a URL final é `/login`, e salvou uma screenshot mostrando a tela de login após a splash (artifacts gerados com sucesso).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699fdad091a08328a6f47f83c9af3ae4)