### PR TITLE
feat: adicionar resiliência HTTP, telemetria de API e workflow de baseline de performance

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,3 +86,10 @@ npm run serve:ssr     # desenvolvimento com SSR via Vite middleware
 npm run build:ssr     # build do cliente + bundle SSR
 NODE_ENV=production npm run serve:ssr
 ```
+
+
+## Performance baseline e hardening
+
+- Rodar baseline automatizado: `npm run perf:baseline`
+- Relatório de baseline: `docs/performance-baseline.json`
+- Plano de execução: `docs/performance-hardening-plan.md`

--- a/docs/performance-baseline.json
+++ b/docs/performance-baseline.json
@@ -1,0 +1,67 @@
+{
+  "generatedAt": "2026-03-06T03:06:24.413Z",
+  "targetSLO": {
+    "frontendRouteP95Ms": 1500,
+    "frontendRouteP99Ms": 2500,
+    "apiErrorRatePercent": 1,
+    "buildTimeSeconds": 60
+  },
+  "checks": {
+    "build": {
+      "exitCode": 0,
+      "durationMs": 26714,
+      "durationSeconds": 26.71
+    },
+    "frontendAudit": {
+      "exitCode": 0,
+      "durationMs": 670,
+      "durationSeconds": 0.67
+    }
+  },
+  "distSummary": {
+    "bundleCount": 36,
+    "totalSizeKb": 4607.85,
+    "topBundles": [
+      {
+        "file": "build/assets/index-BaKy9Qds.js",
+        "sizeKb": 2992.25
+      },
+      {
+        "file": "build/assets/charts-mRm2UTag.js",
+        "sizeKb": 528.7
+      },
+      {
+        "file": "build/assets/mui-B3NNhHv8.js",
+        "sizeKb": 363.68
+      },
+      {
+        "file": "build/assets/react-CcW4e7yl.js",
+        "sizeKb": 160.28
+      },
+      {
+        "file": "build/assets/MonitoringPage-Ccl4OWP2.js",
+        "sizeKb": 159.36
+      },
+      {
+        "file": "build/assets/motion-Bbkfe1uD.js",
+        "sizeKb": 115.86
+      },
+      {
+        "file": "build/assets/FormProvider-CnfXjjEA.js",
+        "sizeKb": 45.04
+      },
+      {
+        "file": "build/assets/identity-BrVR6TWu.js",
+        "sizeKb": 35.55
+      },
+      {
+        "file": "build/assets/SpeciesCatalogPage-qHF91-b1.js",
+        "sizeKb": 21.47
+      },
+      {
+        "file": "build/assets/ProfileSettingsPage-D5VY27YF.js",
+        "sizeKb": 19.65
+      }
+    ]
+  }
+}

--- a/docs/performance-hardening-plan.md
+++ b/docs/performance-hardening-plan.md
@@ -1,0 +1,117 @@
+# Plano de baseline + hardening de performance e confiabilidade
+
+Este plano traduz o checklist solicitado para o contexto atual do frontend HORTELAN.
+
+## 1) Baseline antes de mexer
+
+### Métricas-alvo iniciais
+
+- Latência frontend por rota: **p95 <= 1500ms**, **p99 <= 2500ms**.
+- Taxa de erro API (cliente): **< 1%** por endpoint.
+- Throughput: requests por endpoint via telemetria (`apiMetrics`).
+- Build: **<= 60s**.
+- Tamanho total de bundles JS/CSS: acompanhar em baseline contínuo.
+
+### Como coletar baseline
+
+1. Rodar baseline automático:
+   - `npm run perf:baseline`
+2. Abrir o relatório gerado:
+   - `docs/performance-baseline.json`
+3. Verificar telemetria local em runtime:
+   - `getReliabilityState().observability.apiMetrics`
+
+## 2) Banco de dados (dependente de backend)
+
+O frontend não executa queries SQL diretamente. Ações práticas:
+
+- Exigir no backend:
+  - auditoria N+1,
+  - índices por `WHERE/JOIN/ORDER BY/GROUP BY`,
+  - `EXPLAIN ANALYZE` para endpoints lentos,
+  - slow query log habilitado,
+  - cursor pagination em listas muito grandes.
+- No frontend, validar sempre paginação e limites em chamadas de listagem.
+
+## 3) Cache
+
+- No cliente, priorizar cache de respostas idempotentes com baixa volatilidade.
+- Nunca cachear globalmente dados com escopo de permissão de usuário.
+- Quando backend suportar, usar `ETag`/`Cache-Control` por endpoint.
+
+## 4) Chamadas externas/API
+
+Implementado neste ciclo:
+
+- Timeout com `AbortController`.
+- Retry com backoff exponencial + jitter para métodos idempotentes.
+- Métricas por endpoint (volume, erro, latência).
+
+Próximos passos:
+
+- Circuit breaker (estado aberto/semiaberto) por integração crítica.
+- Limite de concorrência por domínio externo (bulkhead).
+- Deduplicação de requests repetidos no mesmo fluxo.
+
+## 5) Concorrência e I/O
+
+- Manter requests de UI leves; mover processamento pesado para backend/jobs.
+- Evitar processamento síncrono caro durante render.
+
+## 6) Payload e serialização
+
+- Restringir payloads por endpoint e remover campos desnecessários.
+- Paginação obrigatória em listas volumosas.
+
+## 7) Frontend performance
+
+Já existe lazy loading de páginas via `React.lazy`.
+
+Próximos passos:
+
+- Medir custo por rota (bundle por chunk).
+- Virtualizar listas extensas.
+- Revisar dependências pesadas para tree-shaking e substituições.
+
+## 8) Memória e leaks
+
+Implementado neste ciclo:
+
+- Limite de cardinalidade de métricas por endpoint (máx. 40), evitando crescimento sem controle.
+
+## 9) Bugs e qualidade
+
+- Fortalecer validação de inputs em todas as bordas de formulário/integração.
+- Padronizar erros de API por tipo/código para facilitar observabilidade.
+
+## 10) Testes
+
+Fluxo mínimo recomendado em CI:
+
+- `npm run lint`
+- `npm run build`
+- `npm run perf:baseline`
+
+## 11) Observabilidade
+
+Implementado neste ciclo:
+
+- Métricas de request no cliente por endpoint:
+  - total de requests,
+  - total de erros,
+  - latência aproximada p50/p95/p99,
+  - último status observado.
+
+## 12) Limites e proteção
+
+- Definir limites de payload no backend e validação no cliente.
+- Aplicar rate limiting por usuário/IP no backend.
+
+## 13) Deploy/build/runtime
+
+- Baseline de build automatizado (`perf:baseline`) para regressão rápida.
+
+## 14) Segurança e estabilidade
+
+- Revisar dependências periodicamente (audit + atualização seletiva).
+- Evitar logs com dados sensíveis.

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "re-build": "rm -rf build node_modules dist && npm install && npm run build",
     "sentry:sourcemaps": "node scripts/sentry-sourcemaps.js",
     "build:ssr": "npm run build && vite build --ssr src/entry-server.js --outDir build-ssr",
-    "serve:ssr": "node server/ssr-server.mjs"
+    "serve:ssr": "node server/ssr-server.mjs",
+    "perf:baseline": "node scripts/perf-baseline.mjs"
   },
   "babel": {
     "presets": [

--- a/scripts/perf-baseline.mjs
+++ b/scripts/perf-baseline.mjs
@@ -1,0 +1,84 @@
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const root = process.cwd();
+const distDir = path.join(root, 'build');
+const reportPath = path.join(root, 'docs', 'performance-baseline.json');
+
+function run(cmd, args) {
+  const startedAt = Date.now();
+  const output = spawnSync(cmd, args, { cwd: root, encoding: 'utf8' });
+  const durationMs = Date.now() - startedAt;
+  return { ...output, durationMs };
+}
+
+function readDirFiles(dir) {
+  if (!fs.existsSync(dir)) return [];
+
+  const entries = fs.readdirSync(dir, { withFileTypes: true });
+  return entries.flatMap((entry) => {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) return readDirFiles(full);
+    return [full];
+  });
+}
+
+function bytesToKb(bytes) {
+  return Math.round((bytes / 1024) * 100) / 100;
+}
+
+function summarizeDist() {
+  const files = readDirFiles(distDir);
+  const bundles = files
+    .filter((file) => file.endsWith('.js') || file.endsWith('.css'))
+    .map((file) => {
+      const stats = fs.statSync(file);
+      return {
+        file: path.relative(root, file).replaceAll(path.sep, '/'),
+        sizeKb: bytesToKb(stats.size),
+      };
+    })
+    .sort((a, b) => b.sizeKb - a.sizeKb);
+
+  return {
+    bundleCount: bundles.length,
+    totalSizeKb: Math.round(bundles.reduce((acc, item) => acc + item.sizeKb, 0) * 100) / 100,
+    topBundles: bundles.slice(0, 10),
+  };
+}
+
+const build = run('npm', ['run', 'build']);
+const audit = run('npm', ['run', 'audit:frontend']);
+
+const report = {
+  generatedAt: new Date().toISOString(),
+  targetSLO: {
+    frontendRouteP95Ms: 1500,
+    frontendRouteP99Ms: 2500,
+    apiErrorRatePercent: 1,
+    buildTimeSeconds: 60,
+  },
+  checks: {
+    build: {
+      exitCode: build.status,
+      durationMs: build.durationMs,
+      durationSeconds: Math.round((build.durationMs / 1000) * 100) / 100,
+    },
+    frontendAudit: {
+      exitCode: audit.status,
+      durationMs: audit.durationMs,
+      durationSeconds: Math.round((audit.durationMs / 1000) * 100) / 100,
+    },
+  },
+  distSummary: summarizeDist(),
+};
+
+fs.writeFileSync(reportPath, JSON.stringify(report, null, 2));
+
+console.log('Performance baseline generated:', reportPath);
+console.log(JSON.stringify(report, null, 2));
+
+if (build.status !== 0) {
+  process.exit(build.status ?? 1);
+}

--- a/src/services/apiClient.js
+++ b/src/services/apiClient.js
@@ -1,7 +1,10 @@
+import { registerApiMetric } from './platformReliability';
+
 const DEFAULT_API_BASE_URL = 'http://localhost:3001';
 const DEFAULT_TIMEOUT_MS = 12000;
-const DEFAULT_RETRY_ATTEMPTS = 1;
+const DEFAULT_RETRY_ATTEMPTS = 2;
 const RETRYABLE_STATUS_CODES = new Set([408, 425, 429, 500, 502, 503, 504]);
+const MAX_RETRY_DELAY_MS = 1500;
 
 const configuredBaseUrl =
   import.meta.env.VITE_API_BASE_URL ||
@@ -10,8 +13,15 @@ const configuredBaseUrl =
 
 export const API_BASE_URL = configuredBaseUrl.replace(/\/$/, '');
 
-function shouldRetry(error, attempt, maxAttempts) {
+function shouldRetry(error, attempt, maxAttempts, method = 'GET') {
   if (attempt >= maxAttempts) {
+    return false;
+  }
+
+  const normalizedMethod = method.toUpperCase();
+  const idempotentMethod = ['GET', 'HEAD', 'OPTIONS'].includes(normalizedMethod);
+
+  if (!idempotentMethod) {
     return false;
   }
 
@@ -42,9 +52,20 @@ async function safeParseJson(response) {
   }
 }
 
+function calculateBackoffMs(attempt) {
+  const exponentialDelay = Math.min(250 * 2 ** attempt, MAX_RETRY_DELAY_MS);
+  const jitter = Math.floor(Math.random() * 120);
+  return exponentialDelay + jitter;
+}
+
+function sanitizePath(path) {
+  return String(path || '').split('?')[0] || 'unknown';
+}
+
 async function performRequest(path, options = {}, timeoutMs) {
   const controller = new AbortController();
   const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
+  const startedAt = typeof window !== 'undefined' && window.performance?.now ? window.performance.now() : Date.now();
 
   try {
     const response = await fetch(`${API_BASE_URL}${path}`, {
@@ -58,6 +79,8 @@ async function performRequest(path, options = {}, timeoutMs) {
 
     const payload = await safeParseJson(response);
 
+    const finishedAt = typeof window !== 'undefined' && window.performance?.now ? window.performance.now() : Date.now();
+
     if (!response.ok) {
       const error = new Error(payload?.message || `Request failed with status ${response.status}`);
       error.status = response.status;
@@ -65,7 +88,12 @@ async function performRequest(path, options = {}, timeoutMs) {
       throw error;
     }
 
+    registerApiMetric(sanitizePath(path), Math.round(finishedAt - startedAt), response.status, true);
     return payload;
+  } catch (error) {
+    const finishedAt = typeof window !== 'undefined' && window.performance?.now ? window.performance.now() : Date.now();
+    registerApiMetric(sanitizePath(path), Math.round(finishedAt - startedAt), error.status || 0, false);
+    throw error;
   } finally {
     clearTimeout(timeoutId);
   }
@@ -82,11 +110,11 @@ export async function apiRequest(path, options = {}) {
     try {
       return await performRequest(path, requestOptions, timeoutMs);
     } catch (error) {
-      if (!shouldRetry(error, attempt, retryAttempts)) {
+      if (!shouldRetry(error, attempt, retryAttempts, requestOptions.method || 'GET')) {
         throw error;
       }
 
-      const backoffMs = Math.min(300 * 2 ** attempt, 1500);
+      const backoffMs = calculateBackoffMs(attempt);
       await wait(backoffMs);
     }
   }

--- a/src/services/platformReliability.js
+++ b/src/services/platformReliability.js
@@ -54,6 +54,11 @@ const defaultState = {
       { service: 'Motor de automações', uptime: 99.75, latencyMs: 246, status: 'degraded' },
       { service: 'Webhook Gateway', uptime: 99.9, latencyMs: 198, status: 'operational' },
     ],
+    apiMetrics: {
+      totalRequests: 0,
+      totalErrors: 0,
+      byEndpoint: {},
+    },
   },
   featureFlags: {
     flags: [
@@ -91,23 +96,51 @@ const defaultState = {
   },
 };
 
+function cloneDefaultState() {
+  return JSON.parse(JSON.stringify(defaultState));
+}
+
 function readState() {
+  if (typeof window === 'undefined') {
+    return cloneDefaultState();
+  }
+
   const raw = window.localStorage.getItem(STORAGE_KEY);
-  if (!raw) return defaultState;
+  if (!raw) return cloneDefaultState();
 
   try {
-    return { ...defaultState, ...JSON.parse(raw) };
+    return { ...cloneDefaultState(), ...JSON.parse(raw) };
   } catch (error) {
-    return defaultState;
+    return cloneDefaultState();
   }
 }
 
 function persist(nextState) {
+  if (typeof window === 'undefined') {
+    return;
+  }
+
   window.localStorage.setItem(STORAGE_KEY, JSON.stringify(nextState));
 }
 
+function ensureObservabilityShape(state) {
+  if (!state.observability) {
+    state.observability = { ...defaultState.observability };
+  }
+
+  if (!state.observability.apiMetrics) {
+    state.observability.apiMetrics = {
+      totalRequests: 0,
+      totalErrors: 0,
+      byEndpoint: {},
+    };
+  }
+
+  return state;
+}
+
 export function getReliabilityState() {
-  return readState();
+  return ensureObservabilityShape(readState());
 }
 
 export function logUserAction(action, actor = 'usuário atual') {
@@ -138,20 +171,71 @@ export function updateFeatureFlag(key, patch) {
   return state;
 }
 
-export function registerJsTelemetry(message, page = window.location.pathname) {
+export function registerJsTelemetry(message, page) {
   const state = readState();
-  state.observability.jsErrors.unshift({ id: `js-${Date.now()}`, message, page, timestamp: new Date().toISOString() });
+  const resolvedPage = page || (typeof window !== 'undefined' ? window.location.pathname : 'unknown');
+  state.observability.jsErrors.unshift({ id: `js-${Date.now()}`, message, page: resolvedPage, timestamp: new Date().toISOString() });
   state.observability.jsErrors = state.observability.jsErrors.slice(0, 30);
   persist(state);
 }
 
 export function registerFrontendUsage(actionCount = 1) {
-  const state = readState();
+  const state = ensureObservabilityShape(readState());
   state.observability.frontendUsage.actionsPerSession += actionCount;
   persist(state);
 }
 
+export function registerApiMetric(path, durationMs, status, ok) {
+  if (typeof window === 'undefined') {
+    return;
+  }
+
+  const state = ensureObservabilityShape(readState());
+  const key = path || 'unknown';
+  const endpoint = state.observability.apiMetrics.byEndpoint[key] || {
+    requests: 0,
+    errors: 0,
+    latencyMs: { p50: durationMs, p95: durationMs, p99: durationMs },
+    lastStatus: status,
+    lastSeenAt: new Date().toISOString(),
+  };
+
+  endpoint.requests += 1;
+  if (!ok) {
+    endpoint.errors += 1;
+    state.observability.apiMetrics.totalErrors += 1;
+  }
+
+  endpoint.latencyMs.p50 = Math.round((endpoint.latencyMs.p50 + durationMs) / 2);
+  endpoint.latencyMs.p95 = Math.max(endpoint.latencyMs.p95, durationMs);
+  endpoint.latencyMs.p99 = Math.max(endpoint.latencyMs.p99, durationMs);
+  endpoint.lastStatus = status;
+  endpoint.lastSeenAt = new Date().toISOString();
+
+  state.observability.apiMetrics.totalRequests += 1;
+  state.observability.apiMetrics.byEndpoint[key] = endpoint;
+
+  const endpointKeys = Object.keys(state.observability.apiMetrics.byEndpoint);
+  if (endpointKeys.length > 40) {
+    const sortedByLastSeen = endpointKeys.sort(
+      (a, b) =>
+        new Date(state.observability.apiMetrics.byEndpoint[b].lastSeenAt).getTime() -
+        new Date(state.observability.apiMetrics.byEndpoint[a].lastSeenAt).getTime()
+    );
+
+    state.observability.apiMetrics.byEndpoint = sortedByLastSeen
+      .slice(0, 40)
+      .reduce((acc, currentKey) => ({ ...acc, [currentKey]: state.observability.apiMetrics.byEndpoint[currentKey] }), {});
+  }
+
+  persist(state);
+}
+
 export function initReliabilityTelemetry() {
+  if (typeof window === 'undefined') {
+    return;
+  }
+
   window.addEventListener('error', (event) => {
     registerJsTelemetry(event.message || 'Erro JavaScript desconhecido');
   });


### PR DESCRIPTION
### Motivation
- Padronizar comportamento de chamadas externas (timeout/retry/backoff) para reduzir erros e latência inesperada no cliente. 
- Capturar telemetria básica por endpoint (volume, erros, latência) para permitir diagnóstico e baseline antes de otimizações maiores. 
- Evitar crescimento indefinido de dados em memória/localStorage e proteger execução em ambientes SSR. 

### Description
- Fortaleci o cliente HTTP em `src/services/apiClient.js` para usar `AbortController`+timeout, aplicar retry apenas em métodos idempotentes (`GET/HEAD/OPTIONS`), e backoff exponencial com jitter (`calculateBackoffMs`).
- Instrumentei chamadas no cliente chamando `registerApiMetric(path, durationMs, status, ok)` para registrar requests/erros/latência por endpoint. 
- Adicionei e normalizei o estado de observabilidade em `src/services/platformReliability.js`, incluindo `apiMetrics` (totalRequests, totalErrors, byEndpoint), guards para SSR (`typeof window`), clonagem do `defaultState` e limite de cardinalidade de endpoints (máx. 40) para evitar vazamento de memória. 
- Criei o script `scripts/perf-baseline.mjs` e o script NPM `perf:baseline` que executa `build` + `audit:frontend` e gera `docs/performance-baseline.json`, e adicionei `docs/performance-hardening-plan.md` com plano prático; README atualizado com instruções. 

### Testing
- Executei `npm run lint` com sucesso (sem erros bloqueantes). 
- Executei `npm run build` com sucesso e verifiquei saída de bundles na build. 
- Executei `npm run perf:baseline` com sucesso e gerei `docs/performance-baseline.json` contendo resumo de build e top bundles. 
- Executei `npm test` que retornou o comportamento esperado do projeto (script de teste vazio) com saída e código 0.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69aa4383183883288c5259b79079ce71)