### PR TITLE
Persist splash-seen flag to avoid replay after 2FA

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -3,12 +3,23 @@ import { useLocation, useNavigate } from 'react-router-dom';
 import SplashHarvestPro from "./SplashHarvestPro";
 import Router from "./routes";
 
+const SPLASH_SEEN_STORAGE_KEY = 'hortelan:splash-seen';
+
+function shouldShowSplash() {
+  if (typeof window === 'undefined') {
+    return false;
+  }
+
+  return window.sessionStorage.getItem(SPLASH_SEEN_STORAGE_KEY) !== '1';
+}
+
 export default function App() {
-  const [showSplash, setShowSplash] = useState(true);
+  const [showSplash, setShowSplash] = useState(() => shouldShowSplash());
   const navigate = useNavigate();
   const location = useLocation();
 
   const handleSplashFinish = () => {
+    window.sessionStorage.setItem(SPLASH_SEEN_STORAGE_KEY, '1');
     setShowSplash(false);
 
     // Garante a splash como primeira tela em qualquer rota de entrada.


### PR DESCRIPTION
### Motivation
- The splash animation was being shown again after the 2FA validation/post-login routing, so make the splash display only once per browser session.

### Description
- Add `SPLASH_SEEN_STORAGE_KEY` and `shouldShowSplash()` and initialize `showSplash` from `sessionStorage`, and mark the splash as seen (`sessionStorage.setItem(...)`) in `handleSplashFinish` to prevent replay (changes in `src/App.js`).

### Testing
- Ran `npm run lint` which completed successfully (one unrelated pre-existing warning in `src/sections/auth/login/Login.js`).
- Ran `npm test` which exits successfully (`No test runner configured`).
- Started the dev server and exercised the login + 2FA flow with Playwright, captured a screenshot; the splash no longer replays but the test environment navigated to `/404` after login which appears unrelated to this fix.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69aa2f3545448328b65a739d1ee50e67)