### PR TITLE
Remove Hortelan promo banner from Monitoring page

### DIFF
--- a/src/pages/dashboard/MonitoringPage.js
+++ b/src/pages/dashboard/MonitoringPage.js
@@ -34,7 +34,6 @@ import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline';
 import Page from '../../components/Page';
 import Iconify from '../../components/Iconify';
 import BlockchainPanel from '../../components/BlockchainPanel';
-import HortelanPromoBanner from '../../components/HortelanPromoBanner';
 import useAuth from '../../auth/useAuth';
 // sections
 import {
@@ -1064,8 +1063,6 @@ export default function DashboardApp() {
         <Typography variant="h4" sx={{ mb: 5 }}>
           Welcome {user?.name || 'User'} to the Hortelan AgTech Ltda System
         </Typography>
-
-        <HortelanPromoBanner sx={{ mb: 4 }} />
 
         <Grid container spacing={3}>
           <Grid item xs={12}>


### PR DESCRIPTION
### Motivation
- Remove the promotional banner from the Monitoring page so the monitoring view does not show the large Hortelan promo image.

### Description
- Deleted the `HortelanPromoBanner` import and removed its JSX render from `src/pages/dashboard/MonitoringPage.js` so the page now starts directly with the dashboard grid.

### Testing
- Ran `npm run lint -- src/pages/dashboard/MonitoringPage.js` which passed, and executed a Playwright smoke script that loaded `/dashboard/monitoring` and captured a screenshot confirming the banner is no longer rendered.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69acf8f56f08832e9dc2d344888f61ff)