### PR TITLE
Register global error handlers only in production to prevent splash redirect to /404

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -19,6 +19,7 @@ const rootElement = document.getElementById('root');
 
 const ERROR_ROUTE_PATH = '/404';
 let hasRedirectedToErrorPage = false;
+const shouldHandleGlobalErrors = isProduction();
 
 function redirectToErrorPage() {
   if (window.location.pathname === ERROR_ROUTE_PATH || hasRedirectedToErrorPage) {
@@ -30,22 +31,24 @@ function redirectToErrorPage() {
   window.dispatchEvent(new PopStateEvent('popstate'));
 }
 
-window.addEventListener('error', (event) => {
-  // Evita redirecionar por falhas não fatais (ex.: erro de carregamento de imagem/extensão).
-  if (!(event instanceof ErrorEvent) || !event.error) {
-    return;
-  }
+if (shouldHandleGlobalErrors) {
+  window.addEventListener('error', (event) => {
+    // Evita redirecionar por falhas não fatais (ex.: erro de carregamento de imagem/extensão).
+    if (!(event instanceof ErrorEvent) || !event.error) {
+      return;
+    }
 
-  redirectToErrorPage();
-});
+    redirectToErrorPage();
+  });
 
-window.addEventListener('unhandledrejection', (event) => {
-  if (!(event.reason instanceof Error)) {
-    return;
-  }
+  window.addEventListener('unhandledrejection', (event) => {
+    if (!(event.reason instanceof Error)) {
+      return;
+    }
 
-  redirectToErrorPage();
-});
+    redirectToErrorPage();
+  });
+}
 
 async function startApp() {
   if (!isProduction()) {


### PR DESCRIPTION
### Motivation
- The splash screen navigation was being hijacked by global `error`/`unhandledrejection` handlers in non-production environments, causing a redirect to `/404` instead of the intended `/login` after the animation completes.
- The change aims to keep the production fallback to `/404` for fatal runtime failures while avoiding noisy/dev-only errors (e.g. extensions) from breaking the local developer flow.

### Description
- Added a `shouldHandleGlobalErrors` flag that uses `isProduction()` to decide whether to register global error handlers in `src/index.js`.
- Wrapped the `window.addEventListener('error', ...)` and `window.addEventListener('unhandledrejection', ...)` registrations in a `if (shouldHandleGlobalErrors) { ... }` block so they run only in production.
- Preserved the existing `redirectToErrorPage()` logic and production behavior while preventing the handlers from running in localhost/dev.

### Testing
- Ran `npx eslint src/index.js` and it completed successfully.
- Started the app with `npm run dev -- --host 0.0.0.0 --port 4173` and the dev server launched successfully.
- Automated Playwright verification was executed that waited for the splash duration and captured a screenshot, and the final URL was confirmed to be `/login` (no redirect to `/404`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699febe4a1d0832893c4350688a0dc16)