### PR TITLE
Fix routing and Suspense fallback to avoid blank screen after splash

### DIFF
--- a/src/routes.js
+++ b/src/routes.js
@@ -27,7 +27,22 @@ const IntegrationsPage = lazy(() => import('./pages/dashboard/IntegrationsPage')
 const LoginForm = lazy(() => import('./sections/auth/login').then((module) => ({ default: module.LoginForm })));
 
 const renderLazy = (Component) => (
-  <Suspense fallback={<div style={{ minHeight: "100vh", background: "#F7FAFC" }} />}>
+  <Suspense
+    fallback={
+      <div
+        style={{
+          minHeight: '100vh',
+          display: 'grid',
+          placeItems: 'center',
+          background: '#0b1220',
+          color: '#ffffff',
+          fontWeight: 700,
+        }}
+      >
+        Carregando módulo...
+      </div>
+    }
+  >
     <Component />
   </Suspense>
 );
@@ -63,7 +78,7 @@ export default function Router() {
       ],
     },
     {
-      path: 'login',
+      path: '/login',
       element: (
         <RedirectIfAuth>
           {renderLazy(LoginForm)}
@@ -71,7 +86,7 @@ export default function Router() {
       ),
     },
     {
-      path: 'register',
+      path: '/register',
       element: (
         <RedirectIfAuth>
           {renderLazy(LoginForm)}
@@ -79,20 +94,26 @@ export default function Router() {
       ),
     },
     {
-      path: 'forgot-password',
+      path: '/forgot-password',
       element: renderLazy(ForgotPasswordPage),
     },
     {
-      path: 'reset-password',
+      path: '/reset-password',
       element: renderLazy(ResetPasswordPage),
     },
     {
+      path: '/404',
+      element: renderLazy(NotFoundPage),
+    },
+    {
       path: '/',
+      element: <Navigate to="/login" replace />,
+    },
+    {
+      path: '/auth',
       element: <LogoOnlyLayout />,
       children: [
-        { path: '/', element: <Navigate to="/login" /> },
-        { path: '404', element: renderLazy(NotFoundPage) },
-        { path: '*', element: <Navigate to="/404" /> },
+        { index: true, element: <Navigate to="/login" replace /> },
       ],
     },
     {


### PR DESCRIPTION
### Motivation
- The app could land on a blank screen after the splash because lazy-route fallbacks and relative auth routes did not guarantee a visible or matchable entry route when the SPA booted from arbitrary URLs.
- Provide a deterministic initial navigation target and a visible loading state while lazy chunks load so the UX is not a white/empty page during startup.

### Description
- Replaced the minimal blank `Suspense` fallback with a visible centered loading block (text: `Carregando módulo...`) to avoid a white full-height placeholder while lazy chunks load.
- Converted auth route definitions to absolute paths (`/login`, `/register`, `/forgot-password`, `/reset-password`) to ensure consistent matching from any entry URL.
- Added a direct `/404` route and an explicit root redirect from `/` to `/login` so the app always has a valid post-splash landing route and predictable fallback behavior.
- Adjusted the auth/layout routing structure so the index child under the auth layout redirects to `/login` (uses `index: true` with `replace`) and the global `*` route redirects to `/404`.

### Testing
- Built the production bundle with `npm run build` and the build completed successfully (vite build finished without errors). 
- Ran the dev server with `npm run dev -- --host 0.0.0.0 --port 4173` and confirmed the server became ready at `http://localhost:4173/`.
- Automated browser checks (Playwright) navigated to `/`, `/login`, `/dashboard/app` and an arbitrary path and verified final navigation lands at `/login` for root and that the login UI renders; a screenshot of the login page after splash was captured successfully.
- All automated checks and the local build succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69ab5c334a88832884dbd37d9529617a)