### PR TITLE
feat(seo): dynamic metadata, JSON-LD, robots/sitemap and SSR head improvements

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://hortelan-frontend.vercel.app/sitemap.xml

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://hortelan-frontend.vercel.app/</loc>
+    <changefreq>daily</changefreq>
+    <priority>1.0</priority>
+  </url>
+  <url>
+    <loc>https://hortelan-frontend.vercel.app/login</loc>
+    <changefreq>daily</changefreq>
+    <priority>0.9</priority>
+  </url>
+  <url>
+    <loc>https://hortelan-frontend.vercel.app/register</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://hortelan-frontend.vercel.app/forgot-password</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.6</priority>
+  </url>
+  <url>
+    <loc>https://hortelan-frontend.vercel.app/reset-password</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.6</priority>
+  </url>
+</urlset>

--- a/src/components/Page.js
+++ b/src/components/Page.js
@@ -1,30 +1,101 @@
 import PropTypes from 'prop-types';
 import { Helmet } from 'react-helmet-async';
 import { forwardRef } from 'react';
+import { useLocation } from 'react-router-dom';
 // @mui
 import { Box } from '@mui/material';
+import { siteMetadata, toAbsoluteUrl } from '../seo/siteMetadata';
 
 // ----------------------------------------------------------------------
 
-const Page = forwardRef(({ children, title = '', meta, ...other }, ref) => (
-  <>
-    <Helmet>
-      <title>{`${title} | Hortelan AgTech Ltda`}</title>
-      {meta}
-    </Helmet>
+const PRIVATE_PATHS = ['/dashboard'];
+const AUTH_PATHS = ['/login', '/register', '/forgot-password', '/reset-password'];
 
-    <Box ref={ref} {...other}>
-      {children}
-    </Box>
-  </>
-));
+function resolveTitle(pageTitle) {
+  if (!pageTitle) {
+    return siteMetadata.defaultTitle;
+  }
+
+  return pageTitle.includes(siteMetadata.siteName) ? pageTitle : `${pageTitle} | ${siteMetadata.siteName}`;
+}
+
+const Page = forwardRef(
+  (
+    {
+      children,
+      title = '',
+      description = siteMetadata.description,
+      canonicalPath,
+      image,
+      meta,
+      noIndex,
+      schema,
+      ...other
+    },
+    ref
+  ) => {
+    const { pathname } = useLocation();
+    const resolvedPath = canonicalPath || pathname;
+    const canonicalUrl = toAbsoluteUrl(resolvedPath);
+    const pageTitle = resolveTitle(title);
+    const previewImage = toAbsoluteUrl(image || siteMetadata.ogImage);
+    const shouldNoIndex =
+      typeof noIndex === 'boolean'
+        ? noIndex
+        : PRIVATE_PATHS.some((prefix) => pathname.startsWith(prefix)) || AUTH_PATHS.includes(pathname);
+
+    const organizationSchema = {
+      '@context': 'https://schema.org',
+      '@type': 'Organization',
+      name: siteMetadata.siteName,
+      url: siteMetadata.siteUrl,
+      logo: toAbsoluteUrl('/favicon/android-chrome-512x512.png'),
+      sameAs: siteMetadata.socialProfiles,
+    };
+
+    return (
+      <>
+        <Helmet>
+          <title>{pageTitle}</title>
+          <meta name="description" content={description} />
+          <link rel="canonical" href={canonicalUrl} />
+          <meta name="robots" content={shouldNoIndex ? 'noindex,nofollow' : 'index,follow'} />
+
+          <meta property="og:type" content="website" />
+          <meta property="og:site_name" content={siteMetadata.siteName} />
+          <meta property="og:title" content={pageTitle} />
+          <meta property="og:description" content={description} />
+          <meta property="og:url" content={canonicalUrl} />
+          <meta property="og:image" content={previewImage} />
+
+          <meta name="twitter:card" content="summary_large_image" />
+          <meta name="twitter:title" content={pageTitle} />
+          <meta name="twitter:description" content={description} />
+          <meta name="twitter:image" content={previewImage} />
+          {meta}
+
+          <script type="application/ld+json">{JSON.stringify(schema || organizationSchema)}</script>
+        </Helmet>
+
+        <Box ref={ref} {...other}>
+          {children}
+        </Box>
+      </>
+    );
+  }
+);
 
 Page.displayName = 'Page';
 
 Page.propTypes = {
   children: PropTypes.node.isRequired,
   title: PropTypes.string,
+  description: PropTypes.string,
+  canonicalPath: PropTypes.string,
+  image: PropTypes.string,
   meta: PropTypes.node,
+  noIndex: PropTypes.bool,
+  schema: PropTypes.object,
 };
 
 export default Page;

