### PR TITLE
Fixa redirecionamento pós-login para /dashboard/app

### DIFF
--- a/src/utils/authRedirect.js
+++ b/src/utils/authRedirect.js
@@ -1,21 +1,7 @@
 const DEFAULT_AUTH_REDIRECT = '/dashboard/app';
 
-export function resolvePostAuthDestination(candidatePath) {
-  if (typeof candidatePath !== 'string') {
-    return DEFAULT_AUTH_REDIRECT;
-  }
-
-  const sanitizedPath = candidatePath.trim();
-
-  if (!sanitizedPath || sanitizedPath === '/404') {
-    return DEFAULT_AUTH_REDIRECT;
-  }
-
-  if (!sanitizedPath.startsWith('/')) {
-    return DEFAULT_AUTH_REDIRECT;
-  }
-
-  return sanitizedPath;
+export function resolvePostAuthDestination() {
+  return DEFAULT_AUTH_REDIRECT;
 }
 
 export { DEFAULT_AUTH_REDIRECT };


### PR DESCRIPTION
### Motivation
- Garantir que, após a validação na tela de login, o usuário seja sempre direcionado para `/dashboard/app` em vez de aceitar destinos alternativos ou derivados do estado.

### Description
- Simplifiquei a função `resolvePostAuthDestination` em `src/utils/authRedirect.js` para sempre retornar a constante `DEFAULT_AUTH_REDIRECT`.
- Removi a lógica de sanitização e validações do parâmetro de destino opcional para eliminar variações no comportamento pós-login.
- Mantive a constante `DEFAULT_AUTH_REDIRECT` com o valor `'/dashboard/app'` e a exportação pública inalterada.

### Testing
- Executei o linter com `npx eslint src/utils/authRedirect.js` e ele concluiu com sucesso.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a68cebea40832f805888aefaaf6abc)