### PR TITLE
fix: corrigir tela branca causada por APIs antigas do faker

### DIFF
--- a/src/_mock/blog.js
+++ b/src/_mock/blog.js
@@ -30,16 +30,16 @@ const POST_TITLES = [
 ];
 
 const posts = [...Array(23)].map((_, index) => ({
-  id: faker.datatype.uuid(),
+  id: faker.string.uuid(),
   cover: `/static/mock-images/covers/cover_${index + 1}.jpg`,
   title: POST_TITLES[index + 1],
   createdAt: faker.date.past(),
-  view: faker.datatype.number(),
-  comment: faker.datatype.number(),
-  share: faker.datatype.number(),
-  favorite: faker.datatype.number(),
+  view: faker.number.int({ min: 0, max: 9999 }),
+  comment: faker.number.int({ min: 0, max: 9999 }),
+  share: faker.number.int({ min: 0, max: 9999 }),
+  favorite: faker.number.int({ min: 0, max: 9999 }),
   author: {
-    name: faker.name.findName(),
+    name: faker.person.fullName(),
     avatarUrl: `/static/mock-images/avatars/avatar_${index + 1}.jpg`,
   },
 }));

--- a/src/_mock/products.js
+++ b/src/_mock/products.js
@@ -37,11 +37,11 @@ const products = [...Array(24)].map((_, index) => {
   const setIndex = index + 1;
 
   return {
-    id: faker.datatype.uuid(),
+    id: faker.string.uuid(),
     cover: `/static/mock-images/products/product_${setIndex}.jpg`,
     name: PRODUCT_NAME[index],
-    price: faker.datatype.number({ min: 4, max: 99, precision: 0.01 }),
-    priceSale: setIndex % 3 ? null : faker.datatype.number({ min: 19, max: 29, precision: 0.01 }),
+    price: faker.number.float({ min: 4, max: 99, fractionDigits: 2 }),
+    priceSale: setIndex % 3 ? null : faker.number.float({ min: 19, max: 29, fractionDigits: 2 }),
     colors:
       (setIndex === 1 && PRODUCT_COLOR.slice(0, 2)) ||
       (setIndex === 2 && PRODUCT_COLOR.slice(1, 3)) ||

--- a/src/_mock/user.js
+++ b/src/_mock/user.js
@@ -4,10 +4,10 @@ import { sample } from 'lodash';
 // ----------------------------------------------------------------------
 
 const users = [...Array(24)].map((_, index) => ({
-  id: faker.datatype.uuid(),
+  id: faker.string.uuid(),
   avatarUrl: `/static/mock-images/avatars/avatar_${index + 1}.jpg`,
   name: sample(['Garden01', 'Garden02', 'Garden03', 'Garden04', 'Garden05']),
-  company: faker.company.companyName(),
+  company: faker.company.name(),
   isVerified: faker.datatype.boolean(),
   status: sample(['Active', 'Inactive']),
   role: sample([

--- a/src/layouts/dashboard/NotificationsPopover.js
+++ b/src/layouts/dashboard/NotificationsPopover.js
@@ -30,7 +30,7 @@ import MenuPopover from '../../components/MenuPopover';
 
 const NOTIFICATIONS = [
   {
-    id: faker.datatype.uuid(),
+    id: faker.string.uuid(),
     title: 'Your order is placed',
     description: 'waiting for shipping',
     avatar: null,
@@ -39,8 +39,8 @@ const NOTIFICATIONS = [
     isUnRead: true,
   },
   {
-    id: faker.datatype.uuid(),
-    title: faker.name.findName(),
+    id: faker.string.uuid(),
+    title: faker.person.fullName(),
     description: 'answered to your comment on community',
     avatar: '/static/mock-images/avatars/avatar_2.jpg',
     type: 'friend_interactive',
@@ -48,7 +48,7 @@ const NOTIFICATIONS = [
     isUnRead: true,
   },
   {
-    id: faker.datatype.uuid(),
+    id: faker.string.uuid(),
     title: 'You have new comment in the your post community',
     description: '5 unread answers',
     type: 'chat_message',
@@ -56,7 +56,7 @@ const NOTIFICATIONS = [
     isUnRead: false,
   },
   {
-    id: faker.datatype.uuid(),
+    id: faker.string.uuid(),
     title: 'You have new comment in the your post community',
     description: '4 unread answers',
     type: 'chat_message',
@@ -64,7 +64,7 @@ const NOTIFICATIONS = [
     isUnRead: false,
   },
   {
-    id: faker.datatype.uuid(),
+    id: faker.string.uuid(),
     title: 'Delivery processing',
     description: 'Your order is being shipped',
     avatar: null,

--- a/src/pages/dashboard/MonitoringPage.js
+++ b/src/pages/dashboard/MonitoringPage.js
@@ -365,7 +365,7 @@ export default function DashboardApp() {
   );
   const [agendaTarefas, setAgendaTarefas] = useState([
     {
-      id: faker.datatype.uuid(),
+      id: faker.string.uuid(),
       tipo: 'Rega',
       titulo: 'Rega das mudas da Estufa A',
       descricao: 'Aplicar rega leve no início da manhã.',
@@ -373,8 +373,8 @@ export default function DashboardApp() {
       responsavel: 'Ana',
       vencimento: todayString,
       checklist: [
-        { id: faker.datatype.uuid(), texto: 'Conferir umidade antes de regar', concluido: false },
-        { id: faker.datatype.uuid(), texto: 'Registrar volume de água aplicado', concluido: false },
+        { id: faker.string.uuid(), texto: 'Conferir umidade antes de regar', concluido: false },
+        { id: faker.string.uuid(), texto: 'Registrar volume de água aplicado', concluido: false },
       ],
       concluida: false,
       observacoes: [],
@@ -382,28 +382,28 @@ export default function DashboardApp() {
       insumos: [],
     },
     {
-      id: faker.datatype.uuid(),
+      id: faker.string.uuid(),
       tipo: 'Verificação de pragas',
       titulo: 'Inspeção visual no canteiro B',
       descricao: 'Verificar sinais de pulgões e manchas foliares.',
       periodicidade: 'Semanal',
       responsavel: 'Bruno',
       vencimento: twoDaysAgoString,
-      checklist: [{ id: faker.datatype.uuid(), texto: 'Inspecionar verso das folhas', concluido: false }],
+      checklist: [{ id: faker.string.uuid(), texto: 'Inspecionar verso das folhas', concluido: false }],
       concluida: false,
       observacoes: [],
       fotos: [],
       insumos: [],
     },
     {
-      id: faker.datatype.uuid(),
+      id: faker.string.uuid(),
       tipo: 'Troca de água (hidroponia)',
       titulo: 'Troca parcial da solução nutritiva',
       descricao: 'Renovar 30% do reservatório.',
       periodicidade: 'Quinzenal',
       responsavel: 'Equipe Hidroponia',
       vencimento: tomorrowString,
-      checklist: [{ id: faker.datatype.uuid(), texto: 'Medição de pH após troca', concluido: false }],
+      checklist: [{ id: faker.string.uuid(), texto: 'Medição de pH após troca', concluido: false }],
       concluida: false,
       observacoes: [],
       fotos: [],
@@ -449,7 +449,7 @@ export default function DashboardApp() {
 
     setPlantas((prev) => [
       {
-        id: faker.datatype.uuid(),
+        id: faker.string.uuid(),
         ...novaPlanta,
         familia: cropCatalog[novaPlanta.especie].family,
         ciclo: cropCatalog[novaPlanta.especie].cycle,
@@ -457,7 +457,7 @@ export default function DashboardApp() {
         fotos: [],
         observacoes: [],
         tarefas: (baseTasksByPhase[novaPlanta.faseCultivo] || []).map((titulo) => ({
-          id: faker.datatype.uuid(),
+          id: faker.string.uuid(),
           titulo,
           concluida: false,
           prioridade: 'média',
@@ -524,7 +524,7 @@ export default function DashboardApp() {
               ...planta,
               eventos: [
                 {
-                  id: faker.datatype.uuid(),
+                  id: faker.string.uuid(),
                   tipo: draft.tipo,
                   data: draft.data,
                   detalhes: draft.detalhes,
@@ -556,7 +556,7 @@ export default function DashboardApp() {
               ...planta,
               fotos: [
                 {
-                  id: faker.datatype.uuid(),
+                  id: faker.string.uuid(),
                   data: draft.data,
                   url: draft.url,
                   legenda: draft.legenda || '',
@@ -588,7 +588,7 @@ export default function DashboardApp() {
               ...planta,
               observacoes: [
                 {
-                  id: faker.datatype.uuid(),
+                  id: faker.string.uuid(),
                   data: draft.data,
                   texto: draft.texto,
                 },
@@ -665,7 +665,7 @@ export default function DashboardApp() {
 
     setAutomationRules((prev) => [
       {
-        id: faker.datatype.uuid(),
+        id: faker.string.uuid(),
         ...automationDraft,
       },
       ...prev,
@@ -683,7 +683,7 @@ export default function DashboardApp() {
               ...planta,
               tarefas: [
                 {
-                  id: faker.datatype.uuid(),
+                  id: faker.string.uuid(),
                   titulo,
                   concluida: false,
                   prioridade: 'média',
@@ -733,7 +733,7 @@ export default function DashboardApp() {
 
     setAgendamentosAtivos((prev) => [
       {
-        id: faker.datatype.uuid(),
+        id: faker.string.uuid(),
         ...programacao,
       },
       ...prev,
@@ -941,7 +941,7 @@ export default function DashboardApp() {
 
     setNovaTarefaAgenda((prev) => ({
       ...prev,
-      checklist: [...prev.checklist, { id: faker.datatype.uuid(), texto, concluido: false }],
+      checklist: [...prev.checklist, { id: faker.string.uuid(), texto, concluido: false }],
     }));
     setNovoChecklistItem('');
   };
@@ -951,7 +951,7 @@ export default function DashboardApp() {
 
     setAgendaTarefas((prev) => [
       {
-        id: faker.datatype.uuid(),
+        id: faker.string.uuid(),
         ...novaTarefaAgenda,
         titulo: novaTarefaAgenda.titulo.trim(),
         descricao: novaTarefaAgenda.descricao.trim(),
@@ -2707,7 +2707,7 @@ export default function DashboardApp() {
             <AppNewsUpdate
               title="Relevant community information"
               list={[...Array(5)].map((_, index) => ({
-                id: faker.datatype.uuid(),
+                id: faker.string.uuid(),
                 title: 'Relevant post in community',
                 description: 'Visit the community to learn more',
                 image: `/static/mock-images/covers/cover_${index + 1}.jpg`,
@@ -2720,7 +2720,7 @@ export default function DashboardApp() {
             <AppOrderTimeline
               title="Garden Timeline"
               list={[...Array(5)].map((_, index) => ({
-                id: faker.datatype.uuid(),
+                id: faker.string.uuid(),
                 title: [
                   'Garden01 registered',
                   'Purchase of accessories',


### PR DESCRIPTION
### Motivation
- A aplicação travava em tela branca na inicialização por erros em tempo de execução gerados por chamadas legadas da biblioteca `@faker-js/faker` (ex.: `datatype.uuid`, `name.findName`, `datatype.number`).
- Atualizar as chamadas do Faker evita exceções ao montar a árvore React e previne falhas no client render que impediam a página inicial de aparecer.

### Description
- Substituídas chamadas legadas do Faker por suas APIs atuais nas mocks e no dashboard: `faker.datatype.uuid()` → `faker.string.uuid()`, `faker.name.findName()` → `faker.person.fullName()`, `faker.datatype.number()` → `faker.number.int()` / `faker.number.float()`.
- Arquivos atualizados: `src/pages/dashboard/MonitoringPage.js`, `src/_mock/blog.js`, `src/_mock/products.js`, `src/_mock/user.js`, `src/layouts/dashboard/NotificationsPopover.js` para padronizar geração de `id` e valores numéricos de mock.
- Ajustadas entradas de notificações e outros mocks para remover fontes de exceção durante a montagem inicial do componente de notificações.

### Testing
- Levantei o servidor de desenvolvimento com `npm run dev -- --host 0.0.0.0 --port 4173` e o app subiu normalmente (dev server pronto).
- Executei um teste automatizado com Playwright navegando para `http://127.0.0.1:4173/` e confirmei que não há mais erros de página (`pageerror`) na carga inicial após as alterações.
- Tentativa de lint com `npx eslint ...` falhou no ambiente por dependência ausente (`@eslint/eslintrc`), logo o lint não pôde ser validado aqui.
- Rodei `npm test` que retorna sucesso conforme o script do projeto (`No test runner configured`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69ab7a40199083289c08ccaecae69898)