### PR TITLE
Diminuir velocidade da colheitadeira na splash (11.5s → 21s)

### DIFF
--- a/src/SplashHarvestPro.js
+++ b/src/SplashHarvestPro.js
@@ -52,7 +52,7 @@ export default function SplashHarvestPro({ onFinish }) {
 
   useEffect(() => {
     const controls = animate(p, 1, {
-      duration: 11.5,
+      duration: 21,
       ease: [0.2, 0.8, 0.2, 1],
       onComplete: () => {
         setDone(true);


### PR DESCRIPTION
### Motivation
- Tornar o movimento da colheitadeira na tela de splash muito mais lento e suave para melhorar a percepção visual durante o carregamento.

### Description
- Ajustado o tempo da animação principal em `src/SplashHarvestPro.js`, alterando a propriedade `duration` de `11.5` para `21` na chamada `animate(p, 1, { ... })` para reduzir substancialmente a velocidade do deslocamento.

### Testing
- Executado `npm run lint -- src/SplashHarvestPro.js` e a verificação de lint passou com sucesso.
- Capturada uma screenshot automatizada via Playwright (`artifacts/splash-slower-harvester.png`) para validar visualmente a alteração e o script foi executado com sucesso.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699fe29e94548328bf6eac8a99a9a854)