### PR TITLE
chore: update site favicon to use public/favicon SVG

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,8 +3,8 @@
 <head>
   <meta charset="utf-8" />
   <!-- Favicon -->
-  <link rel="apple-touch-icon" href="/static/hortelan-logo.svg">
-  <link rel="icon" type="image/svg+xml" href="/static/hortelan-logo.svg">
+  <link rel="apple-touch-icon" href="/favicon/hortelan-logo.svg">
+  <link rel="icon" type="image/svg+xml" href="/favicon/hortelan-logo.svg">
   <meta name="theme-color" content="#000000" />
   <link rel="manifest" href="/manifest.json" />
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />

--- a/public/index.html
+++ b/public/index.html
@@ -3,8 +3,8 @@
 <head>
   <meta charset="utf-8" />
   <!-- Favicon -->
-  <link rel="apple-touch-icon" href="%PUBLIC_URL%/static/hortelan-logo.svg">
-  <link rel="icon" type="image/svg+xml" href="%PUBLIC_URL%/static/hortelan-logo.svg">
+  <link rel="apple-touch-icon" href="%PUBLIC_URL%/favicon/hortelan-logo.svg">
+  <link rel="icon" type="image/svg+xml" href="%PUBLIC_URL%/favicon/hortelan-logo.svg">
   <meta name="theme-color" content="#000000" />
   <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -3,12 +3,12 @@
   "name": "Hortelan AgTech Ltda V2.0 Systems ",
   "icons": [
     {
-      "src": "static/hortelan-logo.svg",
+      "src": "favicon/hortelan-logo.svg",
       "sizes": "any",
       "type": "image/svg+xml"
     },
     {
-      "src": "static/hortelan-logo.svg",
+      "src": "favicon/hortelan-logo.svg",
       "sizes": "any",
       "type": "image/svg+xml"
     }


### PR DESCRIPTION
### Motivation
- Ensure the site uses the SVG stored in `public/favicon/hortelan-logo.svg` as the canonical favicon and PWA icon instead of the `static/` path.

### Description
- Updated favicon links in the root `index.html` to point to `/favicon/hortelan-logo.svg` instead of `/static/hortelan-logo.svg`.
- Updated favicon links in `public/index.html` to point to `%PUBLIC_URL%/favicon/hortelan-logo.svg` instead of `%PUBLIC_URL%/static/hortelan-logo.svg`.
- Updated the `icons[].src` entries in `public/manifest.json` to use `favicon/hortelan-logo.svg` instead of `static/hortelan-logo.svg`.
- Files changed: `index.html`, `public/index.html`, `public/manifest.json`.

### Testing
- Ran `npm run build` and the production build completed successfully (build artifacts produced, with only bundle-size warnings).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a041a1facc832e91cb52f426aa63a8)