### PR TITLE
Corrige tela branca no boot: fallback da splash, animação mais leve e fallback de rota

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useCallback, useEffect, useState } from "react";
 import { useLocation, useNavigate } from 'react-router-dom';
 import SplashHarvestPro from "./SplashHarvestPro";
 import Router from "./routes";
@@ -8,7 +8,15 @@ export default function App() {
   const navigate = useNavigate();
   const location = useLocation();
 
-  const handleSplashFinish = () => {
+  useEffect(() => {
+    const fallbackTimer = window.setTimeout(() => {
+      setShowSplash(false);
+    }, 10000);
+
+    return () => window.clearTimeout(fallbackTimer);
+  }, []);
+
+  const handleSplashFinish = useCallback(() => {
     setShowSplash(false);
 
     // Garante a splash como primeira tela em qualquer rota de entrada.
@@ -16,7 +24,7 @@ export default function App() {
     if (location.pathname === '/') {
       navigate('/login', { replace: true, state: { forceLogin: true } });
     }
-  };
+  }, [location.pathname, navigate]);
 
   return showSplash ? (
     <SplashHarvestPro onFinish={handleSplashFinish} />

--- a/src/SplashHarvestPro.js
+++ b/src/SplashHarvestPro.js
@@ -53,7 +53,7 @@ export default function SplashHarvestPro({ onFinish }) {
 
   useEffect(() => {
     const controls = animate(p, 1, {
-      duration: 24,
+      duration: 8,
       ease: "linear",
       onComplete: () => {
         setDone(true);
@@ -65,7 +65,7 @@ export default function SplashHarvestPro({ onFinish }) {
 
   // “soja procedural” full-screen (mais densa)
   const plants = useMemo(() => {
-    const count = 2600;
+    const count = 1400;
     const arr = [];
     for (let i = 0; i < count; i++) {
       const x = Math.random() * 100;

--- a/src/routes.js
+++ b/src/routes.js
@@ -27,7 +27,7 @@ const IntegrationsPage = lazy(() => import('./pages/dashboard/IntegrationsPage')
 const LoginForm = lazy(() => import('./sections/auth/login').then((module) => ({ default: module.LoginForm })));
 
 const renderLazy = (Component) => (
-  <Suspense fallback={null}>
+  <Suspense fallback={<div style={{ minHeight: "100vh", background: "#F7FAFC" }} />}>
     <Component />
   </Suspense>
 );


### PR DESCRIPTION
### Motivation
- Evitar que a aplicação fique em tela branca quando a animação da splash não terminar ou quando chunks lazy demorarem a carregar. 

### Description
- Adiciona um fallback de segurança de 10s em `src/App.js` que força a saída da splash caso o `onFinish` não seja disparado e estabiliza `handleSplashFinish` com `useCallback`.
- Reduz a duração da animação na splash de `24s` para `8s` em `src/SplashHarvestPro.js` e diminui a contagem procedural de plantas de `2600` para `1400` para reduzir custo de render inicial.
- Define um fallback visual no `Suspense` das rotas em `src/routes.js` para evitar renderização totalmente em branco enquanto os componentes lazy carregam.

### Testing
- Executado `npm run build` e o build completou com sucesso.
- Executado o servidor em desenvolvimento com `npm run dev -- --host 0.0.0.0 --port 3001` e servidor respondeu corretamente.
- Validações automáticas com Playwright abriram `http://127.0.0.1:3001/`, capturaram screenshots da splash e confirmaram a navegação subsequente para `/login` (sem tela branca) e todas as verificações passaram.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69ab43f5c2888328b01b0a11e85c6665)