### PR TITLE
Fix false 404 redirect when opening Hortelan 360

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -23,6 +23,22 @@ const rootElement = document.getElementById('root');
 const ERROR_ROUTE_PATH = '/404';
 let hasRedirectedToErrorPage = false;
 
+const NON_FATAL_ERROR_PATTERNS = [
+  'aborterror',
+  'the operation was aborted',
+  'resizeobserver loop limit exceeded',
+  'non-error promise rejection captured',
+];
+
+function shouldRedirectToErrorRoute(errorLike) {
+  if (!errorLike) return false;
+
+  const normalizedMessage = `${errorLike?.name || ''} ${errorLike?.message || errorLike}`.toLowerCase().trim();
+  if (!normalizedMessage) return false;
+
+  return !NON_FATAL_ERROR_PATTERNS.some((pattern) => normalizedMessage.includes(pattern));
+}
+
 function redirectToErrorPage() {
   if (window.location.pathname === ERROR_ROUTE_PATH || hasRedirectedToErrorPage) {
     return;
@@ -33,12 +49,16 @@ function redirectToErrorPage() {
   window.dispatchEvent(new PopStateEvent('popstate'));
 }
 
-window.addEventListener('error', () => {
-  redirectToErrorPage();
+window.addEventListener('error', (event) => {
+  if (shouldRedirectToErrorRoute(event.error || event.message)) {
+    redirectToErrorPage();
+  }
 });
 
-window.addEventListener('unhandledrejection', () => {
-  redirectToErrorPage();
+window.addEventListener('unhandledrejection', (event) => {
+  if (shouldRedirectToErrorRoute(event.reason)) {
+    redirectToErrorPage();
+  }
 });
 
 async function startApp() {


### PR DESCRIPTION
### Motivation
- The app was navigating to a global `/404` route when opening the `Hortelan 360` page because broad global `error`/`unhandledrejection` listeners redirected unconditionally, causing non-fatal runtime/browser errors to abort navigation.

### Description
- Added a whitelist of common non-fatal error message patterns and a helper `shouldRedirectToErrorRoute` in `src/index.js` to distinguish fatal errors from expected/non-fatal ones.
- Replaced the unconditional `window.addEventListener('error', ...)` and `window.addEventListener('unhandledrejection', ...)` handlers with guarded handlers that call `shouldRedirectToErrorRoute` before invoking `redirectToErrorPage()`.

### Testing
- Built the production bundle with `npm run build` and the build completed successfully.
- Ran linting with `npm run lint` and there were no lint errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69acf172f8d4832ea691f7b761d6ffb1)