### PR TITLE
Adjust splash harvester to linear low-speed movement

### DIFF
--- a/src/SplashHarvestPro.js
+++ b/src/SplashHarvestPro.js
@@ -11,7 +11,7 @@ export default function SplashHarvestPro({ onFinish }) {
 
   const p = useMotionValue(0);
 
-  // Spring só pra suavizar um pouco o recorte/blur
+  // Spring só para o HUD (barra), sem afetar a velocidade da colheitadeira
   const pSpring = useSpring(p, { stiffness: 120, damping: 22, mass: 0.6 });
 
   // dimensões responsivas
@@ -27,8 +27,9 @@ export default function SplashHarvestPro({ onFinish }) {
     return () => window.removeEventListener("resize", onResize);
   }, []);
 
-  const harvX = useTransform(pSpring, [0, 1], [-460, W + 160]);
-  const cutX = useTransform(pSpring, [0, 1], [0, W]);
+  // Movimento principal linear e constante
+  const harvX = useTransform(p, [0, 1], [-460, W + 160]);
+  const cutX = useTransform(p, [0, 1], [0, W]);
 
   // blur dinâmico por velocidade (motion blur)
   const prevX = useRef(0);
@@ -52,8 +53,8 @@ export default function SplashHarvestPro({ onFinish }) {
 
   useEffect(() => {
     const controls = animate(p, 1, {
-      duration: 21,
-      ease: [0.2, 0.8, 0.2, 1],
+      duration: 24,
+      ease: "linear",
       onComplete: () => {
         setDone(true);
         setTimeout(() => onFinish?.(), 320);


### PR DESCRIPTION
### Motivation
- A colheitadeira na tela splash aparentava acelerar por causa do smoothing aplicado ao valor principal de progresso, exigindo movimento linear e mais lento para manter velocidade baixa e perceptivelmente constante.
- Manter suavização apenas no HUD evita discrepância entre a barra de progresso e a posição visual da colheitadeira.

### Description
- Switched `harvX` and `cutX` to derive from the base motion value `p` instead of the spring-smoothed `pSpring` (file `src/SplashHarvestPro.js`).
- Kept `useSpring(p, ...)` for HUD smoothing only, with a clarifying comment.
- Increased the main animation `duration` from `21` to `24` seconds and set `ease` to `"linear"` to slow and linearize the harvester motion.

### Testing
- Ran `npm run lint -- src/SplashHarvestPro.js` which completed successfully.
- Ran Playwright screenshot scripts: Chromium run failed in this environment with a browser crash (SIGSEGV), while Firefox run completed and produced a screenshot artifact (`artifacts/splash-linear-speed.png`).
- Started the dev server with `npm run dev` and visually inspected the updated splash during the automated screenshot run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699fe37951c483289f4aa8b4e900fcbb)