### PR TITLE
Always show splash screen on initial load

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,11 +1,10 @@
 import React, { useState } from "react";
-import { useLocation, useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 import SplashHarvestPro from "./SplashHarvestPro";
 import Router from "./routes";
 
 export default function App() {
-  const location = useLocation();
-  const [showSplash, setShowSplash] = useState(location.pathname === '/');
+  const [showSplash, setShowSplash] = useState(true);
   const navigate = useNavigate();
 
   const handleSplashFinish = () => {


### PR DESCRIPTION
### Motivation
- Fix a bug where the splash screen was skipped when users landed on deep links (for example on Vercel) because the UI only showed the splash when `location.pathname === '/'`.

### Description
- Initialize the splash flag to always show by setting `useState(true)` in `src/App.js` instead of checking `location.pathname`.
- Remove the now-unused `useLocation` import from `src/App.js`.
- Preserve existing completion behavior where `SplashHarvestPro` calls `onFinish`, which sets the splash off and navigates to `/login` with `replace: true` and `state: { forceLogin: true }`.

### Testing
- Ran `npm run build` and the production build completed successfully. 
- Started the dev server with `npm run dev -- --host 0.0.0.0 --port 4173` and validated the splash appears on first load using an automated Playwright script that saved a screenshot, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a04152fd40832e892fe3664a79b794)