### PR TITLE
Corrige rota 'administração' e adiciona redirect legada para /dashboard/admin

### DIFF
--- a/src/layouts/dashboard/NavConfig.js
+++ b/src/layouts/dashboard/NavConfig.js
@@ -7,7 +7,7 @@ const getIcon = (name) => <Iconify icon={name} width={22} height={22} />;
 
 const navConfig = [
   { title: 'monitoramento', path: '/dashboard/app', icon: getIcon('eva:pie-chart-2-fill') },
-  { title: 'administração', path: '/dashboard/user', icon: getIcon('eva:people-fill') },
+  { title: 'administração', path: '/dashboard/admin', icon: getIcon('eva:people-fill') },
   { title: 'catálogo de espécies', path: '/dashboard/products', icon: getIcon('eva:shopping-bag-fill') },
   { title: 'onboarding', path: '/dashboard/onboarding', icon: getIcon('eva:navigation-2-fill') },
   { title: 'hortelan 360', path: '/dashboard/hortelan-360', icon: getIcon('eva:layers-fill') },

--- a/src/routes.js
+++ b/src/routes.js
@@ -61,7 +61,8 @@ export default function Router() {
       children: [
         { index: true, element: <Navigate to="app" replace /> },
         { path: 'app', element: renderLazy(MonitoringPage) },
-        { path: 'user', element: renderLazy(AdminPanelPage) },
+        { path: 'admin', element: renderLazy(AdminPanelPage) },
+        { path: 'user', element: <Navigate to="/dashboard/admin" replace /> },
         { path: 'products', element: renderLazy(SpeciesCatalogPage) },
         { path: 'blog', element: renderLazy(CommunityPage) },
         { path: 'hortelan-360', element: renderLazy(Hortelan360Page) },


### PR DESCRIPTION
### Motivation
- O item de navegação “administração” apontava para `'/dashboard/user'` enquanto a rota válida foi padronizada para `'/dashboard/admin'`, causando splash seguido de 404 ao abrir o painel administrativo.

### Description
- Atualiza `src/layouts/dashboard/NavConfig.js` para apontar o menu `administração` para `'/dashboard/admin'`.
- Atualiza `src/routes.js` para servir `AdminPanelPage` em `'/dashboard/admin'` e adiciona um redirect legado de `'/dashboard/user'` para `'/dashboard/admin'`.

### Testing
- Executei `npm run build` e a construção de produção completou com sucesso garantindo que as rotas compilam corretamente. 
- Iniciei o modo de desenvolvimento (`npm run dev`) para validar localmente a carga do app e o servidor ficou disponível. 
- Rodei scripts automatizados de browser (Playwright) para validar a navegação ao painel, que não conseguiram avançar além do splash / preview no ambiente aqui (algumas execuções timing out ou exibindo apenas a tela de preview), portanto a verificação visual do painel autenticado não foi concluída em ambiente automatizado aqui.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69acf0d98bc0832e9a571cd9a703440d)