### PR TITLE
Fix splash screen flow on initial load (only redirect to /login from root)

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,15 +1,21 @@
 import React, { useState } from "react";
-import { useNavigate } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
 import SplashHarvestPro from "./SplashHarvestPro";
 import Router from "./routes";
 
 export default function App() {
   const [showSplash, setShowSplash] = useState(true);
   const navigate = useNavigate();
+  const location = useLocation();
 
   const handleSplashFinish = () => {
     setShowSplash(false);
-    navigate('/login', { replace: true, state: { forceLogin: true } });
+
+    // Garante a splash como primeira tela em qualquer rota de entrada.
+    // Faz o redirecionamento para login apenas quando o usuário abre a raiz.
+    if (location.pathname === '/') {
+      navigate('/login', { replace: true, state: { forceLogin: true } });
+    }
   };
 
   return showSplash ? (


### PR DESCRIPTION
### Motivation
- Prevent the splash from being skipped by post-splash navigation when the app is opened on a non-root route in the deployed environment, ensuring the splash is shown as the first screen on first load.

### Description
- Updated `src/App.js` to import `useLocation` and changed `handleSplashFinish` so it only calls `navigate('/login', { replace: true, state: { forceLogin: true } })` when `location.pathname === '/'`, otherwise it simply hides the splash and renders the app router.

### Testing
- Ran `npm run lint -- src/App.js` and it completed successfully.
- Ran `npm run build` and the production build completed successfully.
- Executed an automated Playwright script that opened `/` and produced a screenshot (`artifacts/splash-fixed.png`) confirming the splash renders on initial load.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a06cf20774832eb3984a91d8995a89)