### PR TITLE
feat: melhorar detecção automática de idioma por geolocalização e locale do navegador

### DIFF
--- a/src/services/localization.js
+++ b/src/services/localization.js
@@ -214,10 +214,56 @@ const detectLanguageFromBrowser = () => {
   return LANGS.some((lang) => lang.value === browserLanguage) ? browserLanguage : 'pt';
 };
 
+const detectCountryFromBrowserLocale = () => {
+  if (typeof navigator === 'undefined') return null;
+
+  const localeSources = [navigator.language, ...(navigator.languages || [])].filter(Boolean);
+
+  for (const locale of localeSources) {
+    const localeMatch = locale.match(/[-_]([A-Za-z]{2})$/);
+    if (localeMatch) {
+      return localeMatch[1].toUpperCase();
+    }
+  }
+
+  return null;
+};
+
+const fetchCountryCode = async (url, resolver) => {
+  const controller = new AbortController();
+  const timeoutId = window.setTimeout(() => controller.abort(), 4000);
+
+  try {
+    const response = await fetch(url, { signal: controller.signal });
+    if (!response.ok) return null;
+    const data = await response.json();
+    return resolver(data);
+  } catch (error) {
+    return null;
+  } finally {
+    window.clearTimeout(timeoutId);
+  }
+};
+
 const detectLanguageByGeolocation = async () => {
-  const response = await fetch('https://ipapi.co/json/');
-  const data = await response.json();
-  return mapCountryToLanguage(data?.country_code) || 'pt';
+  const countryFromLocale = detectCountryFromBrowserLocale();
+  if (countryFromLocale) {
+    return mapCountryToLanguage(countryFromLocale);
+  }
+
+  if (typeof window === 'undefined') {
+    return detectLanguageFromBrowser();
+  }
+
+  const countryCode =
+    (await fetchCountryCode('https://ipapi.co/json/', (data) => data?.country_code)) ||
+    (await fetchCountryCode('https://ipwho.is/', (data) => (data?.success ? data.country_code : null)));
+
+  if (countryCode) {
+    return mapCountryToLanguage(countryCode);
+  }
+
+  return detectLanguageFromBrowser();
 };
 
 export {


### PR DESCRIPTION
### Motivation
- Melhorar a seleção inicial do idioma do dashboard usando informações locais do navegador antes de consultar serviços externos.
- Tornar a detecção resiliente a falhas/latência de APIs externas ao adicionar timeouts e múltiplos provedores.
- Garantir fallback robusto para o idioma do navegador quando geolocalização não estiver disponível.

### Description
- Atualiza `src/services/localization.js` com o helper `detectCountryFromBrowserLocale` que extrai o código do país de `navigator.language`/`navigator.languages`.
- Adiciona `fetchCountryCode` que consulta um endpoint com `AbortController` e timeout de 4s para evitar travamentos de rede.
- Reestrutura `detectLanguageByGeolocation` para a ordem de resolução: locale do navegador → `ipapi.co` → `ipwho.is` → idioma do navegador (`detectLanguageFromBrowser`).

### Testing
- Executado `npm run lint` sem erros (sucesso).
- Aplicação iniciada com `npm run dev -- --host 0.0.0.0 --port 4173` e acessível localmente (servidor levantado com sucesso).
- Captura de tela gerada da aplicação em execução local para validação visual (artifact gerado com sucesso).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69acfd0849b8832e9ef66be6965f3213)