### PR TITLE
Fix Vite dependency optimization failure for ApexCharts

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -3,6 +3,11 @@ import react from '@vitejs/plugin-react';
 
 export default defineConfig({
   plugins: [react()],
+  resolve: {
+    alias: {
+      'apexcharts/client': 'apexcharts',
+    },
+  },
   esbuild: {
     loader: 'jsx',
     include: /src\/.*\.[jt]sx?$/,


### PR DESCRIPTION
### Motivation
- Prevent Vite dependency optimization/build failure caused by `react-apexcharts` importing the unresolved subpath `apexcharts/client` by making that import resolvable at build/start time.

### Description
- Add a `resolve.alias` entry in `vite.config.js` that maps `'apexcharts/client'` to `'apexcharts'` to route the import to the installed package.

### Testing
- Successfully started the dev server with `npm run start -- --host 0.0.0.0 --port 3001` and completed a production build with `npm run build` (both commands exited without errors).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69ab40ebf95c832884a3e184ad28edcd)