### PR TITLE
Fix redirect to login when opening protected dashboard routes unauthenticated

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,10 +1,11 @@
 import React, { useState } from "react";
-import { useNavigate } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
 import SplashHarvestPro from "./SplashHarvestPro";
 import Router from "./routes";
 
 export default function App() {
-  const [showSplash, setShowSplash] = useState(true);
+  const location = useLocation();
+  const [showSplash, setShowSplash] = useState(location.pathname === '/');
   const navigate = useNavigate();
 
   const handleSplashFinish = () => {


### PR DESCRIPTION
### Motivation
- O `App` estava exibindo a tela de splash sempre, bloqueando a inicialização das rotas e impedindo que o guard `RequireAuth` redirecionasse imediatamente para `/login` quando o usuário acessava uma rota protegida diretamente.

### Description
- Atualizei `src/App.js` para importar `useLocation` e inicializar `showSplash` com `location.pathname === '/'`, fazendo com que a splash seja exibida somente na rota raiz; mantive `handleSplashFinish` navegando para `/login` após a splash.

### Testing
- Rodei o build com `npm run -s build` e a compilação foi concluída com sucesso; apenas `src/App.js` foi alterado.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699fee0571c0832ebdf8eadf7260143d)