### PR TITLE
Fix white screen on startup by initializing theme palette in shadows

### DIFF
--- a/src/theme/shadows.js
+++ b/src/theme/shadows.js
@@ -1,9 +1,10 @@
 // material
 import { alpha } from '@mui/material/styles';
-import palette from './palette';
+import getPalette from './palette';
 
 // ----------------------------------------------------------------------
 
+const palette = getPalette('light');
 const LIGHT_MODE = palette.grey[500];
 
 const createShadow = (color) => {


### PR DESCRIPTION
### Motivation
- The app failed during bootstrap with `Cannot read properties of undefined (reading '500')` because `src/theme/shadows.js` treated the exported `getPalette` factory as a static `palette` object.

### Description
- Update `src/theme/shadows.js` to import `getPalette` and instantiate a light palette (`getPalette('light')`) before reading `palette.grey[500]`, preventing runtime access of `grey` on an undefined value.

### Testing
- Ran `npm run build` which completed successfully.
- Launched the dev server and executed an automated Playwright check that reproduced the error before the change and confirmed no `PAGEERROR` after the fix (screenshot captured by the script).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69acecd24cc8832ea02eec09410de604)