### PR TITLE
fix: garantir sincronização de idioma ao trocar bandeira

### DIFF
--- a/src/services/localization.js
+++ b/src/services/localization.js
@@ -123,6 +123,10 @@ const applyGoogleLanguage = (language) => {
     languageSyncAttempts = 0;
   }
 
+  if (pendingLanguage) {
+    scheduleLanguageSync();
+  }
+
   document.documentElement.setAttribute('lang', language);
 };
 


### PR DESCRIPTION
### Motivation
- Corrigir um caso em que ao trocar o idioma o cookie/localStorage são atualizados mas a tradução não é aplicada porque o seletor do Google Translate (`select.goog-te-combo`) ainda não foi injetado no DOM.

### Description
- Em `src/services/localization.js` foi adicionada uma chamada a `scheduleLanguageSync()` no final de `applyGoogleLanguage()` quando `pendingLanguage` ainda está definida, garantindo que a sincronização continue sendo tentada até o seletor do Google Translate ficar disponível.

### Testing
- Executado `npm run lint -- src/services/localization.js` e `npm test`, ambos passaram sem falhas.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69acf07e62b0832eabccd6afd0e7a1c7)