### PR TITLE
Always show demo credentials on login page (remove feature flag)

### DIFF
--- a/src/sections/auth/login/Login.js
+++ b/src/sections/auth/login/Login.js
@@ -22,7 +22,6 @@ import AuthSocial from '../AuthSocial';
 import { RegisterForm } from '../register';
 
 
-const ENABLE_DEMO_AUTH = import.meta.env.VITE_ENABLE_DEMO_AUTH === 'true';
 const RootStyle = styled('div')(({ theme }) => ({
   [theme.breakpoints.up('md')]: {
     display: 'flex',
@@ -350,7 +349,7 @@ export default function LoginForm() {
                 ? 'Preencha seus dados e confirme seu e-mail para acessar a plataforma.'
                 : 'Use seu e-mail e senha para continuar.'}
             </Typography>
-            {!isRegisterMode && ENABLE_DEMO_AUTH && (
+            {!isRegisterMode && (
               <Typography sx={{ color: 'text.secondary', mb: 5 }}>
                 Acesso de demonstração: <strong>davidfernandes@hortelanagtech.com</strong> / <strong>admin</strong>.
               </Typography>


### PR DESCRIPTION
### Motivation
- Surface the demo credentials unconditionally on the login screen by removing the feature flag guard so testers and demos see the credentials without extra config.

### Description
- Removed the `ENABLE_DEMO_AUTH` constant and updated the conditional in `src/sections/auth/login/Login.js` to always render the demo credentials paragraph when not in register mode.

### Testing
- Ran the existing automated test suite (`npm test`) and lint/type checks; all tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69ab8dbaebe88328b28b55513ecb5ea2)