### PR TITLE
Redirect to login after splash screen

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,12 +1,19 @@
 import React, { useState } from "react";
+import { useNavigate } from 'react-router-dom';
 import SplashHarvestPro from "./SplashHarvestPro";
 import Router from "./routes";
 
 export default function App() {
   const [showSplash, setShowSplash] = useState(true);
+  const navigate = useNavigate();
+
+  const handleSplashFinish = () => {
+    setShowSplash(false);
+    navigate('/login', { replace: true });
+  };
 
   return showSplash ? (
-    <SplashHarvestPro onFinish={() => setShowSplash(false)} />
+    <SplashHarvestPro onFinish={handleSplashFinish} />
   ) : (
     <Router />
   );


### PR DESCRIPTION
### Motivation
- Ensure that once the splash (`SplashHarvestPro`) finishes, the app shows the login UI by navigating to the `/login` route so `LoginForm` is presented immediately.

### Description
- Updated `src/App.js` to import `useNavigate` from `react-router-dom`, added a `handleSplashFinish` handler that sets `showSplash` to `false` and calls `navigate('/login', { replace: true })`, and passed this handler to `SplashHarvestPro` via `onFinish`.

### Testing
- Built the app with `npm run build` which completed successfully, started the dev server with `npm run dev` and verified the flow by running a Playwright script that loaded `http://127.0.0.1:4173/` and captured a screenshot after the splash; all automated checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699fe85b2378832882df3655d7950fac)