### PR TITLE
feat: global auto-translation by geolocation (centralized localization service)

### DIFF
--- a/src/components/localization/AutoTranslateBootstrap.js
+++ b/src/components/localization/AutoTranslateBootstrap.js
@@ -1,0 +1,36 @@
+import { useEffect } from 'react';
+import {
+  applyGoogleLanguage,
+  detectLanguageByGeolocation,
+  detectLanguageFromBrowser,
+  ensureGoogleTranslate,
+  ensureTranslateDomSetup,
+  getStoredLanguage,
+} from '../../services/localization';
+
+export default function AutoTranslateBootstrap() {
+  useEffect(() => {
+    ensureTranslateDomSetup();
+    ensureGoogleTranslate();
+
+    const applyDetectedLanguage = async () => {
+      const manualLanguage = getStoredLanguage();
+      if (manualLanguage) {
+        applyGoogleLanguage(manualLanguage);
+        return;
+      }
+
+      try {
+        const detectedLanguage = await detectLanguageByGeolocation();
+        applyGoogleLanguage(detectedLanguage);
+      } catch (error) {
+        const fallbackLanguage = detectLanguageFromBrowser();
+        applyGoogleLanguage(fallbackLanguage);
+      }
+    };
+
+    applyDetectedLanguage();
+  }, []);
+
+  return null;
+}

--- a/src/index.js
+++ b/src/index.js
@@ -13,6 +13,7 @@ import { initReliabilityTelemetry } from './services/platformReliability';
 import { AuthProvider } from './auth/AuthContext';
 import GlobalErrorBoundary from './components/GlobalErrorBoundary';
 import ThemeProvider from './theme';
+import AutoTranslateBootstrap from './components/localization/AutoTranslateBootstrap';
 
 // ----------------------------------------------------------------------
 
