### PR TITLE
Only redirect to /404 for critical runtime errors

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -21,6 +21,8 @@ const rootElement = document.getElementById('root');
 const ERROR_ROUTE_PATH = '/404';
 let hasRedirectedToErrorPage = false;
 
+const CRITICAL_ERROR_SIGNATURES = ['loading chunk', 'failed to fetch dynamically imported module'];
+
 function redirectToErrorPage() {
   if (window.location.pathname === ERROR_ROUTE_PATH || hasRedirectedToErrorPage) {
     return;
@@ -31,9 +33,24 @@ function redirectToErrorPage() {
   window.dispatchEvent(new PopStateEvent('popstate'));
 }
 
+function isCriticalRuntimeError(reason) {
+  if (!reason) {
+    return false;
+  }
+
+  const message = typeof reason === 'string' ? reason : reason.message;
+
+  if (!message || typeof message !== 'string') {
+    return false;
+  }
+
+  const normalizedMessage = message.toLowerCase();
+  return CRITICAL_ERROR_SIGNATURES.some((signature) => normalizedMessage.includes(signature));
+}
+
 window.addEventListener('error', (event) => {
-  // Evita redirecionar por falhas não fatais (ex.: erro de carregamento de imagem/extensão).
-  if (!(event instanceof ErrorEvent) || !event.error) {
+  // Evita redirecionar por falhas não fatais (ex.: extensão, erro de API, warning de runtime).
+  if (!(event instanceof ErrorEvent) || !isCriticalRuntimeError(event.error)) {
     return;
   }
 
@@ -41,7 +58,7 @@ window.addEventListener('error', (event) => {
 });
 
 window.addEventListener('unhandledrejection', (event) => {
-  if (!(event.reason instanceof Error)) {
+  if (!isCriticalRuntimeError(event.reason)) {
     return;
   }
 


### PR DESCRIPTION
### Motivation
- The app was redirecting users to `/404` on generic runtime errors or promise rejections, causing false 404s after authentication/validation flows.  
- The intent is to preserve the global safety fallback for truly fatal runtime failures (e.g. chunk-loading failures) while avoiding redirects caused by extension noise or non-critical runtime warnings.  
- Narrowing the criteria for the global redirect reduces user-facing disruptions without removing the existing protection for unrecoverable errors.

### Description
- Tightened global runtime error handling in `src/index.js` by adding a `CRITICAL_ERROR_SIGNATURES` list containing known fatal signatures.  
- Added the `isCriticalRuntimeError` helper to detect whether an `Error`/rejection message matches critical signatures.  
- Updated `window.addEventListener('error', ...)` and `window.addEventListener('unhandledrejection', ...)` to only call `redirectToErrorPage()` when `isCriticalRuntimeError` returns `true`, keeping the existing redirect behavior for real critical cases.

### Testing
- Ran `npm run lint -- src/index.js` and the lint check completed successfully (with an unrelated warning elsewhere).  
- Built the production bundle with `npm run build` and the build completed successfully.  
- Verified the modified file was limited to `src/index.js` and the app still produces a production build without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a688cdb608832fbc7a19d803325b85)