### PR TITLE
fix(help-center): remover banner e efeito de digitação do cabeçalho

### DIFF
--- a/src/pages/HelpCenter.js
+++ b/src/pages/HelpCenter.js
@@ -33,8 +33,6 @@ import InstagramIcon from '@mui/icons-material/Instagram';
 import YouTubeIcon from '@mui/icons-material/YouTube';
 import EmailRoundedIcon from '@mui/icons-material/EmailRounded';
 import Page from '../components/Page';
-import HortelanPromoBanner from '../components/HortelanPromoBanner';
-import GSAPTypingText from '../components/GSAPTypingText';
 
 const faqItems = [
   {
@@ -127,29 +125,12 @@ export default function HelpCenter() {
         <Stack spacing={3}>
           <Box>
             <Typography variant="h4" gutterBottom>
-              <GSAPTypingText
-                texts={[
-                  'Central de ajuda e suporte',
-                  'Suporte técnico especializado para sua horta conectada',
-                  'Resolva incidentes com contexto de sensores e automações',
-                ]}
-              />
+              Central de ajuda e suporte
             </Typography>
             <Typography color="text.secondary">
-              <GSAPTypingText
-                texts={[
-                  'Consulte conteúdos de autoatendimento, abra chamados e acompanhe tickets com contexto técnico.',
-                  'Tenha acesso rápido a FAQ, histórico de tickets e suporte contextual em um só lugar.',
-                ]}
-                speed={28}
-                eraseSpeed={17}
-                holdDuration={1100}
-                startDelay={200}
-              />
+              Consulte conteúdos de autoatendimento, abra chamados e acompanhe tickets com contexto técnico.
             </Typography>
           </Box>
-
-          <HortelanPromoBanner />
 
           <Card>
             <CardContent>


### PR DESCRIPTION
### Motivation
- Tornar o cabeçalho da página de suporte estático conforme a solicitação para remover a imagem/banner promocional e o efeito de digitação no título.

### Description
- Removeu o uso do componente `HortelanPromoBanner` da página de suporte em `src/pages/HelpCenter.js` para eliminar o banner promocional.
- Removeu o componente `GSAPTypingText` e substituiu o título/subtítulo por textos estáticos: `Central de ajuda e suporte` e uma descrição fixa.
- Eliminou os imports não utilizados de `HortelanPromoBanner` e `GSAPTypingText` em `src/pages/HelpCenter.js`.
- Alteração limitada a `src/pages/HelpCenter.js` sem modificar a lógica das abas ou demais funcionalidades da página.

### Testing
- Executado `npx eslint src/pages/HelpCenter.js` e sem erros (passou).
- Subida a aplicação com `npm run dev -- --host 0.0.0.0 --port 4173` para validação automatizada do build de desenvolvimento (iniciou com sucesso).
- Rodado um script Playwright (Firefox) que realizou login, navegou para `/dashboard/suporte` e gerou uma captura de tela da página atualizada (script concluiu com sucesso e artefato gerado).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69acf9f5f764832ea2df57a564e4b4e0)