### PR TITLE
fix(auth): always redirect login success to DashboardApp

### DIFF
--- a/src/sections/auth/AuthSocial.js
+++ b/src/sections/auth/AuthSocial.js
@@ -1,17 +1,16 @@
 import { useState } from 'react';
-import { useLocation, useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 // material
 import { Stack, Button, Divider, Typography, Alert } from '@mui/material';
 // component
 import Iconify from '../../components/Iconify';
 import useAuth from '../../auth/useAuth';
-import { DEFAULT_AUTH_REDIRECT, resolvePostAuthDestination } from '../../utils/authRedirect';
+import { DEFAULT_AUTH_REDIRECT } from '../../utils/authRedirect';
 
 // ----------------------------------------------------------------------
 
 export default function AuthSocial() {
   const navigate = useNavigate();
-  const location = useLocation();
   const { loginWithSocial } = useAuth();
   const [socialError, setSocialError] = useState('');
 
@@ -29,8 +28,7 @@ export default function AuthSocial() {
       return;
     }
 
-    const destination = resolvePostAuthDestination(location.state?.from || DEFAULT_AUTH_REDIRECT);
-    navigate(destination, { replace: true });
+    navigate(DEFAULT_AUTH_REDIRECT, { replace: true });
   };
 
   return (

--- a/src/sections/auth/login/Login.js
+++ b/src/sections/auth/login/Login.js
@@ -1,6 +1,6 @@
 import * as Yup from 'yup';
 import { useMemo, useState } from 'react';
-import { Link as RouterLink, Navigate, useLocation, useNavigate, useSearchParams } from 'react-router-dom';
+import { Link as RouterLink, Navigate, useNavigate, useSearchParams } from 'react-router-dom';
 // form
 import { useForm } from 'react-hook-form';
 import { yupResolver } from '@hookform/resolvers/yup';
@@ -16,7 +16,7 @@ import Logo from '../../../components/Logo';
 import Iconify from '../../../components/Iconify';
 import { FormProvider, RHFCheckbox, RHFTextField } from '../../../components/hook-form';
 import useAuth from '../../../auth/useAuth';
-import { DEFAULT_AUTH_REDIRECT, resolvePostAuthDestination } from '../../../utils/authRedirect';
+import { DEFAULT_AUTH_REDIRECT } from '../../../utils/authRedirect';
 // sections
 import AuthSocial from '../AuthSocial';
 import { RegisterForm } from '../register';
@@ -118,7 +118,6 @@ const ContentStyle = styled('div')(({ theme }) => ({
 
 function LoginFields() {
   const navigate = useNavigate();
-  const location = useLocation();
   const { login } = useAuth();
 
   const [showPassword, setShowPassword] = useState(false);
@@ -186,8 +185,7 @@ function LoginFields() {
       return;
     }
 
-    const destination = resolvePostAuthDestination(location.state?.from || DEFAULT_AUTH_REDIRECT);
-    navigate(destination, { replace: true });
+    navigate(DEFAULT_AUTH_REDIRECT, { replace: true });
   };
 
   return (
@@ -283,7 +281,6 @@ function LoginFields() {
 export default function LoginForm() {
   const smUp = useResponsive('up', 'sm');
   const mdUp = useResponsive('up', 'md');
-  const location = useLocation();
   const [searchParams, setSearchParams] = useSearchParams();
 
   const isRegisterMode = useMemo(


### PR DESCRIPTION
### Motivation

- Garantir que, após validação bem-sucedida de credenciais (incluindo 2FA quando aplicável), o usuário seja encaminhado diretamente à página do painel `DashboardApp` (`/dashboard/app`).
- Remover a resolução dinâmica de destino pós-login baseada em `location.state.from` para simplificar o fluxo de autenticação.

### Description

- Altere o fluxo de login por e-mail/senha em `src/sections/auth/login/Login.js` para navegar sempre para `DEFAULT_AUTH_REDIRECT` após sucesso (equivalente a `/dashboard/app`).
- Altere o login social em `src/sections/auth/AuthSocial.js` para também navegar sempre para `DEFAULT_AUTH_REDIRECT` após sucesso.
- Removi imports e usos agora desnecessários de `resolvePostAuthDestination` e `useLocation` relacionados à resolução dinâmica de rota pós-login.
- Arquivos modificados: `src/sections/auth/login/Login.js`, `src/sections/auth/AuthSocial.js`.

### Testing

- Executei o lint com `npm run lint`, que concluiu com sucesso; não houve erros de lint, apenas 1 aviso preexistente de dependência de hook em `Login.js`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a684bc4760832f9022c82e1ac58069)