### PR TITLE
Remove auth screen lazy-loading message before login

### DIFF
--- a/src/routes.js
+++ b/src/routes.js
@@ -26,23 +26,23 @@ const IntegrationsOperationsPage = lazy(() => import('./pages/dashboard/Integrat
 const IntegrationsPage = lazy(() => import('./pages/dashboard/IntegrationsPage'));
 const LoginForm = lazy(() => import('./sections/auth/login').then((module) => ({ default: module.LoginForm })));
 
-const renderLazy = (Component) => (
-  <Suspense
-    fallback={
-      <div
-        style={{
-          minHeight: '100vh',
-          display: 'grid',
-          placeItems: 'center',
-          background: '#0b1220',
-          color: '#ffffff',
-          fontWeight: 700,
-        }}
-      >
-        Carregando módulo...
-      </div>
-    }
+const lazyModuleFallback = (
+  <div
+    style={{
+      minHeight: '100vh',
+      display: 'grid',
+      placeItems: 'center',
+      background: '#0b1220',
+      color: '#ffffff',
+      fontWeight: 700,
+    }}
   >
+    Carregando módulo...
+  </div>
+);
+
+const renderLazy = (Component, fallback = lazyModuleFallback) => (
+  <Suspense fallback={fallback}>
     <Component />
   </Suspense>
 );
@@ -81,7 +81,7 @@ export default function Router() {
       path: '/login',
       element: (
         <RedirectIfAuth>
-          {renderLazy(LoginForm)}
+          {renderLazy(LoginForm, null)}
         </RedirectIfAuth>
       ),
     },
@@ -89,7 +89,7 @@ export default function Router() {
       path: '/register',
       element: (
         <RedirectIfAuth>
-          {renderLazy(LoginForm)}
+          {renderLazy(LoginForm, null)}
         </RedirectIfAuth>
       ),
     },


### PR DESCRIPTION
### Motivation
- Prevent the intermediate "Carregando módulo..." message from appearing between the splash and the auth screens to improve perceived startup UX.
- Make the lazy-loading fallback reusable and optionally overridable so specific routes can disable it.

### Description
- Extracted the default lazy-loading fallback into `lazyModuleFallback` and kept the same visual styling in `src/routes.js`.
- Updated `renderLazy` to accept an optional `fallback` parameter (`renderLazy(Component, fallback = lazyModuleFallback)`).
- Disabled the fallback for the auth routes by calling `renderLazy(LoginForm, null)` for `/login` and `/register` so the loading text is not shown.

### Testing
- Ran `npx eslint src/routes.js` which failed due to a missing `@eslint/eslintrc` dependency in the environment.
- Ran `npm run build` which failed due to existing project build issues unrelated to this change (`@pixi/core` resolution and Sentry export mismatches).
- Started the dev server with `npm run dev -- --host 0.0.0.0 --port 4173` which succeeded and served the app.
- Executed an automated Playwright script that navigated to `/login` and captured a screenshot, confirming the loading message no longer appears (screenshot artifact produced).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69ab8cd2882c8328bb37d2f862956fc6)