### PR TITLE
Always show splash on initial load and recover from /404

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -3,28 +3,17 @@ import { useLocation, useNavigate } from 'react-router-dom';
 import SplashHarvestPro from "./SplashHarvestPro";
 import Router from "./routes";
 
-const SPLASH_SEEN_STORAGE_KEY = 'hortelan:splash-seen';
-
-function shouldShowSplash() {
-  if (typeof window === 'undefined') {
-    return false;
-  }
-
-  return window.sessionStorage.getItem(SPLASH_SEEN_STORAGE_KEY) !== '1';
-}
-
 export default function App() {
-  const [showSplash, setShowSplash] = useState(() => shouldShowSplash());
+  const [showSplash, setShowSplash] = useState(true);
   const navigate = useNavigate();
   const location = useLocation();
 
   const handleSplashFinish = () => {
-    window.sessionStorage.setItem(SPLASH_SEEN_STORAGE_KEY, '1');
     setShowSplash(false);
 
     // Garante a splash como primeira tela em qualquer rota de entrada.
-    // Faz o redirecionamento para login apenas quando o usuário abre a raiz.
-    if (location.pathname === '/') {
+    // Se a aplicação chegar na raiz ou na página 404, redireciona para login.
+    if (location.pathname === '/' || location.pathname === '/404') {
       navigate('/login', { replace: true, state: { forceLogin: true } });
     }
   };


### PR DESCRIPTION
### Motivation
- Prevent the app from landing stuck on the 404 page as the first screen by ensuring the splash always appears on initial load and handles the `/404` entry route.

### Description
- Removed the `sessionStorage` gating and defaulted splash visibility to `true` so the splash always renders on first load in `src/App.js`.
- Stopped setting the storage flag and adjusted the post-splash redirect to send users to `/login` when the current path is `/` or `/404` in `src/App.js`.
- The app continues to render the normal router after the splash completes.

### Testing
- Ran `npm run build` and the production build completed successfully.
- Started the dev server with `npm run dev` and it reported ready on `http://localhost:3000/`.
- End-to-end checks with Playwright produced a screenshot of `/` confirming the splash renders; a separate Playwright run targeting `/404` with Chromium crashed (browser process SIGSEGV), while a Firefox run to `/` succeeded and produced a screenshot.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69aa35f6921483289394bb741cfed435)