### PR TITLE
Fix splash screen fallback on initial app load

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -21,19 +21,33 @@ class SplashErrorBoundary extends Component {
 
   render() {
     if (this.state.hasError) {
-      return (
-        <div style={{ minHeight: '100vh', background: '#0b1220', color: '#fff', display: 'grid', placeItems: 'center', fontWeight: 700 }}>
-          Carregando plataforma Hortelan...
-        </div>
-      );
+      return null;
     }
 
     return this.props.children;
   }
 }
 
+function SplashFallback() {
+  return (
+    <div
+      style={{
+        minHeight: '100vh',
+        background: '#0b1220',
+        color: '#fff',
+        display: 'grid',
+        placeItems: 'center',
+        fontWeight: 700,
+      }}
+    >
+      Carregando plataforma Hortelan...
+    </div>
+  );
+}
+
 export default function App() {
   const [showSplash, setShowSplash] = useState(true);
+  const [showFallbackSplash, setShowFallbackSplash] = useState(false);
   const navigate = useNavigate();
   const location = useLocation();
 
@@ -55,11 +69,26 @@ export default function App() {
     }
   }, [location.pathname, navigate]);
 
-  return showSplash ? (
-    <SplashErrorBoundary onError={() => setShowSplash(false)}>
+  const handleSplashError = useCallback(() => {
+    setShowFallbackSplash(true);
+
+    // Mantém uma splash mínima visível antes de carregar o Router.
+    window.setTimeout(() => {
+      setShowSplash(false);
+    }, 1800);
+  }, []);
+
+  if (!showSplash) {
+    return <Router />;
+  }
+
+  if (showFallbackSplash) {
+    return <SplashFallback />;
+  }
+
+  return (
+    <SplashErrorBoundary onError={handleSplashError}>
       <SplashHarvestPro onFinish={handleSplashFinish} />
     </SplashErrorBoundary>
-  ) : (
-    <Router />
   );
 }


### PR DESCRIPTION
### Motivation
- The splash animation could throw during initial rendering and the app would immediately skip the splash, producing no initial loading feedback for the user.
- Ensure users always see a splash (animated or minimal) on first load even when the animation component fails.

### Description
- Modified `src/App.js` so `SplashErrorBoundary` stops returning a built-in static UI and instead returns `null`, delegating fallback handling to the app host.
- Added a lightweight `SplashFallback` component and a `showFallbackSplash` state to present a minimal splash when `SplashHarvestPro` errors.
- Implemented `handleSplashError` to show the fallback splash briefly (approximately `1800ms`) before allowing the app `Router` to mount, preserving the existing 10s global fallback timeout.
- Adjusted the render flow so the app returns early with `<Router />` when `showSplash` is false, otherwise displays the animated splash or the fallback splash as needed.

### Testing
- Ran `npm run test` which executed the repository test script and exited successfully (`No test runner configured`).
- Ran `npm run lint` which failed in this environment due to missing dependency resolution (`Cannot find module '@eslint/eslintrc'`).
- Attempted `npm run dev` but the dev server could not start in this environment because `vite` was not available after package install issues.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69ab4974da848328aa24db7220aab7fe)