### PR TITLE
fix(auth): exibir rótulos Google e Apple nos botões de login social

### DIFF
--- a/src/sections/auth/AuthSocial.js
+++ b/src/sections/auth/AuthSocial.js
@@ -41,11 +41,21 @@ export default function AuthSocial() {
 
       <Stack direction="row" spacing={2}>
         <Button fullWidth size="large" color="inherit" variant="outlined" onClick={() => handleSocialLogin('google')}>
-          <Iconify icon="eva:google-fill" color="#DF3E30" width={22} height={22} />
+          <Stack direction="row" spacing={1} alignItems="center">
+            <Iconify icon="eva:google-fill" color="#DF3E30" width={22} height={22} />
+            <Typography variant="body2" fontWeight={600}>
+              Google
+            </Typography>
+          </Stack>
         </Button>
 
         <Button fullWidth size="large" color="inherit" variant="outlined" onClick={() => handleSocialLogin('apple')}>
-          <Iconify icon="mdi:apple" color="#000000" width={22} height={22} />
+          <Stack direction="row" spacing={1} alignItems="center">
+            <Iconify icon="mdi:apple" color="#000000" width={22} height={22} />
+            <Typography variant="body2" fontWeight={600}>
+              Apple
+            </Typography>
+          </Stack>
         </Button>
       </Stack>
 


### PR DESCRIPTION
### Motivation
- Tornar explícitas as opções de login social na tela de login porque os provedores Google e Apple não exibiam rótulos, dificultando a descoberta pelo usuário.

### Description
- Atualiza `src/sections/auth/AuthSocial.js` para envolver os ícones dos provedores em um `Stack` e adicionar `Typography` com os rótulos `Google` e `Apple`, preservando o fluxo de autenticação existente.

### Testing
- Executado `npm run lint -- src/sections/auth/AuthSocial.js` e concluído com sucesso; também executei um script automatizado de validação com Playwright que capturou uma screenshot da página `/login` mostrando os rótulos (artefato gerado com sucesso).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ace8b462a4832eb8ce879dfc6b5997)