### PR TITLE
Fix notifications bell icon rendering in dashboard navbar

### DIFF
--- a/src/layouts/dashboard/NotificationsPopover.js
+++ b/src/layouts/dashboard/NotificationsPopover.js
@@ -19,6 +19,7 @@ import {
   ListItemAvatar,
   ListItemButton,
 } from '@mui/material';
+import NotificationsRoundedIcon from '@mui/icons-material/NotificationsRounded';
 // utils
 import { fToNow } from '../../utils/formatTime';
 // components
@@ -109,7 +110,7 @@ export default function NotificationsPopover() {
         sx={{ width: 40, height: 40 }}
       >
         <Badge badgeContent={totalUnRead} color="error">
-          <Iconify icon="eva:bell-fill" width={20} height={20} />
+          <NotificationsRoundedIcon sx={{ width: 20, height: 20 }} />
         </Badge>
       </IconButton>
 


### PR DESCRIPTION
### Motivation
- Replace the notification bell rendering because the previous icon failed to display reliably in the navbar, ensuring the badge and layout remain stable.

### Description
- Import `NotificationsRoundedIcon` from `@mui/icons-material` and replace the `Iconify` usage of `eva:bell-fill` with `<NotificationsRoundedIcon sx={{ width: 20, height: 20 }} />` in `src/layouts/dashboard/NotificationsPopover.js` to preserve size and badge alignment.

### Testing
- Ran `npx eslint src/layouts/dashboard/NotificationsPopover.js` and executed the dev server plus automated Playwright screenshot script to validate the change; the automated checks completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ace97a3200832eb7eeada696ffedda)