### PR TITLE
Fix Vite dependency scan error by importing SimpleBar dist CSS

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
 // scroll bar
-import 'simplebar/src/simplebar.css';
+import 'simplebar/dist/simplebar.css';
 
 import { createRoot, hydrateRoot } from 'react-dom/client';
 import { BrowserRouter } from 'react-router-dom';


### PR DESCRIPTION
### Motivation
- Vite's dependency scan failed during startup because `simplebar/src/simplebar.css` is not a resolvable/exported specifier from the installed SimpleBar package, causing the dev server to error on dependency pre-bundling.

### Description
- Updated the SimpleBar stylesheet import in `src/index.js` from `import 'simplebar/src/simplebar.css';` to `import 'simplebar/dist/simplebar.css';` so the import uses the package-distributed CSS path.

### Testing
- Ran `npm run build` and the build completed successfully, with no SimpleBar import resolution error reported.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69ab070aabac83288d659eaff561ef7c)