### PR TITLE
Improve dashboard responsiveness across device sizes

### DIFF
--- a/src/layouts/dashboard/index.js
+++ b/src/layouts/dashboard/index.js
@@ -19,15 +19,18 @@ const RootStyle = styled('div')({
 
 const MainStyle = styled('div')(({ theme }) => ({
   flexGrow: 1,
+  width: 0,
+  minWidth: 0,
   overflow: 'auto',
   minHeight: '100%',
-  paddingTop: APP_BAR_MOBILE + 24,
-  paddingLeft: theme.spacing(2),
-  paddingRight: theme.spacing(2),
+  paddingTop: APP_BAR_MOBILE + 16,
+  paddingLeft: theme.spacing(1.5),
+  paddingRight: theme.spacing(1.5),
   paddingBottom: theme.spacing(10),
   [theme.breakpoints.up('sm')]: {
     paddingLeft: theme.spacing(3),
     paddingRight: theme.spacing(3),
+    paddingTop: APP_BAR_MOBILE + 24,
   },
   [theme.breakpoints.up('lg')]: {
     paddingTop: APP_BAR_DESKTOP + 24,

--- a/src/pages/dashboard/MonitoringPage.js
+++ b/src/pages/dashboard/MonitoringPage.js
@@ -1071,7 +1071,7 @@ export default function DashboardApp() {
                 <Typography variant="h5" sx={{ mb: 2 }}>
                   Widgets personalizáveis do dashboard
                 </Typography>
-                <FormGroup row>
+                <FormGroup row sx={{ rowGap: 1, columnGap: 1, '& .MuiFormControlLabel-root': { mr: 1 } }}>
                   <FormControlLabel
                     control={<Switch checked={enabledWidgets.resumoHortas} onChange={onToggleWidget('resumoHortas')} />}
                     label="Resumo das hortas"
@@ -1390,8 +1390,13 @@ export default function DashboardApp() {
                     </Typography>
                     <Stack spacing={1}>
                       {automationDraft.condicoes.map((condicao, index) => (
-                        <Stack key={`condicao-${index}`} direction="row" spacing={1} alignItems="center">
-                          <FormControl size="small" sx={{ minWidth: 180 }}>
+                        <Stack
+                          key={`condicao-${index}`}
+                          direction={{ xs: 'column', sm: 'row' }}
+                          spacing={1}
+                          alignItems={{ xs: 'stretch', sm: 'center' }}
+                        >
+                          <FormControl size="small" sx={{ minWidth: { sm: 180 } }}>
                             <InputLabel id={`condicao-sensor-${index}`}>Sensor</InputLabel>
                             <Select
                               labelId={`condicao-sensor-${index}`}
@@ -1406,7 +1411,7 @@ export default function DashboardApp() {
                               ))}
                             </Select>
                           </FormControl>
-                          <FormControl size="small" sx={{ minWidth: 90 }}>
+                          <FormControl size="small" sx={{ minWidth: { sm: 90 } }}>
                             <InputLabel id={`condicao-operador-${index}`}>Op.</InputLabel>
                             <Select
                               labelId={`condicao-operador-${index}`}
@@ -1448,8 +1453,13 @@ export default function DashboardApp() {
                     </Typography>
                     <Stack spacing={1}>
                       {automationDraft.dependencias.map((dependencia, index) => (
-                        <Stack key={`dependencia-${index}`} direction="row" spacing={1} alignItems="center">
-                          <FormControl size="small" sx={{ minWidth: 180 }}>
+                        <Stack
+                          key={`dependencia-${index}`}
+                          direction={{ xs: 'column', sm: 'row' }}
+                          spacing={1}
+                          alignItems={{ xs: 'stretch', sm: 'center' }}
+                        >
+                          <FormControl size="small" sx={{ minWidth: { sm: 180 } }}>
                             <InputLabel id={`dependencia-sensor-${index}`}>Sensor</InputLabel>
                             <Select
                               labelId={`dependencia-sensor-${index}`}
@@ -1464,7 +1474,7 @@ export default function DashboardApp() {
                               ))}
                             </Select>
                           </FormControl>
-                          <FormControl size="small" sx={{ minWidth: 120 }}>
+                          <FormControl size="small" sx={{ minWidth: { sm: 120 } }}>
                             <InputLabel id={`dependencia-status-${index}`}>Status</InputLabel>
                             <Select
                               labelId={`dependencia-status-${index}`}
@@ -2138,7 +2148,7 @@ export default function DashboardApp() {
               <CardContent>
                 <Stack direction={{ xs: 'column', md: 'row' }} spacing={2} alignItems={{ md: 'center' }} sx={{ mb: 3 }}>
                   <Typography variant="h5">Planejamento de plantio inteligente</Typography>
-                  <FormControl sx={{ minWidth: 220 }}>
+                  <FormControl fullWidth sx={{ maxWidth: { md: 320 } }}>
                     <InputLabel id="regiao-label">Sazonalidade por região</InputLabel>
                     <Select labelId="regiao-label" label="Sazonalidade por região" value={region} onChange={(event) => setRegion(event.target.value)}>
                       {regionOptions.map((option) => (

--- a/src/sections/@dashboard/app/AppNewsUpdate.js
+++ b/src/sections/@dashboard/app/AppNewsUpdate.js
@@ -54,20 +54,20 @@ function NewsItem({ news }) {
   const { image, title, description, postedAt } = news;
 
   return (
-    <Stack direction="row" alignItems="center" spacing={2}>
+    <Stack direction={{ xs: 'column', sm: 'row' }} alignItems={{ xs: 'flex-start', sm: 'center' }} spacing={2}>
       <Box component="img" alt={title} src={image} sx={{ width: 48, height: 48, borderRadius: 1.5, flexShrink: 0 }} />
 
-      <Box sx={{ minWidth: 240, flexGrow: 1 }}>
-        <Link color="inherit" variant="subtitle2" underline="hover" noWrap>
+      <Box sx={{ minWidth: 0, flexGrow: 1, width: 1 }}>
+        <Link color="inherit" variant="subtitle2" underline="hover" sx={{ wordBreak: 'break-word' }}>
           {title}
         </Link>
 
-        <Typography variant="body2" sx={{ color: 'text.secondary' }} noWrap>
+        <Typography variant="body2" sx={{ color: 'text.secondary', wordBreak: 'break-word' }}>
           {description}
         </Typography>
       </Box>
 
-      <Typography variant="caption" sx={{ pr: 3, flexShrink: 0, color: 'text.secondary' }}>
+      <Typography variant="caption" sx={{ pr: { sm: 3 }, flexShrink: 0, color: 'text.secondary', alignSelf: { xs: 'flex-end', sm: 'center' } }}>
         {fToNow(postedAt)}
       </Typography>
     </Stack>

--- a/src/sections/@dashboard/app/AppTasks.js
+++ b/src/sections/@dashboard/app/AppTasks.js
@@ -95,7 +95,7 @@ function TaskItem({ task, checked, onChange }) {
 
   return (
     <Stack
-      direction="row"
+      direction={{ xs: 'column', sm: 'row' }}
       sx={{
         px: 2,
         py: 0.75,
@@ -108,7 +108,7 @@ function TaskItem({ task, checked, onChange }) {
       <FormControlLabel
         control={<Checkbox checked={checked} onChange={onChange} />}
         label={task.label}
-        sx={{ flexGrow: 1, m: 0 }}
+        sx={{ flexGrow: 1, m: 0, mr: { sm: 1 } }}
       />
 
       <MoreMenuButton


### PR DESCRIPTION
### Motivation
- Make dashboard UI elements (menu, controls, images, text) adapt cleanly to narrow viewports so content doesn't overflow or get clipped. 
- Reduce rigid min-widths and horizontal padding that caused overflow beside the persistent sidebar on small screens.

### Description
- Tighten the main dashboard content container so it can shrink safely by adding `width: 0` and `minWidth: 0` and reducing mobile padding. (src/layouts/dashboard/index.js)
- Make the widget toggle group wrap and add gap styles so toggles break onto multiple rows on small screens. (src/pages/dashboard/MonitoringPage.js)
- Convert several row-based control groups (automation conditions and dependencies) into responsive Stacks that switch to column layout on small screens and make `FormControl` min-widths conditional on breakpoints. (src/pages/dashboard/MonitoringPage.js)
- Make the region selector full-width on small screens with a `maxWidth` cap to prevent horizontal overflow. (src/pages/dashboard/MonitoringPage.js)
- Improve news/task item responsiveness by stacking image/title/time vertically on mobile, removing hard min-widths, enabling text wrapping for titles/descriptions, and adjusting spacing for small screens. (src/sections/@dashboard/app/AppNewsUpdate.js, src/sections/@dashboard/app/AppTasks.js)

### Testing
- Ran `npm run lint` and the linter completed successfully.
- Built the production bundle with `npm run build` and the build finished without errors.
- Started the dev server and captured an automated mobile viewport screenshot of `/dashboard/app` to validate responsive layout (390×844).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69acfcc5b550832e8a82cbaacf11dc42)