### PR TITLE
style: exibe apenas ícones nos botões sociais

### DIFF
--- a/src/sections/auth/AuthSocial.js
+++ b/src/sections/auth/AuthSocial.js
@@ -41,21 +41,11 @@ export default function AuthSocial() {
 
       <Stack direction="row" spacing={2}>
         <Button fullWidth size="large" color="inherit" variant="outlined" onClick={() => handleSocialLogin('google')}>
-          <Stack direction="row" spacing={1} alignItems="center">
-            <Iconify icon="eva:google-fill" color="#DF3E30" width={22} height={22} />
-            <Typography variant="body2" fontWeight={600}>
-              Google
-            </Typography>
-          </Stack>
+          <Iconify icon="eva:google-fill" color="#DF3E30" width={22} height={22} />
         </Button>
 
         <Button fullWidth size="large" color="inherit" variant="outlined" onClick={() => handleSocialLogin('apple')}>
-          <Stack direction="row" spacing={1} alignItems="center">
-            <Iconify icon="mdi:apple" color="#000000" width={22} height={22} />
-            <Typography variant="body2" fontWeight={600}>
-              Apple
-            </Typography>
-          </Stack>
+          <Iconify icon="mdi:apple" color="#000000" width={22} height={22} />
         </Button>
       </Stack>
 


### PR DESCRIPTION
### Motivation
- Remover os rótulos textuais e exibir somente os ícones dos provedores Google e Apple nos botões de login social para atender à solicitação de UI.

### Description
- Atualiza `src/sections/auth/AuthSocial.js` para remover os elementos de texto (`Typography`) e o `Stack` interno em cada botão, mantendo apenas o componente `Iconify` com os ícones `eva:google-fill` e `mdi:apple`.

### Testing
- Executados `npm run lint -- src/sections/auth/AuthSocial.js`, inicialização do dev server com `npm run dev -- --host 0.0.0.0 --port 4173` e validação visual automatizada via Playwright que gerou uma screenshot; todos os passos concluídos com sucesso.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69acef457abc832eb27026e64483407d)