### PR TITLE
Aumenta a logo do dashboard para o dobro do tamanho

### DIFF
--- a/src/layouts/dashboard/DashboardSidebar.js
+++ b/src/layouts/dashboard/DashboardSidebar.js
@@ -100,7 +100,7 @@ export default function DashboardSidebar({ isOpenSidebar, onCloseSidebar }) {
       }}
     >
       <Box sx={{ px: 2.5, py: 3, display: 'inline-flex' }}>
-        <Logo />
+        <Logo sx={{ width: 80, height: 80 }} />
       </Box>
 
       <Box sx={{ mb: 5, mx: 2.5 }}>


### PR DESCRIPTION
### Motivation
- Dobrar o tamanho da logo exibida no sidebar do dashboard para melhorar a visibilidade no layout do painel.

### Description
- Ajustei a renderização do componente `Logo` em `DashboardSidebar` para receber `sx={{ width: 80, height: 80 }}` substituindo o tamanho padrão.

### Testing
- Executei `npx eslint src/layouts/dashboard/DashboardSidebar.js` com sucesso.
- Iniciei a aplicação com `npm run dev -- --host 0.0.0.0 --port 4173` e o servidor subiu com sucesso (Vite ready).
- Rodei um script Playwright que fez login e gerou uma captura `artifacts/dashboard-logo-doubled.png` confirmando visualmente o novo tamanho da logo.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69acfc950bbc832ea251fc5ced6cae55)