### PR TITLE
Corrige redirecionamento pós-login (2FA) e aguarda login social para evitar navegar para /404

### DIFF
--- a/src/sections/auth/AuthSocial.js
+++ b/src/sections/auth/AuthSocial.js
@@ -5,6 +5,7 @@ import { Stack, Button, Divider, Typography, Alert } from '@mui/material';
 // component
 import Iconify from '../../components/Iconify';
 import useAuth from '../../auth/useAuth';
+import { DEFAULT_AUTH_REDIRECT, resolvePostAuthDestination } from '../../utils/authRedirect';
 
 // ----------------------------------------------------------------------
 
@@ -14,9 +15,9 @@ export default function AuthSocial() {
   const { loginWithSocial } = useAuth();
   const [socialError, setSocialError] = useState('');
 
-  const handleSocialLogin = (provider) => {
+  const handleSocialLogin = async (provider) => {
     setSocialError('');
-    const result = loginWithSocial({ provider, remember: true, trustDevice: true });
+    const result = await loginWithSocial({ provider, remember: true, trustDevice: true });
 
     if (result.error) {
       setSocialError(result.error);
@@ -28,7 +29,7 @@ export default function AuthSocial() {
       return;
     }
 
-    const destination = location.state?.from || '/dashboard/app';
+    const destination = resolvePostAuthDestination(location.state?.from || DEFAULT_AUTH_REDIRECT);
     navigate(destination, { replace: true });
   };
 

--- a/src/sections/auth/login/Login.js
+++ b/src/sections/auth/login/Login.js
@@ -16,6 +16,7 @@ import Logo from '../../../components/Logo';
 import Iconify from '../../../components/Iconify';
 import { FormProvider, RHFCheckbox, RHFTextField } from '../../../components/hook-form';
 import useAuth from '../../../auth/useAuth';
+import { DEFAULT_AUTH_REDIRECT, resolvePostAuthDestination } from '../../../utils/authRedirect';
 // sections
 import AuthSocial from '../AuthSocial';
 import { RegisterForm } from '../register';
@@ -185,7 +186,7 @@ function LoginFields() {
       return;
     }
 
-    const destination = location.state?.from || '/dashboard/app';
+    const destination = resolvePostAuthDestination(location.state?.from || DEFAULT_AUTH_REDIRECT);
     navigate(destination, { replace: true });
   };
 

--- a/src/utils/authRedirect.js
+++ b/src/utils/authRedirect.js
@@ -1,0 +1,21 @@
+const DEFAULT_AUTH_REDIRECT = '/dashboard/app';
+
+export function resolvePostAuthDestination(candidatePath) {
+  if (typeof candidatePath !== 'string') {
+    return DEFAULT_AUTH_REDIRECT;
+  }
+
+  const sanitizedPath = candidatePath.trim();
+
+  if (!sanitizedPath || sanitizedPath === '/404') {
+    return DEFAULT_AUTH_REDIRECT;
+  }
+
+  if (!sanitizedPath.startsWith('/')) {
+    return DEFAULT_AUTH_REDIRECT;
+  }
+
+  return sanitizedPath;
+}
+
+export { DEFAULT_AUTH_REDIRECT };


### PR DESCRIPTION
### Motivation
- Usuários estavam sendo redirecionados para `/404` após completar a autenticação (ex.: depois do 2FA) porque o destino vindo em `location.state.from` podia ser inválido ou igual a `/404`.
- O handler de login social não `await`ava `loginWithSocial`, o que poderia causar navegação prematura antes do resultado da autenticação ser processado.

### Description
- Adiciona `src/utils/authRedirect.js` com `resolvePostAuthDestination` e `DEFAULT_AUTH_REDIRECT` para sanitizar e normalizar destinos pós-autenticação e garantir fallback para `/dashboard/app`.
- Altera `src/sections/auth/login/Login.js` para usar `resolvePostAuthDestination(location.state?.from || DEFAULT_AUTH_REDIRECT)` ao navegar após login / validação de 2FA.
- Altera `src/sections/auth/AuthSocial.js` para `await loginWithSocial(...)` e usar `resolvePostAuthDestination` antes de chamar `navigate`.

### Testing
- Executado `npm run lint -- src/sections/auth/login/Login.js src/sections/auth/AuthSocial.js src/utils/authRedirect.js` e o lint passou com sucesso.
- Executado `npm run build` e a build completou com sucesso.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a6818dbddc832f9adc0290c53c14d1)