### PR TITLE
Adicionar SplashErrorBoundary defensivo para evitar tela branca na splash

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,7 +1,36 @@
-import React, { useCallback, useEffect, useState } from "react";
+import React, { Component, useCallback, useEffect, useState } from "react";
 import { useLocation, useNavigate } from 'react-router-dom';
 import SplashHarvestPro from "./SplashHarvestPro";
 import Router from "./routes";
+
+class SplashErrorBoundary extends Component {
+  constructor(props) {
+    super(props);
+    this.state = { hasError: false };
+  }
+
+  static getDerivedStateFromError() {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error) {
+    // eslint-disable-next-line no-console
+    console.error('Falha ao renderizar SplashHarvestPro.', error);
+    this.props.onError?.();
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <div style={{ minHeight: '100vh', background: '#0b1220', color: '#fff', display: 'grid', placeItems: 'center', fontWeight: 700 }}>
+          Carregando plataforma Hortelan...
+        </div>
+      );
+    }
+
+    return this.props.children;
+  }
+}
 
 export default function App() {
   const [showSplash, setShowSplash] = useState(true);
@@ -27,7 +56,9 @@ export default function App() {
   }, [location.pathname, navigate]);
 
   return showSplash ? (
-    <SplashHarvestPro onFinish={handleSplashFinish} />
+    <SplashErrorBoundary onError={() => setShowSplash(false)}>
+      <SplashHarvestPro onFinish={handleSplashFinish} />
+    </SplashErrorBoundary>
   ) : (
     <Router />
   );


### PR DESCRIPTION
### Motivation
- Evitar que erros de renderização na tela de splash deixem a aplicação em tela branca sem recuperar a navegação.

### Description
- Adiciona o componente `SplashErrorBoundary` em `src/App.js` para capturar erros de renderização da `SplashHarvestPro` e fornecer um fallback visual simples.
- Envolve `SplashHarvestPro` com `SplashErrorBoundary` e aciona `onError` para encerrar a splash e permitir o fluxo normal de rotas (`setShowSplash(false)`).
- Mantém o timer de fallback existente e a lógica de redirecionamento para `'/login'` intactos.

### Testing
- Executado `npm run lint` e o lint passou sem erros.
- Executado `npm run build` e a build foi concluída com sucesso.
- Rodado um script Playwright para abrir `http://127.0.0.1:3001` e capturar um screenshot da splash, que confirmou a renderização do fallback/visual esperado.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69ab47a18b4c8328bf183e441acf1606)