### PR TITLE
Adjust Vite dev server host and port

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -21,7 +21,8 @@ export default defineConfig({
     },
   },
   server: {
-    port: 3000,
+    host: '127.0.0.1',
+    port: 5173,
   },
   build: {
     outDir: 'build',


### PR DESCRIPTION
### Motivation
- Ensure the Vite dev server binds to the loopback interface and uses the expected port so the local dev banner shows `http://127.0.0.1:5173/` instead of the previous `http://localhost:3000/`.

### Description
- Update `vite.config.js` to add `host: '127.0.0.1'` and change `port` from `3000` to `5173` under the `server` configuration.

### Testing
- Ran `npm run dev` (with a short timeout) and confirmed the Vite banner reports `Local:   http://127.0.0.1:5173/`, indicating the new host and port are active.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69ab5e521ccc83289af7b5b31bc33379)