### PR TITLE
Allow Vite dev server to fallback to next available port

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -23,6 +23,7 @@ export default defineConfig({
   server: {
     host: '127.0.0.1',
     port: 5173,
+    strictPort: false,
   },
   build: {
     outDir: 'build',


### PR DESCRIPTION
### Motivation
- Ensure the Vite dev server can automatically pick another port when the default `5173` is occupied to avoid manual intervention during local development.

### Description
- Add `strictPort: false` to the `server` block in `vite.config.js` while keeping `port: 5173` so Vite can try the next open port (e.g. `5174`) if `5173` is in use.

### Testing
- Started a temporary process on `5173` and ran `npm run dev -- --host 127.0.0.1`, and Vite reported `Port 5173 is in use, trying another one...` and served at `http://127.0.0.1:5174/`, confirming the fallback behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69ab7d4b914c8328a34f2032c6c8d702)