### PR TITLE
Fix auth requests defaulting to localhost in non-local environments

### DIFF
--- a/src/services/apiClient.js
+++ b/src/services/apiClient.js
@@ -1,15 +1,30 @@
 import { registerApiMetric } from './platformReliability';
 
-const DEFAULT_API_BASE_URL = 'http://localhost:3001';
+const LOCAL_API_BASE_URL = 'http://localhost:3001';
 const DEFAULT_TIMEOUT_MS = 12000;
 const DEFAULT_RETRY_ATTEMPTS = 2;
 const RETRYABLE_STATUS_CODES = new Set([408, 425, 429, 500, 502, 503, 504]);
 const MAX_RETRY_DELAY_MS = 1500;
 
+function resolveDefaultApiBaseUrl() {
+  if (typeof window === 'undefined') {
+    return LOCAL_API_BASE_URL;
+  }
+
+  const hostname = window.location?.hostname || '';
+  const isLocalEnvironment = ['localhost', '127.0.0.1', '0.0.0.0'].includes(hostname);
+
+  if (isLocalEnvironment) {
+    return LOCAL_API_BASE_URL;
+  }
+
+  return window.location.origin;
+}
+
 const configuredBaseUrl =
   import.meta.env.VITE_API_BASE_URL ||
   import.meta.env.VITE_BACKEND_URL ||
-  DEFAULT_API_BASE_URL;
+  resolveDefaultApiBaseUrl();
 
 export const API_BASE_URL = configuredBaseUrl.replace(/\/$/, '');
 


### PR DESCRIPTION
### Motivation
- Users reported login failing with the message `Serviço de autenticação indisponível` because the frontend was still sending API requests to `http://localhost:3001` when running outside a local environment and env vars were not provided.

### Description
- Replaced the previous hardcoded default API base with a resolver in `src/services/apiClient.js` that returns `http://localhost:3001` only for SSR or local hostnames (`localhost`, `127.0.0.1`, `0.0.0.0`) and otherwise uses `window.location.origin`.
- `configuredBaseUrl` now prefers `VITE_API_BASE_URL` / `VITE_BACKEND_URL` and falls back to the new `resolveDefaultApiBaseUrl()` function.
- The exported `API_BASE_URL` continues to be normalized by stripping a trailing slash via `replace(/\/$/, '')` to ensure correct path concatenation.

### Testing
- Ran `npm run lint` and it completed successfully with no linting errors.
- Ran `npm run build` and the production build completed successfully (with existing chunk-size warnings only).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ace4a9cc24832ea9119308df982a25)