### PR TITLE
Ensure splash always navigates to login (add forceLogin flag)

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -10,7 +10,7 @@ export default function App() {
 
   const handleSplashFinish = () => {
     setShowSplash(false);
-    navigate('/login', { replace: true });
+    navigate('/login', { replace: true, state: { forceLogin: true } });
   };
 
   return showSplash ? (

--- a/src/components/auth/RedirectIfAuth.js
+++ b/src/components/auth/RedirectIfAuth.js
@@ -1,11 +1,13 @@
 import PropTypes from 'prop-types';
-import { Navigate } from 'react-router-dom';
+import { Navigate, useLocation } from 'react-router-dom';
 import useAuth from '../../auth/useAuth';
 
 export default function RedirectIfAuth({ children }) {
+  const location = useLocation();
   const { authenticated } = useAuth();
+  const forceLogin = Boolean(location.state?.forceLogin);
 
-  if (authenticated) {
+  if (authenticated && !forceLogin) {
     return <Navigate to="/dashboard/app" replace />;
   }
 


### PR DESCRIPTION
### Motivation
- The splash flow must always lead to the login screen even if a user is already authenticated after the splash finishes.
- Prevent automatic bounce from `/login` to `/dashboard/app` when landing from the splash screen.

### Description
- Send a `forceLogin: true` state when navigating to `/login` from the splash completion handler in `src/App.js` by updating the `handleSplashFinish` call to `navigate('/login', { replace: true, state: { forceLogin: true } })`.
- Update `src/components/auth/RedirectIfAuth.js` to read `location.state?.forceLogin` and skip the redirect to `/dashboard/app` when `forceLogin` is present so the login page remains shown.
- Changes touch `src/App.js` and `src/components/auth/RedirectIfAuth.js` and implement the minimal state flag to control redirect behavior.

### Testing
- Ran `npm run lint -- src/App.js src/components/auth/RedirectIfAuth.js` and it completed successfully.
- Built the production bundle with `npm run build` and the build succeeded.
- Started the dev server (`vite`) and confirmed it served the app locally.
- Captured an automated browser screenshot via Playwright after the splash timeout to validate the app lands on the login page; the screenshot artifact was produced successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699ff14cb2ec832ea9b6a9dce2fc9e35)