@@ -79,6 +80,7 @@ const appTree = (
     <ThemeProvider>
       <AuthProvider>
         <BrowserRouter>
+          <AutoTranslateBootstrap />
           <GlobalErrorBoundary>
             <App />
           </GlobalErrorBoundary>

--- a/src/layouts/dashboard/LanguagePopover.js
+++ b/src/layouts/dashboard/LanguagePopover.js
@@ -1,134 +1,16 @@
 import { useEffect, useMemo, useState } from 'react';
 import { alpha } from '@mui/material/styles';
 import { Box, Stack, IconButton, Tooltip } from '@mui/material';
-
-const STORAGE_KEY = 'preferredLanguage';
-const GOOGLE_COOKIE_KEY = 'googtrans';
-
-const LANGS = [
-  { value: 'en', label: 'English', icon: '/static/icons/eua.svg', countries: ['US'] },
-  { value: 'pt', label: 'Português (Brasil)', icon: '/static/icons/brasil.svg', countries: ['BR'] },
-  { value: 'es', label: 'Español', icon: '/static/icons/espanha.svg', countries: ['ES'] },
-  { value: 'fr', label: 'Français', icon: '/static/icons/franca.svg', countries: ['FR'] },
-  { value: 'ja', label: '日本語', icon: '/static/icons/japao.svg', countries: ['JP'] },
-];
-
-const COUNTRY_LANGUAGE_MAP = {
-  BR: 'pt',
-  PT: 'pt',
-  FR: 'fr',
-  BE: 'fr',
-  CA: 'en',
-  US: 'en',
-  GB: 'en',
-  AU: 'en',
-  NZ: 'en',
-  IE: 'en',
-  JP: 'ja',
-  ES: 'es',
-  MX: 'es',
-  AR: 'es',
-  CL: 'es',
-  CO: 'es',
-  PE: 'es',
-  UY: 'es',
-  PY: 'es',
-  BO: 'es',
-  VE: 'es',
-  EC: 'es',
-  CR: 'es',
-  PA: 'es',
-  GT: 'es',
-  HN: 'es',
-  SV: 'es',
-  NI: 'es',
-  DO: 'es',
-  DE: 'de',
-  AT: 'de',
-  CH: 'de',
-  IT: 'it',
-  NL: 'nl',
-  PL: 'pl',
-  SE: 'sv',
-  NO: 'no',
-  DK: 'da',
-  FI: 'fi',
-  CZ: 'cs',
-  GR: 'el',
-  TR: 'tr',
-  RO: 'ro',
-  HU: 'hu',
-  RU: 'ru',
-  UA: 'uk',
-  IL: 'iw',
-  SA: 'ar',
-  AE: 'ar',
-  EG: 'ar',
-  MA: 'ar',
-  DZ: 'ar',
-  IN: 'hi',
-  TH: 'th',
-  VN: 'vi',
-  ID: 'id',
-  KR: 'ko',
-  CN: 'zh-CN',
-  TW: 'zh-TW',
-};
-
-const GOOGLE_TRANSLATE_LANGUAGES = [
-  ...new Set([...LANGS.map((lang) => lang.value), ...Object.values(COUNTRY_LANGUAGE_MAP)]),
-].join(',');
-
-const mapCountryToLanguage = (countryCode) => {
-  if (!countryCode) return 'pt';
-  const upperCountryCode = countryCode.toUpperCase();
-  const mappedLanguage = COUNTRY_LANGUAGE_MAP[upperCountryCode];
-  if (mappedLanguage) return mappedLanguage;
-  const language = LANGS.find((lang) => lang.countries.includes(upperCountryCode));
-  return language?.value || 'pt';
-};
-
-const applyGoogleLanguage = (language) => {
-  if (!language) return;
-
-  const cookieValue = `/pt/${language}`;
-  document.cookie = `${GOOGLE_COOKIE_KEY}=${cookieValue};path=/`;
-  document.cookie = `${GOOGLE_COOKIE_KEY}=${cookieValue};path=/;domain=.${window.location.hostname}`;
-
-  const select = document.querySelector('select.goog-te-combo');
-  if (select && select.value !== language) {
-    select.value = language;
-    select.dispatchEvent(new Event('change'));
-  }
-};
-
-const ensureGoogleTranslate = () => {
-  if (window.google?.translate?.TranslateElement) return;
-
-  if (!document.getElementById('google-translate-script')) {
-    const script = document.createElement('script');
-    script.id = 'google-translate-script';
-    script.src = 'https://translate.google.com/translate_a/element.js?cb=googleTranslateElementInit';
-    script.async = true;
-    document.body.appendChild(script);
-  }
-
-  if (!window.googleTranslateElementInit) {
-    window.googleTranslateElementInit = () => {
-      if (!window.google?.translate?.TranslateElement) return;
-
-      // eslint-disable-next-line no-new
-      new window.google.translate.TranslateElement(
-        {
-          pageLanguage: 'pt',
-          autoDisplay: false,
-          includedLanguages: GOOGLE_TRANSLATE_LANGUAGES,
-        },
-        'google_translate_element'
-      );
-    };
-  }
-};
+import {
+  LANGS,
+  STORAGE_KEY,
+  applyGoogleLanguage,
+  ensureGoogleTranslate,
+  ensureTranslateDomSetup,
+  getStoredLanguage,
+  detectLanguageByGeolocation,
+  detectLanguageFromBrowser,
+} from '../../services/localization';
 
 export default function LanguagePopover() {
   const [selectedLanguage, setSelectedLanguage] = useState('pt');
@@ -138,22 +20,9 @@ export default function LanguagePopover() {
   useEffect(() => {
     ensureGoogleTranslate();
 
-    if (!document.getElementById('google_translate_element')) {
-      const translateContainer = document.createElement('div');
-      translateContainer.id = 'google_translate_element';
-      translateContainer.style.display = 'none';
-      document.body.appendChild(translateContainer);
-    }
+    ensureTranslateDomSetup();
 
-    const styleId = 'google-translate-hide-style';
-    if (!document.getElementById(styleId)) {
-      const style = document.createElement('style');
-      style.id = styleId;
-      style.innerHTML = '.goog-te-banner-frame.skiptranslate, .goog-te-gadget-icon { display: none !important; } body { top: 0 !important; }';
-      document.head.appendChild(style);
-    }
-
-    const manualLanguage = localStorage.getItem(STORAGE_KEY);
+    const manualLanguage = getStoredLanguage();
     if (manualLanguage) {
       setSelectedLanguage(manualLanguage);
       applyGoogleLanguage(manualLanguage);
@@ -162,14 +31,11 @@ export default function LanguagePopover() {
 
     const autoDetectLanguage = async () => {
       try {
-        const response = await fetch('https://ipapi.co/json/');
-        const data = await response.json();
-        const detectedLanguage = mapCountryToLanguage(data?.country_code) || 'pt';
+        const detectedLanguage = await detectLanguageByGeolocation();
         setSelectedLanguage(detectedLanguage);
         applyGoogleLanguage(detectedLanguage);
       } catch (error) {
-        const browserLanguage = (navigator.language || 'pt').slice(0, 2);
-        const fallbackLanguage = LANGS.some((lang) => lang.value === browserLanguage) ? browserLanguage : 'pt';
+        const fallbackLanguage = detectLanguageFromBrowser();
         setSelectedLanguage(fallbackLanguage);
         applyGoogleLanguage(fallbackLanguage);
       }

--- a/src/services/localization.js
+++ b/src/services/localization.js
@@ -1,0 +1,181 @@
+const STORAGE_KEY = 'preferredLanguage';
+const GOOGLE_COOKIE_KEY = 'googtrans';
+
+const LANGS = [
+  { value: 'en', label: 'English', icon: '/static/icons/eua.svg', countries: ['US'] },
+  { value: 'pt', label: 'Português (Brasil)', icon: '/static/icons/brasil.svg', countries: ['BR'] },
+  { value: 'es', label: 'Español', icon: '/static/icons/espanha.svg', countries: ['ES'] },
+  { value: 'fr', label: 'Français', icon: '/static/icons/franca.svg', countries: ['FR'] },
+  { value: 'ja', label: '日本語', icon: '/static/icons/japao.svg', countries: ['JP'] },
+];
+
+const COUNTRY_LANGUAGE_MAP = {
+  BR: 'pt',
+  PT: 'pt',
+  FR: 'fr',
+  BE: 'fr',
+  CA: 'en',
+  US: 'en',
+  GB: 'en',
+  AU: 'en',
+  NZ: 'en',
+  IE: 'en',
+  JP: 'ja',
+  ES: 'es',
+  MX: 'es',
+  AR: 'es',
+  CL: 'es',
+  CO: 'es',
+  PE: 'es',
+  UY: 'es',
+  PY: 'es',
+  BO: 'es',
+  VE: 'es',
+  EC: 'es',
+  CR: 'es',
+  PA: 'es',
+  GT: 'es',
+  HN: 'es',
+  SV: 'es',
+  NI: 'es',
+  DO: 'es',
+  DE: 'de',
+  AT: 'de',
+  CH: 'de',
+  IT: 'it',
+  NL: 'nl',
+  PL: 'pl',
+  SE: 'sv',
+  NO: 'no',
+  DK: 'da',
+  FI: 'fi',
+  CZ: 'cs',
+  GR: 'el',
+  TR: 'tr',
+  RO: 'ro',
+  HU: 'hu',
+  RU: 'ru',
+  UA: 'uk',
+  IL: 'iw',
+  SA: 'ar',
+  AE: 'ar',
+  EG: 'ar',
+  MA: 'ar',
+  DZ: 'ar',
+  IN: 'hi',
+  TH: 'th',
+  VN: 'vi',
+  ID: 'id',
+  KR: 'ko',
+  CN: 'zh-CN',
+  TW: 'zh-TW',
+};
+
+const GOOGLE_TRANSLATE_LANGUAGES = [
+  ...new Set([...LANGS.map((lang) => lang.value), ...Object.values(COUNTRY_LANGUAGE_MAP)]),
+].join(',');
+
+const mapCountryToLanguage = (countryCode) => {
+  if (!countryCode) return 'pt';
+  const upperCountryCode = countryCode.toUpperCase();
+  const mappedLanguage = COUNTRY_LANGUAGE_MAP[upperCountryCode];
+  if (mappedLanguage) return mappedLanguage;
+  const language = LANGS.find((lang) => lang.countries.includes(upperCountryCode));
+  return language?.value || 'pt';
+};
+
+const applyGoogleLanguage = (language) => {
+  if (!language || typeof document === 'undefined') return;
+
+  const cookieValue = `/pt/${language}`;
+  document.cookie = `${GOOGLE_COOKIE_KEY}=${cookieValue};path=/`;
+
+  if (typeof window !== 'undefined' && window.location?.hostname) {
+    document.cookie = `${GOOGLE_COOKIE_KEY}=${cookieValue};path=/;domain=.${window.location.hostname}`;
+  }
+
+  const select = document.querySelector('select.goog-te-combo');
+  if (select && select.value !== language) {
+    select.value = language;
+    select.dispatchEvent(new Event('change'));
+  }
+
+  document.documentElement.setAttribute('lang', language);
+};
+
+const ensureGoogleTranslate = () => {
+  if (typeof window === 'undefined' || typeof document === 'undefined') return;
+
+  if (window.google?.translate?.TranslateElement) return;
+
+  if (!document.getElementById('google-translate-script')) {
+    const script = document.createElement('script');
+    script.id = 'google-translate-script';
+    script.src = 'https://translate.google.com/translate_a/element.js?cb=googleTranslateElementInit';
+    script.async = true;
+    document.body.appendChild(script);
+  }
+
+  if (!window.googleTranslateElementInit) {
+    window.googleTranslateElementInit = () => {
+      if (!window.google?.translate?.TranslateElement) return;
+
+      // eslint-disable-next-line no-new
+      new window.google.translate.TranslateElement(
+        {
+          pageLanguage: 'pt',
+          autoDisplay: false,
+          includedLanguages: GOOGLE_TRANSLATE_LANGUAGES,
+        },
+        'google_translate_element'
+      );
+    };
+  }
+};
+
+const ensureTranslateDomSetup = () => {
+  if (typeof document === 'undefined') return;
+
+  if (!document.getElementById('google_translate_element')) {
+    const translateContainer = document.createElement('div');
+    translateContainer.id = 'google_translate_element';
+    translateContainer.style.display = 'none';
+    document.body.appendChild(translateContainer);
+  }
+
+  const styleId = 'google-translate-hide-style';
+  if (!document.getElementById(styleId)) {
+    const style = document.createElement('style');
+    style.id = styleId;
+    style.innerHTML = '.goog-te-banner-frame.skiptranslate, .goog-te-gadget-icon { display: none !important; } body { top: 0 !important; }';
+    document.head.appendChild(style);
+  }
+};
+
+const getStoredLanguage = () => {
+  if (typeof window === 'undefined') return null;
+  return window.localStorage.getItem(STORAGE_KEY);
+};
+
+const detectLanguageFromBrowser = () => {
+  if (typeof navigator === 'undefined') return 'pt';
+  const browserLanguage = (navigator.language || 'pt').slice(0, 2);
+  return LANGS.some((lang) => lang.value === browserLanguage) ? browserLanguage : 'pt';
+};
+
+const detectLanguageByGeolocation = async () => {
+  const response = await fetch('https://ipapi.co/json/');
+  const data = await response.json();
+  return mapCountryToLanguage(data?.country_code) || 'pt';
+};
+
+export {
+  LANGS,
+  STORAGE_KEY,
+  applyGoogleLanguage,
+  ensureGoogleTranslate,
+  ensureTranslateDomSetup,
+  getStoredLanguage,
+  detectLanguageFromBrowser,
+  detectLanguageByGeolocation,
+};


### PR DESCRIPTION
### Motivation
- The automatic translation previously initialized only when the dashboard `LanguagePopover` was rendered, so the app did not auto-translate for users landing outside the dashboard.
- Centralize geolocation + language logic to provide consistent behavior and improve accessibility/SEO by setting the document `lang` attribute.

### Description
- Extracted language/geolocation/Google Translate helpers into `src/services/localization.js` including country→language mapping, `ipapi.co` detection, browser fallback, Google Translate script loading, DOM setup and `lang` attribute setting.
- Added a global bootstrap component `src/components/localization/AutoTranslateBootstrap.js` that runs at app startup and applies a stored/manual language or a detected language automatically across the whole application.
- Updated `src/index.js` to mount `AutoTranslateBootstrap` so translation is initialized for every entry point, and refactored `src/layouts/dashboard/LanguagePopover.js` to reuse the new service while keeping manual language switching working.
- When applying language the code now sets the Google Translate cookie and updates the document `lang` attribute to improve accessibility and SEO consistency.

### Testing
- Ran `npm run lint` and it completed successfully with no lint errors.
- Ran `npm run test:unit` and all unit tests passed (4 tests, 0 failures).
- Ran `npm run build` and the production build completed successfully (Vite build succeeded, with chunk-size warnings only).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ab9d2a2abc833192861629a9c4ca8c)