--- a/src/entry-server.js
+++ b/src/entry-server.js
@@ -4,7 +4,7 @@ import { StaticRouter } from 'react-router-dom/server';
 import { HelmetProvider } from 'react-helmet-async';
 import App from './App';
 
-const SSR_ROUTES = ['/login', '/register', '/forgot-password'];
+const SSR_ROUTES = ['/', '/login', '/register', '/forgot-password', '/reset-password', '/404'];
 
 export function shouldUseSsr(url) {
   const path = url.split('?')[0];
@@ -23,6 +23,8 @@ export function render(url) {
 
   return {
     appHtml,
-    headTags: helmetContext.helmet ? `${helmetContext.helmet.title.toString()}${helmetContext.helmet.meta.toString()}` : '',
+    headTags: helmetContext.helmet
+      ? `${helmetContext.helmet.title.toString()}${helmetContext.helmet.meta.toString()}${helmetContext.helmet.link.toString()}${helmetContext.helmet.script.toString()}`
+      : '',
   };
 }

--- a/src/seo/siteMetadata.js
+++ b/src/seo/siteMetadata.js
@@ -1,0 +1,22 @@
+const DEFAULT_SITE_URL = 'https://hortelan-frontend.vercel.app';
+const DEFAULT_DESCRIPTION =
+  'Hortelan AgTech Ltda: plataforma para monitoramento operacional, catálogo de espécies, integrações e inteligência para operações agrícolas em escala.';
+const DEFAULT_OG_IMAGE = '/static/preview.jpg';
+
+export const siteMetadata = {
+  siteName: 'Hortelan AgTech Ltda',
+  defaultTitle: 'Hortelan AgTech Ltda',
+  description: DEFAULT_DESCRIPTION,
+  siteUrl: (import.meta.env.VITE_SITE_URL || DEFAULT_SITE_URL).replace(/\/$/, ''),
+  ogImage: import.meta.env.VITE_OG_IMAGE || DEFAULT_OG_IMAGE,
+  socialProfiles: ['https://www.linkedin.com'],
+};
+
+export function toAbsoluteUrl(path = '/') {
+  if (/^https?:\/\//i.test(path)) {
+    return path;
+  }
+
+  const normalizedPath = path.startsWith('/') ? path : `/${path}`;
+  return `${siteMetadata.siteUrl}${normalizedPath}`;
+}


### PR DESCRIPTION
### Motivation
- Melhorar indexação orgânica e previews sociais sem migrar para Next.js, centralizando metadados e pré-render básico para rotas chave.
- Garantir que tags importantes (canonical, OG, JSON-LD) sejam geradas por rota e apareçam no HTML server-side para crawlers e compartilhamentos.

### Description
- Adicionado `src/seo/siteMetadata.js` com `siteMetadata` e `toAbsoluteUrl` para configurar `VITE_SITE_URL` e `VITE_OG_IMAGE` e normalizar URLs.
- Atualizado `src/components/Page.js` para emitir `title`, `description`, `canonical`, `robots`, Open Graph, Twitter Card e JSON-LD Organization, e para calcular `noindex` automaticamente em rotas privadas/autenticação.
- Ajustado `src/entry-server.js` para incluir `link` e `script` extraídos pelo `react-helmet-async` no head server-side e ampliar a lista de rotas SSR para `['/', '/login', '/register', '/forgot-password', '/reset-password', '/404']`.
- Adicionados `public/robots.txt` e `public/sitemap.xml` com entradas básicas de descoberta para os principais caminhos.

### Testing
- Executado `npm run lint` e o lint passou com sucesso (`✅`).
- Executado `npm run build` e o build de produção completou com sucesso (`✅`).
- Executado `npm run build:ssr` e falhou devido a uma configuração de SSR/Vite existente (`react cannot be included in manualChunks`) que precisa de ajuste na pipeline SSR (`❌`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69aae3ae6cb08328ba52381dc8a43e1b)