### PR TITLE
fix(auth): handle backend 2FA challenges returned via HTTP errors

### DIFF
--- a/src/auth/AuthContext.js
+++ b/src/auth/AuthContext.js
@@ -62,6 +62,30 @@ function ensureAuthResultShape(result) {
   return { error: 'Resposta de autenticação inválida. Tente novamente.' };
 }
 
+function getAuthResultFromBackendError(error) {
+  const payload = error?.payload;
+
+  if (payload && typeof payload === 'object') {
+    if (payload.requiresTwoFactor) {
+      return payload;
+    }
+
+    if (payload.data && typeof payload.data === 'object' && payload.data.requiresTwoFactor) {
+      return payload.data;
+    }
+
+    if (payload.error) {
+      return { error: payload.error };
+    }
+
+    if (payload.message) {
+      return { error: payload.message };
+    }
+  }
+
+  return null;
+}
+
 export function AuthProvider({ children }) {
   const [user, setUser] = useState(() => getAuthenticatedUser());
   const [sessions, setSessions] = useState(() => getUserSessions());
@@ -101,19 +125,23 @@ export function AuthProvider({ children }) {
         twoFactorCode,
       });
     } catch (error) {
-      if (!ENABLE_DEMO_AUTH) {
-        return { error: 'Serviço de autenticação indisponível. Tente novamente em instantes.' };
-      }
+      const backendResult = getAuthResultFromBackendError(error);
 
-      result = loginWithEmailAndPassword({
-        email,
-        password,
-        remember,
-        trustDevice,
-        deviceName,
-        challengeId,
-        twoFactorCode,
-      });
+      if (backendResult) {
+        result = backendResult;
+      } else if (!ENABLE_DEMO_AUTH) {
+        return { error: 'Serviço de autenticação indisponível. Tente novamente em instantes.' };
+      } else {
+        result = loginWithEmailAndPassword({
+          email,
+          password,
+          remember,
+          trustDevice,
+          deviceName,
+          challengeId,
+          twoFactorCode,
+        });
+      }
     }
 
     result = ensureAuthResultShape(result);
@@ -170,11 +198,15 @@ export function AuthProvider({ children }) {
     try {
       result = await socialLoginWithBackend({ provider, remember, trustDevice, deviceName });
     } catch (error) {
-      if (!ENABLE_DEMO_AUTH) {
-        return { error: 'Serviço de autenticação social indisponível. Tente novamente em instantes.' };
-      }
+      const backendResult = getAuthResultFromBackendError(error);
 
-      result = loginWithSocialProvider({ provider, remember, trustDevice, deviceName });
+      if (backendResult) {
+        result = backendResult;
+      } else if (!ENABLE_DEMO_AUTH) {
+        return { error: 'Serviço de autenticação social indisponível. Tente novamente em instantes.' };
+      } else {
+        result = loginWithSocialProvider({ provider, remember, trustDevice, deviceName });
+      }
     }
 
     result = ensureAuthResultShape(result);


### PR DESCRIPTION
### Motivation
- The login flow treated any non-2xx backend response as a service outage, causing the UI to show `Serviço de autenticação indisponível` even when the backend returned a valid 2FA challenge.

### Description
- Added `getAuthResultFromBackendError` to normalize `error.payload` from backend HTTP errors into usable auth result objects (`requiresTwoFactor`, `demoCode`, or error text) in `src/auth/AuthContext.js`.
- Updated the `login` flow to inspect the backend error payload first, then fall back to the demo auth implementation when `VITE_ENABLE_DEMO_AUTH` is enabled, and only return the generic service-unavailable message when no usable payload is present.
- Applied the same error-payload normalization to `loginWithSocial` to keep social and email login behavior consistent.
- No behavior change to successful 2xx responses; existing state updates (`setUser`, `setSessions`, etc.) remain unchanged when authentication succeeds.

### Testing
- Ran `npm run lint` which completed successfully.
- Ran unit tests with `npm run test:unit -- --runInBand` which passed (4 tests, 0 failures).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69abb3af4960832e87d38210534e43bc)