### PR TITLE
Corrige redirecionamento do /dashboard e rota duplicada `integracoes`

### DIFF
--- a/src/routes.js
+++ b/src/routes.js
@@ -37,6 +37,7 @@ export default function Router() {
         </RequireAuth>
       ),
       children: [
+        { index: true, element: <Navigate to="app" replace /> },
         { path: 'app', element: <DashboardApp /> },
         { path: 'user', element: <User /> },
         { path: 'products', element: <Products /> },
@@ -51,7 +52,7 @@ export default function Router() {
         { path: 'assinaturas', element: <Subscriptions /> },
         { path: 'integracoes', element: <Integrations /> },
         { path: 'suporte', element: <HelpCenter /> },
-        { path: 'integracoes', element: <IntegrationsOps /> },
+        { path: 'integracoes/ops', element: <IntegrationsOps /> },
       ],
     },
     {


### PR DESCRIPTION
### Motivation
- Corrigir fluxo pós-login onde acessar `/dashboard` deixava o layout sem conteúdo visível, garantindo que a raiz do dashboard direcione para a página principal do app. 
- Evitar ambiguidade de roteamento causada por duas rotas com o mesmo `path: 'integracoes'` que poderiam causar matching incorreto.

### Description
- Adicionada rota index filha em `src/routes.js`: `{ index: true, element: <Navigate to="app" replace /> }` para que `/dashboard` redirecione para `/dashboard/app`.
- Alterado o caminho de `IntegrationsOps` de `integracoes` para `integracoes/ops` em `src/routes.js` para eliminar colisão de rota.
- Nenhuma outra modificação estrutural foi necessária; apenas ajustes de rotas na lista de `children` do `path: '/dashboard'`.

### Testing
- Executado `npm run lint` e o lint passou sem erros.
- Servidor de desenvolvimento iniciado com `npm run dev` e verificado via automação de navegador que o login leva à URL final `/dashboard/app`.
- Teste automatizado com Playwright simulou login (incluindo código 2FA do ambiente de demo), navegou para `/dashboard` e capturou screenshot comprovando o redirecionamento correto; verificado como bem-sucedido.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699fefb83f64832e92e20b639b6ff142)