### PR TITLE
Fix session logout text wrapping in AccountPopover

### DIFF
--- a/src/layouts/dashboard/AccountPopover.js
+++ b/src/layouts/dashboard/AccountPopover.js
@@ -129,17 +129,21 @@ export default function AccountPopover() {
         <Divider sx={{ borderStyle: 'dashed' }} />
 
         <Stack sx={{ p: 1 }}>
-          <MenuItem onClick={handleLogoutOthers}>
+          <MenuItem onClick={handleLogoutOthers} sx={{ alignItems: 'flex-start', whiteSpace: 'normal' }}>
             <ListItemText
               primary="Encerrar outras sessões"
               secondary="Mantém somente este dispositivo conectado"
+              primaryTypographyProps={{ sx: { whiteSpace: 'normal' } }}
+              secondaryTypographyProps={{ sx: { whiteSpace: 'normal' } }}
             />
           </MenuItem>
 
-          <MenuItem onClick={handleLogoutAll}>
+          <MenuItem onClick={handleLogoutAll} sx={{ alignItems: 'flex-start', whiteSpace: 'normal' }}>
             <ListItemText
               primary="Encerrar todas as sessões"
               secondary="Desconecta todos os dispositivos"
+              primaryTypographyProps={{ sx: { whiteSpace: 'normal' } }}
+              secondaryTypographyProps={{ sx: { whiteSpace: 'normal' } }}
             />
           </MenuItem>
 


### PR DESCRIPTION
### Motivation
- Session termination labels in the account popover were overflowing the popover bounds and becoming unreadable on smaller widths. 

### Description
- Update `src/layouts/dashboard/AccountPopover.js` to allow multiline wrapping by applying `whiteSpace: 'normal'` on the two relevant `MenuItem`s and on the `primary`/`secondary` typography via `primaryTypographyProps` and `secondaryTypographyProps`. 
- Align the menu items to the top using `alignItems: 'flex-start'` so wrapped text stays readable and vertically aligned within the popover. 

### Testing
- Ran the linter with `npm run lint -- --ext .js,.jsx src/layouts/dashboard/AccountPopover.js` and it passed. 
- Launched the dev server with `npm run dev -- --host 0.0.0.0 --port 4173` and verified the UI. 
- Captured a Playwright screenshot of the updated popover to validate the visual fix.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ace9a186d8832eb390ad7e2a99d13a)