### PR TITLE
Update login flows to consume auth payload and set default post-auth redirect

### DIFF
--- a/src/auth/AuthContext.js
+++ b/src/auth/AuthContext.js
@@ -29,6 +29,29 @@ import { loginWithBackend, socialLoginWithBackend } from '../services/authApi';
 
 export const AuthContext = createContext(null);
 
+
+function getAuthPayload(result) {
+  if (!result || typeof result !== 'object') {
+    return { user: null, session: null };
+  }
+
+  if (result.user || result.session) {
+    return {
+      user: result.user || null,
+      session: result.session || null,
+    };
+  }
+
+  if (result.data && typeof result.data === 'object') {
+    return {
+      user: result.data.user || null,
+      session: result.data.session || null,
+    };
+  }
+
+  return { user: null, session: null };
+}
+
 function ensureAuthResultShape(result) {
   if (result && typeof result === 'object') {
     return result;
@@ -93,9 +116,32 @@ export function AuthProvider({ children }) {
       return result;
     }
 
-    refreshAuthState();
+    const { user: authenticatedUser, session } = getAuthPayload(result);
+
+    if (authenticatedUser) {
+      setUser(authenticatedUser);
+    } else {
+      setUser(getAuthenticatedUser());
+    }
+
+    if (session) {
+      setSessions((previousSessions) => {
+        const nextSessions = previousSessions.filter((item) => item.id !== session.id);
+        return [...nextSessions, session];
+      });
+    } else {
+      setSessions(getUserSessions());
+    }
+
+    setTwoFactor(getTwoFactorSettings());
+    setTrustedDevices(getTrustedDevices());
+    setConsents(getUserConsents());
+    setDeletionRequest(getAccountDeletionRequest());
+    setConsentLogs(getConsentAuditLogs());
+    setRetentionPolicy(getDataRetentionPolicy());
+
     return result;
-  }, [refreshAuthState]);
+  }, []);
 
   const logout = useCallback(() => {
     logoutCurrentSession();
@@ -127,9 +173,32 @@ export function AuthProvider({ children }) {
       return result;
     }
 
-    refreshAuthState();
+    const { user: authenticatedUser, session } = getAuthPayload(result);
+
+    if (authenticatedUser) {
+      setUser(authenticatedUser);
+    } else {
+      setUser(getAuthenticatedUser());
+    }
+
+    if (session) {
+      setSessions((previousSessions) => {
+        const nextSessions = previousSessions.filter((item) => item.id !== session.id);
+        return [...nextSessions, session];
+      });
+    } else {
+      setSessions(getUserSessions());
+    }
+
+    setTwoFactor(getTwoFactorSettings());
+    setTrustedDevices(getTrustedDevices());
+    setConsents(getUserConsents());
+    setDeletionRequest(getAccountDeletionRequest());
+    setConsentLogs(getConsentAuditLogs());
+    setRetentionPolicy(getDataRetentionPolicy());
+
     return result;
-  }, [refreshAuthState]);
+  }, []);
 
   const update2FASettings = useCallback(({ enabled, method }) => {
     const result = updateTwoFactorSettings({ enabled, method });
@@ -216,7 +285,7 @@ export function AuthProvider({ children }) {
       deletionRequest,
       consentLogs,
       retentionPolicy,
-      authenticated: isAuthenticated(),
+      authenticated: Boolean(user) || isAuthenticated(),
       login,
       loginWithSocial,
       logout,

--- a/src/utils/authRedirect.js
+++ b/src/utils/authRedirect.js
@@ -1,4 +1,4 @@
-const DEFAULT_AUTH_REDIRECT = '/dashboard';
+const DEFAULT_AUTH_REDIRECT = '/dashboard/app';
 
 export function resolvePostAuthDestination() {
   return DEFAULT_AUTH_REDIRECT;


### PR DESCRIPTION
### Motivation

- Normalize and consume different authentication response shapes so the app can update its local state directly after login and social login. 
- Avoid always doing a full `refreshAuthState()` when a login returns explicit `user`/`session` data for a more targeted state update. 
- Make the `authenticated` flag reflect the in-memory `user` state and update the default post-auth redirect path to the new route.

### Description

- Added a `getAuthPayload` helper to extract `user` and `session` from several possible response shapes. 
- Updated `AuthProvider` `login` and `loginWithSocial` handlers to use `getAuthPayload` and update `user` and `sessions` directly when present instead of calling `refreshAuthState()`. 
- Removed `refreshAuthState` from the `login` and `loginWithSocial` dependency arrays and kept targeted refreshes for other actions. 
- Changed `authenticated` to `Boolean(user) || isAuthenticated()` so components see authentication immediately when `user` is set, and updated `DEFAULT_AUTH_REDIRECT` from `/dashboard` to `/dashboard/app`.

### Testing

- No automated tests were run as part of this rollout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69aa39f5477c83289aacebdc8d1a5637)