### PR TITLE
Revamp 404 page UI, simplify runtime-error redirect, and adjust splash redirect behavior

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -12,8 +12,8 @@ export default function App() {
     setShowSplash(false);
 
     // Garante a splash como primeira tela em qualquer rota de entrada.
-    // Se a aplicação chegar na raiz ou na página 404, redireciona para login.
-    if (location.pathname === '/' || location.pathname === '/404') {
+    // Se a aplicação chegar na raiz, redireciona para login.
+    if (location.pathname === '/') {
       navigate('/login', { replace: true, state: { forceLogin: true } });
     }
   };

--- a/src/index.js
+++ b/src/index.js
@@ -21,8 +21,6 @@ const rootElement = document.getElementById('root');
 const ERROR_ROUTE_PATH = '/404';
 let hasRedirectedToErrorPage = false;
 
-const CRITICAL_ERROR_SIGNATURES = ['loading chunk', 'failed to fetch dynamically imported module'];
-
 function redirectToErrorPage() {
   if (window.location.pathname === ERROR_ROUTE_PATH || hasRedirectedToErrorPage) {
     return;
@@ -33,35 +31,11 @@ function redirectToErrorPage() {
   window.dispatchEvent(new PopStateEvent('popstate'));
 }
 
-function isCriticalRuntimeError(reason) {
-  if (!reason) {
-    return false;
-  }
-
-  const message = typeof reason === 'string' ? reason : reason.message;
-
-  if (!message || typeof message !== 'string') {
-    return false;
-  }
-
-  const normalizedMessage = message.toLowerCase();
-  return CRITICAL_ERROR_SIGNATURES.some((signature) => normalizedMessage.includes(signature));
-}
-
-window.addEventListener('error', (event) => {
-  // Evita redirecionar por falhas não fatais (ex.: extensão, erro de API, warning de runtime).
-  if (!(event instanceof ErrorEvent) || !isCriticalRuntimeError(event.error)) {
-    return;
-  }
-
+window.addEventListener('error', () => {
   redirectToErrorPage();
 });
 
-window.addEventListener('unhandledrejection', (event) => {
-  if (!isCriticalRuntimeError(event.reason)) {
-    return;
-  }
-
+window.addEventListener('unhandledrejection', () => {
   redirectToErrorPage();
 });
 

--- a/src/pages/errors/NotFoundPage.js
+++ b/src/pages/errors/NotFoundPage.js
@@ -1,49 +1,141 @@
 import { Link as RouterLink } from 'react-router-dom';
 // @mui
-import { styled } from '@mui/material/styles';
-import { Button, Typography, Container, Box } from '@mui/material';
+import { alpha, styled } from '@mui/material/styles';
+import { Button, Typography, Container, Box, Stack, Paper, Chip } from '@mui/material';
+import SensorsRoundedIcon from '@mui/icons-material/SensorsRounded';
+import SpaRoundedIcon from '@mui/icons-material/SpaRounded';
+import HubRoundedIcon from '@mui/icons-material/HubRounded';
 // components
 import Page from '../../components/Page';
 
 // ----------------------------------------------------------------------
 
-const ContentStyle = styled('div')(({ theme }) => ({
-  maxWidth: 480,
-  margin: 'auto',
+const HeroSection = styled(Box)(({ theme }) => ({
   minHeight: '100vh',
   display: 'flex',
-  justifyContent: 'center',
-  flexDirection: 'column',
-  padding: theme.spacing(12, 0)
+  alignItems: 'center',
+  position: 'relative',
+  overflow: 'hidden',
+  padding: theme.spacing(8, 0),
+  background: `linear-gradient(140deg, ${alpha(theme.palette.success.light, 0.28)} 0%, ${alpha(theme.palette.info.light, 0.24)} 55%, ${alpha(theme.palette.primary.light, 0.2)} 100%)`,
+}));
+
+const GlowShape = styled(Box)(({ theme }) => ({
+  position: 'absolute',
+  borderRadius: '50%',
+  zIndex: 0,
+  '&.shape1': {
+    width: 320,
+    height: 320,
+    top: -120,
+    right: -70,
+    background: alpha(theme.palette.success.main, 0.2),
+  },
+  '&.shape2': {
+    width: 240,
+    height: 240,
+    bottom: -90,
+    left: -60,
+    background: alpha(theme.palette.info.main, 0.2),
+  },
+}));
+
+const ErrorCard = styled(Paper)(({ theme }) => ({
+  position: 'relative',
+  zIndex: 1,
+  width: '100%',
+  maxWidth: 1080,
+  margin: '0 auto',
+  borderRadius: theme.spacing(4),
+  border: `1px solid ${alpha(theme.palette.success.main, 0.25)}`,
+  boxShadow: `0 28px 54px ${alpha(theme.palette.primary.dark, 0.18)}`,
+  padding: theme.spacing(4),
+  background: `linear-gradient(180deg, ${alpha(theme.palette.common.white, 0.97)}, ${alpha(theme.palette.common.white, 0.93)})`,
+  [theme.breakpoints.up('md')]: {
+    padding: theme.spacing(6),
+  },
+}));
+
+const ContextItem = styled(Box)(({ theme }) => ({
+  display: 'flex',
+  alignItems: 'center',
+  gap: theme.spacing(1.2),
+  borderRadius: theme.spacing(1.5),
+  backgroundColor: alpha(theme.palette.success.main, 0.08),
+  border: `1px solid ${alpha(theme.palette.success.main, 0.2)}`,
+  padding: theme.spacing(1.2, 1.4),
 }));
 
 // ----------------------------------------------------------------------
 
-export default function Page404() {
+export default function NotFoundPage() {
   return (
-    <Page title="404 Page Not Found">
-      <Container>
-        <ContentStyle sx={{ textAlign: 'center', alignItems: 'center' }}>
-          <Typography variant="h3" paragraph>
-            Sorry, page not found!
-          </Typography>
+    <Page title="Erro 404">
+      <HeroSection>
+        <GlowShape className="shape1" />
+        <GlowShape className="shape2" />
 
-          <Typography sx={{ color: 'text.secondary' }}>
-            Sorry, we couldn’t find the page you’re looking for. Perhaps you’ve mistyped the URL? Be
-            sure to check your spelling.
-          </Typography>
+        <Container>
+          <ErrorCard>
+            <Stack direction={{ xs: 'column', md: 'row' }} spacing={{ xs: 4, md: 7 }} alignItems="center">
+              <Box sx={{ width: '100%', maxWidth: 500 }}>
+                <Chip
+                  icon={<SensorsRoundedIcon />}
+                  label="Plataforma de Horta Conectada"
+                  color="success"
+                  sx={{ mb: 2, fontWeight: 700 }}
+                />
 
-          <Box
-            component="img"
-            src="/static/illustrations/illustration_404.svg"
-            sx={{ height: 260, mx: 'auto', my: { xs: 5, sm: 10 } }}
-          />
+                <Typography variant="h2" sx={{ mb: 1, color: 'primary.main', fontWeight: 800 }}>
+                  Erro 404
+                </Typography>
 
-          <Button to="/" size="large" variant="contained" component={RouterLink}>
-            Go to Home
-          </Button>
-        </ContentStyle>
-      </Container>
+                <Typography variant="h4" sx={{ mb: 2, lineHeight: 1.2 }}>
+                  Sinal perdido na sua plantação inteligente
+                </Typography>
+
+                <Typography sx={{ color: 'text.secondary', mb: 1.2 }}>
+                  Esta rota não foi encontrada no painel da sua rede IoT. Vamos te reconectar para continuar
+                  monitorando sensores, irrigação e saúde da horta.
+                </Typography>
+
+                <Typography sx={{ color: 'text.secondary', mb: 3 }}>
+                  Tente novamente mais tarde se o problema persistir.
+                </Typography>
+
+                <Stack direction={{ xs: 'column', sm: 'row' }} spacing={1.5}>
+                  <Button to="/login" size="large" variant="contained" component={RouterLink}>
+                    Voltar ao painel
+                  </Button>
+
+                  <Button size="large" variant="outlined" onClick={() => window.location.reload()}>
+                    Reconectar agora
+                  </Button>
+                </Stack>
+
+                <Stack direction={{ xs: 'column', sm: 'row' }} spacing={1.2} sx={{ mt: 3 }}>
+                  <ContextItem>
+                    <SpaRoundedIcon color="success" fontSize="small" />
+                    <Typography variant="body2">Cultivo monitorado</Typography>
+                  </ContextItem>
+
+                  <ContextItem>
+                    <HubRoundedIcon color="info" fontSize="small" />
+                    <Typography variant="body2">Sensores em rede</Typography>
+                  </ContextItem>
+                </Stack>
+              </Box>
+
+              <Box
+                component="img"
+                src="/static/illustrations/illustration_404.svg"
+                alt="Ilustração de horta conectada com IoT"
+                sx={{ width: '100%', maxWidth: 430, height: 'auto' }}
+              />
+            </Stack>
+          </ErrorCard>
+        </Container>
+      </HeroSection>
     </Page>
   );
 }


### PR DESCRIPTION
### Motivation
- Improve the user experience for the 404 route with a clearer, branded UI and localized messaging. 
- Avoid accidentally redirecting a user away from the explicit 404 page when the splash finishes. 
- Simplify runtime error handling so application-level errors reliably route users to the error page.

### Description
- Update `App.js` to only force-redirect to `/login` when the app starts at the root path (`'/'`) and stop redirecting when the initial route is `'/404'`. 
- Simplify error handling in `src/index.js` by removing message-based filtering and always calling the error redirect for `error` and `unhandledrejection` events. 
- Replace the old minimal 404 view in `src/pages/errors/NotFoundPage.js` with a redesigned `NotFoundPage` using `HeroSection`, `GlowShape`, and `ErrorCard` styled components, localized Portuguese copy, new icons, chips, contextual items, and action buttons for returning to the login panel or reloading to reconnect. 

### Testing
- No automated tests were executed as part of this rollout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69aad9cb61a48328b3d8976c65a9b070)