### PR TITLE
Guard against invalid auth backend responses to prevent 404 after 2FA

### DIFF
--- a/src/auth/AuthContext.js
+++ b/src/auth/AuthContext.js
@@ -29,6 +29,14 @@ import { loginWithBackend, socialLoginWithBackend } from '../services/authApi';
 
 export const AuthContext = createContext(null);
 
+function ensureAuthResultShape(result) {
+  if (result && typeof result === 'object') {
+    return result;
+  }
+
+  return { error: 'Resposta de autenticação inválida. Tente novamente.' };
+}
+
 export function AuthProvider({ children }) {
   const [user, setUser] = useState(() => getAuthenticatedUser());
   const [sessions, setSessions] = useState(() => getUserSessions());
@@ -79,6 +87,8 @@ export function AuthProvider({ children }) {
       });
     }
 
+    result = ensureAuthResultShape(result);
+
     if (result.error || result.requiresTwoFactor) {
       return result;
     }
@@ -110,6 +120,8 @@ export function AuthProvider({ children }) {
     } catch (error) {
       result = loginWithSocialProvider({ provider, remember, trustDevice, deviceName });
     }
+
+    result = ensureAuthResultShape(result);
 
     if (result.error || result.requiresTwoFactor) {
       return result;


### PR DESCRIPTION
### Motivation
- The app could receive an empty or non-object response from the auth backend after the 2FA step, which left the client in an inconsistent state and could trigger incorrect routing (e.g. falling back to the 404 route), so the auth result must be normalized before further processing.

### Description
- Add `ensureAuthResultShape(result)` in `src/auth/AuthContext.js` to normalize backend/authenticator responses and return a controlled error when the payload is not an object.
- Call `ensureAuthResultShape` in both `login` and `loginWithSocial` flows before checking `error`/`requiresTwoFactor` so the app never proceeds with an invalid result.
- The only modified file is `src/auth/AuthContext.js` and the change produces a user-facing error message `Resposta de autenticação inválida. Tente novamente.` for invalid payloads.

### Testing
- Ran a production build with `npm run -s build` and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a687245a30832fa68ef913ff968ed5)