### PR TITLE
Add legacy route redirect for Hortelan 360

### DIFF
--- a/src/routes.js
+++ b/src/routes.js
@@ -66,6 +66,7 @@ export default function Router() {
         { path: 'products', element: renderLazy(SpeciesCatalogPage) },
         { path: 'blog', element: renderLazy(CommunityPage) },
         { path: 'hortelan-360', element: renderLazy(Hortelan360Page) },
+        { path: 'hortelan360', element: <Navigate to="/dashboard/hortelan-360" replace /> },
         { path: 'onboarding', element: renderLazy(OnboardingPage) },
         { path: 'status', element: renderLazy(PlatformStatusPage) },
         { path: 'security', element: renderLazy(SecurityCenterPage) },


### PR DESCRIPTION
### Motivation
- Some flows referenced a legacy non-hyphenated path and clicking **Hortelan 360** led to the splash then a 404 instead of the intended page, so a compatibility redirect is required.

### Description
- Added a legacy route alias in `src/routes.js`: `{ path: 'hortelan360', element: <Navigate to="/dashboard/hortelan-360" replace /> }` to redirect `/dashboard/hortelan360` to the canonical `/dashboard/hortelan-360`.

### Testing
- Ran `npm run lint -- src/routes.js` and the lint check passed.
- Ran `npm run build` and the production build completed successfully.
- Executed an automated Playwright check that injects a valid session and navigates to `/dashboard/hortelan360`, which resolved to the dashboard route and produced a screenshot (`artifacts/hortelan360-route-fix.png`) confirming the redirect worked.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69acf9387598832eb38abd4efaa7cbc0)