### PR TITLE
Remove duplicate splash screen from login flow

### DIFF
--- a/src/pages/Login.js
+++ b/src/pages/Login.js
@@ -1,5 +1,4 @@
 import { Link as RouterLink } from 'react-router-dom';
-import { useState } from 'react';
 // @mui
 import { alpha, keyframes, styled } from '@mui/material/styles';
 import { Card, Link, Container, Typography } from '@mui/material';
@@ -9,7 +8,6 @@ import useResponsive from '../hooks/useResponsive';
 // components
 import Page from '../components/Page';
 import Logo from '../components/Logo';
-import HarvestSplashScreen from '../components/fx/HarvestSplashScreen';
 // sections
 import { LoginForm } from '../sections/auth/login';
 import AuthSocial from '../sections/auth/AuthSocial';
@@ -125,7 +123,6 @@ const ContentStyle = styled('div')(({ theme }) => ({
 // ----------------------------------------------------------------------
 
 export default function Login() {
-  const [showSplash, setShowSplash] = useState(true);
   const smUp = useResponsive('up', 'sm');
 
   const mdUp = useResponsive('up', 'md');
@@ -136,14 +133,6 @@ export default function Login() {
   const rightLeafRotation = useTransform(scrollYProgress, [0, 1], [12, -18]);
   const rightLeafY = useTransform(scrollYProgress, [0, 1], [0, 10]);
   const cableWave = useTransform(scrollYProgress, [0, 0.25, 0.5, 0.75, 1], [0, 8, 0, -8, 0]);
-
-  if (showSplash) {
-    return (
-      <Page title="Login">
-        <HarvestSplashScreen durationSec={12} onComplete={() => setShowSplash(false)} />
-      </Page>
-    );
-  }
 
   return (
     <Page title="Login">


### PR DESCRIPTION
### Motivation
- The app showed two splash screens on startup because the top-level `App` renders `SplashHarvestPro` and `Login` also gated rendering behind a `HarvestSplashScreen`; the change removes the redundant second splash so users see only the initial app splash.

### Description
- Removed the `showSplash` state and its conditional rendering that displayed `HarvestSplashScreen` from `src/pages/Login.js`.
- Removed the now-unused `useState` and `HarvestSplashScreen` imports from `src/pages/Login.js`.
- `Login` now renders its login content immediately instead of waiting for a page-specific splash.
- Only `src/pages/Login.js` was modified.

### Testing
- Ran `npm run build` and the build completed successfully.
- Started the dev server with `npm run dev -- --host 0.0.0.0 --port 4173` and it started without errors.
- Automated Playwright script navigated to the app and captured a screenshot showing the login page without a second splash (script succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699fde56c4c48328b0cb3898884db9c1)