### PR TITLE
Make theme toggle functional: add ThemeModeContext and mode-aware palette

### DIFF
--- a/src/layouts/dashboard/ModeTheme.js
+++ b/src/layouts/dashboard/ModeTheme.js
@@ -1,5 +1,6 @@
 import { styled } from '@mui/material/styles';
 import Switch from '@mui/material/Switch';
+import { useThemeMode } from '../../theme';
 
 const MaterialUISwitch = styled(Switch)(({ theme }) => ({
   width: 62,
@@ -14,7 +15,7 @@ const MaterialUISwitch = styled(Switch)(({ theme }) => ({
       transform: 'translateX(22px)',
       '& .MuiSwitch-thumb:before': {
         backgroundImage: `url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" height="20" width="20" viewBox="0 0 20 20"><path fill="${encodeURIComponent(
-          '#fff',
+          '#fff'
         )}" d="M4.2 2.5l-.7 1.8-1.8.7 1.8.7.7 1.8.6-1.8L6.7 5l-1.9-.7-.6-1.8zm15 8.3a6.7 6.7 0 11-6.6-6.6 5.8 5.8 0 006.6 6.6z"/></svg>')`,
       },
       '& + .MuiSwitch-track': {
@@ -37,7 +38,7 @@ const MaterialUISwitch = styled(Switch)(({ theme }) => ({
       backgroundRepeat: 'no-repeat',
       backgroundPosition: 'center',
       backgroundImage: `url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" height="20" width="20" viewBox="0 0 20 20"><path fill="${encodeURIComponent(
-        '#fff',
+        '#fff'
       )}" d="M9.305 1.667V3.75h1.389V1.667h-1.39zm-4.707 1.95l-.982.982L5.09 6.072l.982-.982-1.473-1.473zm10.802 0L13.927 5.09l.982.982 1.473-1.473-.982-.982zM10 5.139a4.872 4.872 0 00-4.862 4.86A4.872 4.872 0 0010 14.862 4.872 4.872 0 0014.86 10 4.872 4.872 0 0010 5.139zm0 1.389A3.462 3.462 0 0113.471 10a3.462 3.462 0 01-3.473 3.472A3.462 3.462 0 016.527 10 3.462 3.462 0 0110 6.528zM1.665 9.305v1.39h2.083v-1.39H1.666zm14.583 0v1.39h2.084v-1.39h-2.084zM5.09 13.928L3.616 15.4l.982.982 1.473-1.473-.982-.982zm9.82 0l-.982.982 1.473 1.473.982-.982-1.473-1.473zM9.305 16.25v2.083h1.389V16.25h-1.39z"/></svg>')`,
     },
   },
@@ -49,5 +50,7 @@ const MaterialUISwitch = styled(Switch)(({ theme }) => ({
 }));
 
 export default function ModeTheme() {
-  return <MaterialUISwitch sx={{ m: 1 }} defaultChecked />;
+  const { mode, toggleMode } = useThemeMode();
+
+  return <MaterialUISwitch sx={{ m: 1 }} checked={mode === 'dark'} onChange={toggleMode} />;
 }

--- a/src/theme/index.js
+++ b/src/theme/index.js
@@ -1,49 +1,85 @@
 import PropTypes from 'prop-types';
-import { useMemo } from 'react';
+import { createContext, useCallback, useContext, useMemo, useState } from 'react';
 // material
 import { CssBaseline, GlobalStyles } from '@mui/material';
 import { ThemeProvider as MUIThemeProvider, createTheme, StyledEngineProvider } from '@mui/material/styles';
 //
-import palette from './palette';
+import getPalette from './palette';
 import typography from './typography';
 import componentsOverride from './overrides';
 import shadows, { customShadows } from './shadows';
 
 // ----------------------------------------------------------------------
 
+const ThemeModeContext = createContext({
+  mode: 'light',
+  toggleMode: () => {},
+});
+
 ThemeProvider.propTypes = {
   children: PropTypes.node,
 };
 
+export function useThemeMode() {
+  return useContext(ThemeModeContext);
+}
+
 export default function ThemeProvider({ children }) {
+  const [mode, setMode] = useState(() => {
+    if (typeof window === 'undefined') {
+      return 'light';
+    }
+
+    const savedMode = window.localStorage.getItem('themeMode');
+    return savedMode === 'dark' ? 'dark' : 'light';
+  });
+
+  const toggleMode = useCallback(() => {
+    setMode((prevMode) => {
+      const nextMode = prevMode === 'light' ? 'dark' : 'light';
+      window.localStorage.setItem('themeMode', nextMode);
+      return nextMode;
+    });
+  }, []);
+
   const themeOptions = useMemo(
     () => ({
-      palette,
+      palette: getPalette(mode),
       shape: { borderRadius: 8 },
       typography,
       shadows,
       customShadows,
     }),
-    []
+    [mode]
   );
 
   const theme = createTheme(themeOptions);
   theme.components = componentsOverride(theme);
 
+  const themeModeValue = useMemo(
+    () => ({
+      mode,
+      toggleMode,
+    }),
+    [mode, toggleMode]
+  );
+
   return (
     <StyledEngineProvider injectFirst>
-      <MUIThemeProvider theme={theme}>
-        <CssBaseline />
-        <GlobalStyles
-          styles={{
-            html: { width: '100%', height: '100%' },
-            body: { width: '100%', minHeight: '100%', overflowX: 'hidden' },
-            '#root': { width: '100%', minHeight: '100%' },
-            img: { maxWidth: '100%', height: 'auto' },
-          }}
-        />
-        {children}
-      </MUIThemeProvider>
+      <ThemeModeContext.Provider value={themeModeValue}>
+        <MUIThemeProvider theme={theme}>
+          <CssBaseline />
+          <GlobalStyles
+            styles={{
+              html: { width: '100%', height: '100%' },
+              body: { width: '100%', minHeight: '100%', overflowX: 'hidden' },
+              '#root': { width: '100%', minHeight: '100%' },
+              img: { maxWidth: '100%', height: 'auto' },
+            }}
+          />
+          {children}
+        </MUIThemeProvider>
+      </ThemeModeContext.Provider>
     </StyledEngineProvider>
   );
 }

--- a/src/theme/palette.js
+++ b/src/theme/palette.js
@@ -98,30 +98,43 @@ const CHART_COLORS = {
   red: ['#FF6C40', '#FF8F6D', '#FFBD98', '#FFF2D4'],
 };
 
-const palette = {
-  common: { black: '#000', white: '#fff' },
-  primary: { ...PRIMARY },
-  secondary: { ...SECONDARY },
-  info: { ...INFO },
-  success: { ...SUCCESS },
-  warning: { ...WARNING },
-  error: { ...ERROR },
-  grey: GREY,
-  gradients: GRADIENTS,
-  chart: CHART_COLORS,
-  divider: GREY[500_24],
-  text: { primary: GREY[800], secondary: GREY[600], disabled: GREY[500] },
-  background: { paper: '#fff', default: GREY[100], neutral: GREY[200] },
-  action: {
-    active: GREY[600],
-    hover: GREY[500_8],
-    selected: GREY[500_16],
-    disabled: GREY[500_80],
-    disabledBackground: GREY[500_24],
-    focus: GREY[500_24],
-    hoverOpacity: 0.08,
-    disabledOpacity: 0.48,
-  },
-};
+function getPalette(mode = 'light') {
+  const isLight = mode === 'light';
 
-export default palette;
+  return {
+    mode,
+    common: { black: '#000', white: '#fff' },
+    primary: { ...PRIMARY },
+    secondary: { ...SECONDARY },
+    info: { ...INFO },
+    success: { ...SUCCESS },
+    warning: { ...WARNING },
+    error: { ...ERROR },
+    grey: GREY,
+    gradients: GRADIENTS,
+    chart: CHART_COLORS,
+    divider: GREY[500_24],
+    text: {
+      primary: isLight ? GREY[800] : '#fff',
+      secondary: isLight ? GREY[600] : GREY[500],
+      disabled: GREY[500],
+    },
+    background: {
+      paper: isLight ? '#fff' : GREY[800],
+      default: isLight ? GREY[100] : GREY[900],
+      neutral: isLight ? GREY[200] : alpha(GREY[500], 0.12),
+    },
+    action: {
+      active: isLight ? GREY[600] : GREY[500],
+      hover: GREY[500_8],
+      selected: GREY[500_16],
+      disabled: GREY[500_80],
+      disabledBackground: GREY[500_24],
+      focus: GREY[500_24],
+      hoverOpacity: 0.08,
+      disabledOpacity: 0.48,
+    },
+  };
+}
+
+export default getPalette;


### PR DESCRIPTION
### Motivation
- The UI switch for light/dark theme was uncontrolled and not changing the app theme, so the toggle appeared non-functional.
- The palette was static and unaware of `mode`, preventing proper light/dark styling across the app.

### Description
- Introduced a `ThemeModeContext` in `src/theme/index.js` that exposes `mode` and `toggleMode`, persisting the chosen mode in `localStorage` (`themeMode`) and restoring it on startup.
- Replaced the static palette export with a mode-aware `getPalette(mode)` in `src/theme/palette.js` so `createTheme` receives a palette tailored to `light` or `dark` modes.
- Updated `src/layouts/dashboard/ModeTheme.js` to use `useThemeMode()` and render the switch as a controlled component (`checked={mode === 'dark'}`) calling `toggleMode` on change.
- Kept theme creation and component overrides intact while wiring `getPalette(mode)` into the theme generation flow in `ThemeProvider`.

### Testing
- Ran `npm run lint` and it completed successfully (`eslint` passed). 
- Ran `npm run build` and it completed successfully (Vite produced a production build without errors). 
- Started the dev server and exercised the UI via headless browser scripts; a dashboard screenshot artifact was produced to validate the UI after the change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ace9b6fa20832e8970a0301df463ef)