### PR TITLE
Reduz velocidade da colheitadeira na splash

### DIFF
--- a/src/pages/Login.js
+++ b/src/pages/Login.js
@@ -140,7 +140,7 @@ export default function Login() {
   if (showSplash) {
     return (
       <Page title="Login">
-        <HarvestSplashScreen durationSec={4} onComplete={() => setShowSplash(false)} />
+        <HarvestSplashScreen durationSec={12} onComplete={() => setShowSplash(false)} />
       </Page>
     );
   }


### PR DESCRIPTION
### Motivation
- Deixar a passagem da colheitadeira na tela splash do login significativamente mais lenta para melhorar a percepção da animação e leitura do efeito.

### Description
- Aumentei o `durationSec` passado para `HarvestSplashScreen` de `4` para `12` no arquivo `src/pages/Login.js` (`<HarvestSplashScreen durationSec={12} ... />`).

### Testing
- Rodei `npx eslint src/pages/Login.js` e o lint passou sem erros; a validação automática foi bem-sucedida.
- Tentei capturar uma screenshot com Playwright para validar visualmente, mas o Chromium no ambiente apresentou `SIGSEGV` e a execução falhou.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699fdaf647148328bac2d85c23533292)