### PR TITLE
Redirect global frontend errors to Page404

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -12,6 +12,7 @@ import * as serviceWorker from './serviceWorker';
 import { tryLoadAndStartRecorder } from '@alwaysmeticulous/recorder-loader';
 import { initReliabilityTelemetry } from './services/platformReliability';
 import { AuthProvider } from './auth/AuthContext';
+import GlobalErrorBoundary from './components/GlobalErrorBoundary';
 
 // ----------------------------------------------------------------------
 
@@ -19,7 +20,6 @@ const rootElement = document.getElementById('root');
 
 const ERROR_ROUTE_PATH = '/404';
 let hasRedirectedToErrorPage = false;
-const shouldHandleGlobalErrors = isProduction();
 
 function redirectToErrorPage() {
   if (window.location.pathname === ERROR_ROUTE_PATH || hasRedirectedToErrorPage) {
@@ -31,24 +31,22 @@ function redirectToErrorPage() {
   window.dispatchEvent(new PopStateEvent('popstate'));
 }
 
-if (shouldHandleGlobalErrors) {
-  window.addEventListener('error', (event) => {
-    // Evita redirecionar por falhas não fatais (ex.: erro de carregamento de imagem/extensão).
-    if (!(event instanceof ErrorEvent) || !event.error) {
-      return;
-    }
+window.addEventListener('error', (event) => {
+  // Evita redirecionar por falhas não fatais (ex.: erro de carregamento de imagem/extensão).
+  if (!(event instanceof ErrorEvent) || !event.error) {
+    return;
+  }
 
-    redirectToErrorPage();
-  });
+  redirectToErrorPage();
+});
 
-  window.addEventListener('unhandledrejection', (event) => {
-    if (!(event.reason instanceof Error)) {
-      return;
-    }
+window.addEventListener('unhandledrejection', (event) => {
+  if (!(event.reason instanceof Error)) {
+    return;
+  }
 
-    redirectToErrorPage();
-  });
-}
+  redirectToErrorPage();
+});
 
 async function startApp() {
   if (!isProduction()) {
@@ -83,7 +81,9 @@ const appTree = (
   <HelmetProvider>
     <AuthProvider>
       <BrowserRouter>
-        <App />
+        <GlobalErrorBoundary>
+          <App />
+        </GlobalErrorBoundary>
       </BrowserRouter>
     </AuthProvider>
   </HelmetProvider>


### PR DESCRIPTION
### Motivation
- Ensure that any frontend runtime error or temporary unavailability of parts of the web app is redirected to the `Page404` screen (`NotFound`) so users see a single fallback page for failures.

### Description
- Import `GlobalErrorBoundary` and wrap the root `App` with it in `src/index.js` so React render/runtime exceptions are caught and routed to the error page via the same mechanism.
- Always register global handlers for `window.error` and `window.unhandledrejection` in `src/index.js` to call `redirectToErrorPage()` regardless of environment (removed the previous production-only guard).
- `redirectToErrorPage()` replaces the current history entry to `'/404'` and dispatches a `popstate` to trigger routing, while guarding with `hasRedirectedToErrorPage` to avoid repeated redirects.

### Testing
- Ran the production build with `npm run build` and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a685bbcf20832faff191283bc0c119)