### PR TITLE
feat: enable Vercel Analytics in app root

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -5,6 +5,7 @@ import { createRoot, hydrateRoot } from 'react-dom/client';
 import { BrowserRouter } from 'react-router-dom';
 import { HelmetProvider } from 'react-helmet-async';
 import * as Sentry from '@sentry/react';
+import { Analytics } from '@vercel/analytics/react';
 
 //
 import App from './App';
@@ -84,6 +85,7 @@ const appTree = (
           <GlobalErrorBoundary>
             <App />
           </GlobalErrorBoundary>
+          <Analytics />
         </BrowserRouter>
       </AuthProvider>
     </ThemeProvider>


### PR DESCRIPTION
### Motivation
- Enable Vercel Web Analytics so page views and basic navigation metrics are collected when the app is deployed on Vercel.

### Description
- Imported `Analytics` from `@vercel/analytics/react` in `src/index.js` and added it to the root React tree.
- Rendered `<Analytics />` inside the `BrowserRouter` to ensure client-side navigation and page views are tracked.

### Testing
- Ran `npm run lint`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69abdffb1ee8832ea66df16a70ab339a)