### PR TITLE
Fix 2FA login redirect to dashboard

### DIFF
--- a/src/utils/authRedirect.js
+++ b/src/utils/authRedirect.js
@@ -1,4 +1,4 @@
-const DEFAULT_AUTH_REDIRECT = '/dashboard/app';
+const DEFAULT_AUTH_REDIRECT = '/dashboard';
 
 export function resolvePostAuthDestination() {
   return DEFAULT_AUTH_REDIRECT;


### PR DESCRIPTION
### Motivation
- Corrigir o redirecionamento após validação de 2FA para que o fluxo leve à tela principal do dashboard (`/dashboard`) em vez de resultar em `404`.

### Description
- Alterei `DEFAULT_AUTH_REDIRECT` em `src/utils/authRedirect.js` de `'/dashboard/app'` para `'/dashboard'`.

### Testing
- Rodei `npm run lint` (sucesso com 1 aviso pré-existente em `src/sections/auth/login/Login.js`) e `npm test` (retorna sucesso porque não há runner de testes configurado).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69aa32499a548328aace3e4154628653)