### PR TITLE
Use MUI Google and Apple icons for social login buttons

### DIFF
--- a/src/sections/auth/AuthSocial.js
+++ b/src/sections/auth/AuthSocial.js
@@ -2,8 +2,9 @@ import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 // material
 import { Stack, Button, Divider, Typography, Alert } from '@mui/material';
+import GoogleIcon from '@mui/icons-material/Google';
+import AppleIcon from '@mui/icons-material/Apple';
 // component
-import Iconify from '../../components/Iconify';
 import useAuth from '../../auth/useAuth';
 import { DEFAULT_AUTH_REDIRECT } from '../../utils/authRedirect';
 
@@ -41,11 +42,11 @@ export default function AuthSocial() {
 
       <Stack direction="row" spacing={2}>
         <Button fullWidth size="large" color="inherit" variant="outlined" onClick={() => handleSocialLogin('google')}>
-          <Iconify icon="eva:google-fill" color="#DF3E30" width={22} height={22} />
+          <GoogleIcon sx={{ color: '#DF3E30' }} />
         </Button>
 
         <Button fullWidth size="large" color="inherit" variant="outlined" onClick={() => handleSocialLogin('apple')}>
-          <Iconify icon="mdi:apple" color="#000000" width={22} height={22} />
+          <AppleIcon sx={{ color: '#000000' }} />
         </Button>
       </Stack>
 


### PR DESCRIPTION
### Motivation
- The social login buttons were rendering extra/blank content instead of only the intended provider icons, so the UI should show only the Google and Apple icons in those two buttons.

### Description
- Replaced `Iconify` usage in `src/sections/auth/AuthSocial.js` with Material UI `Google` and `Apple` icons by adding `GoogleIcon` and `AppleIcon` imports and swapping the icon components while keeping the existing button markup and click handlers.

### Testing
- Ran `npx eslint src/sections/auth/AuthSocial.js` and it completed successfully.
- Started the dev server with `npm run dev -- --host 0.0.0.0 --port 4173` to validate visually and it launched successfully.
- Captured a Playwright screenshot of the login page showing the updated social icon buttons (artifact produced).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69acff29c7d4832ea6e03ce6cb075e2a)