### PR TITLE
feat(localization): normalize locale codes and modernize language switcher

### DIFF
--- a/src/layouts/dashboard/LanguagePopover.js
+++ b/src/layouts/dashboard/LanguagePopover.js
@@ -1,9 +1,24 @@
 import { useEffect, useMemo, useState } from 'react';
 import { alpha } from '@mui/material/styles';
-import { Box, Stack, IconButton, Tooltip } from '@mui/material';
+import {
+  Box,
+  Button,
+  Chip,
+  Menu,
+  MenuItem,
+  Stack,
+  IconButton,
+  Tooltip,
+  ListItemIcon,
+  ListItemText,
+  Typography,
+} from '@mui/material';
+import KeyboardArrowDownRoundedIcon from '@mui/icons-material/KeyboardArrowDownRounded';
+import CheckRoundedIcon from '@mui/icons-material/CheckRounded';
 import {
   LANGS,
   STORAGE_KEY,
+  normalizeLanguageCode,
   applyGoogleLanguage,
   ensureGoogleTranslate,
   ensureTranslateDomSetup,
@@ -12,14 +27,26 @@ import {
   detectLanguageFromBrowser,
 } from '../../services/localization';
 
+const DISPLAY_LANGUAGE_CODE = {
+  pt: 'pt-BR',
+  en: 'en',
+  es: 'es',
+  fr: 'fr',
+  ja: 'ja',
+};
+
 export default function LanguagePopover() {
   const [selectedLanguage, setSelectedLanguage] = useState('pt');
+  const [anchorEl, setAnchorEl] = useState(null);
 
   const languageOptions = useMemo(() => LANGS, []);
+  const selectedOption = useMemo(
+    () => languageOptions.find((option) => option.value === selectedLanguage) || languageOptions[0],
+    [languageOptions, selectedLanguage]
+  );
 
   useEffect(() => {
     ensureGoogleTranslate();
-
     ensureTranslateDomSetup();
 
     const manualLanguage = getStoredLanguage();
@@ -32,10 +59,11 @@ export default function LanguagePopover() {
     const autoDetectLanguage = async () => {
       try {
         const detectedLanguage = await detectLanguageByGeolocation();
-        setSelectedLanguage(detectedLanguage);
-        applyGoogleLanguage(detectedLanguage);
+        const normalizedLanguage = normalizeLanguageCode(detectedLanguage);
+        setSelectedLanguage(normalizedLanguage);
+        applyGoogleLanguage(normalizedLanguage);
       } catch (error) {
-        const fallbackLanguage = detectLanguageFromBrowser();
+        const fallbackLanguage = normalizeLanguageCode(detectLanguageFromBrowser());
         setSelectedLanguage(fallbackLanguage);
         applyGoogleLanguage(fallbackLanguage);
       }
@@ -45,34 +73,95 @@ export default function LanguagePopover() {
   }, []);
 
   const handleLanguageChange = (language) => {
-    localStorage.setItem(STORAGE_KEY, language);
-    setSelectedLanguage(language);
-    applyGoogleLanguage(language);
+    const normalizedLanguage = normalizeLanguageCode(language);
+    localStorage.setItem(STORAGE_KEY, normalizedLanguage);
+    setSelectedLanguage(normalizedLanguage);
+    applyGoogleLanguage(normalizedLanguage);
+    setAnchorEl(null);
   };
 
   return (
-    <Stack direction="row" spacing={0.5} alignItems="center">
-      {languageOptions.map((option) => (
-        <Tooltip key={option.value} title={option.label} arrow>
-          <IconButton
-            onClick={() => handleLanguageChange(option.value)}
-            sx={{
-              p: 0.25,
-              width: 32,
-              height: 32,
-              borderRadius: 0.75,
-              border: '1px solid',
-              borderColor: option.value === selectedLanguage ? 'primary.main' : 'transparent',
-              bgcolor: (theme) =>
-                option.value === selectedLanguage
-                  ? alpha(theme.palette.primary.main, theme.palette.action.focusOpacity)
-                  : 'transparent',
-            }}
-          >
-            <Box component="img" src={option.icon} alt={option.label} sx={{ width: 24, height: 16, borderRadius: 0.5 }} />
-          </IconButton>
-        </Tooltip>
-      ))}
+    <Stack direction="row" spacing={1} alignItems="center">
+      <Stack direction="row" spacing={0.5} alignItems="center">
+        {languageOptions.map((option) => (
+          <Tooltip key={option.value} title={option.label} arrow>
+            <IconButton
+              onClick={() => handleLanguageChange(option.value)}
+              sx={{
+                p: 0.25,
+                width: 32,
+                height: 32,
+                borderRadius: 0.75,
+                border: '1px solid',
+                borderColor: option.value === selectedLanguage ? 'primary.main' : 'transparent',
+                bgcolor: (theme) =>
+                  option.value === selectedLanguage
+                    ? alpha(theme.palette.primary.main, theme.palette.action.focusOpacity)
+                    : 'transparent',
+              }}
+            >
+              <Box component="img" src={option.icon} alt={option.label} sx={{ width: 24, height: 16, borderRadius: 0.5 }} />
+            </IconButton>
+          </Tooltip>
+        ))}
+      </Stack>
+
+      <Button
+        size="small"
+        color="inherit"
+        variant="outlined"
+        onClick={(event) => setAnchorEl(event.currentTarget)}
+        endIcon={<KeyboardArrowDownRoundedIcon fontSize="small" />}
+        sx={{
+          textTransform: 'none',
+          borderRadius: 2,
+          borderColor: 'divider',
+          minWidth: 120,
+          px: 1.25,
+          py: 0.5,
+        }}
+      >
+        <Stack direction="row" spacing={1} alignItems="center">
+          <Box component="img" src={selectedOption.icon} alt={selectedOption.label} sx={{ width: 18, height: 12, borderRadius: 0.4 }} />
+          <Box textAlign="left">
+            <Typography variant="caption" color="text.secondary" lineHeight={1}>
+              Idioma
+            </Typography>
+            <Typography variant="body2" lineHeight={1.2}>
+              {DISPLAY_LANGUAGE_CODE[selectedOption.value] || selectedOption.value}
+            </Typography>
+          </Box>
+        </Stack>
+      </Button>
+
+      <Menu
+        anchorEl={anchorEl}
+        open={Boolean(anchorEl)}
+        onClose={() => setAnchorEl(null)}
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
+        transformOrigin={{ vertical: 'top', horizontal: 'right' }}
+      >
+        {languageOptions.map((option) => {
+          const isActive = option.value === selectedLanguage;
+          return (
+            <MenuItem key={option.value} onClick={() => handleLanguageChange(option.value)} selected={isActive} sx={{ minWidth: 220 }}>
+              <ListItemIcon sx={{ minWidth: 32 }}>
+                <Box component="img" src={option.icon} alt={option.label} sx={{ width: 20, height: 14, borderRadius: 0.5 }} />
+              </ListItemIcon>
+              <ListItemText primary={option.label} secondary={DISPLAY_LANGUAGE_CODE[option.value] || option.value} />
+              {isActive ? <CheckRoundedIcon fontSize="small" color="success" /> : null}
+            </MenuItem>
+          );
+        })}
+      </Menu>
+
+      <Chip
+        size="small"
+        color="primary"
+        variant="outlined"
+        label={`Atual: ${DISPLAY_LANGUAGE_CODE[selectedOption.value] || selectedOption.value}`}
+        sx={{ borderRadius: 1.5 }}
+      />
     </Stack>
   );
 }

--- a/src/services/localization.js
+++ b/src/services/localization.js
@@ -82,6 +82,21 @@ const GOOGLE_TRANSLATE_LANGUAGES = [
   ...new Set([...LANGS.map((lang) => lang.value), ...Object.values(COUNTRY_LANGUAGE_MAP)]),
 ].join(',');
 
+const normalizeLanguageCode = (languageCode) => {
+  if (!languageCode) return 'pt';
+
+  const normalizedCode = languageCode.toLowerCase();
+
+  if (normalizedCode === 'pt-br' || normalizedCode === 'pt_br') return 'pt';
+  if (normalizedCode === 'en-us' || normalizedCode === 'en_us') return 'en';
+  if (normalizedCode === 'es-es' || normalizedCode === 'es_es') return 'es';
+  if (normalizedCode === 'fr-fr' || normalizedCode === 'fr_fr') return 'fr';
+  if (normalizedCode === 'ja-jp' || normalizedCode === 'ja_jp') return 'ja';
+
+  const [baseLanguage] = normalizedCode.split(/[-_]/);
+  return LANGS.some((lang) => lang.value === baseLanguage) ? baseLanguage : 'pt';
+};
+
 const mapCountryToLanguage = (countryCode) => {
   if (!countryCode) return 'pt';
   const upperCountryCode = countryCode.toUpperCase();
@@ -94,13 +109,15 @@ const mapCountryToLanguage = (countryCode) => {
 const applyGoogleLanguage = (language) => {
   if (!language || typeof document === 'undefined') return;
 
-  if (pendingLanguage !== language) {
+  const normalizedLanguage = normalizeLanguageCode(language);
+
+  if (pendingLanguage !== normalizedLanguage) {
     languageSyncAttempts = 0;
   }
 
-  pendingLanguage = language;
+  pendingLanguage = normalizedLanguage;
 
-  const cookieValue = `/${SOURCE_LANGUAGE}/${language}`;
+  const cookieValue = `/${SOURCE_LANGUAGE}/${normalizedLanguage}`;
   document.cookie = `${GOOGLE_COOKIE_KEY}=${cookieValue};path=/`;
 
   if (typeof window !== 'undefined' && window.location?.hostname) {
@@ -108,8 +125,8 @@ const applyGoogleLanguage = (language) => {
   }
 
   const select = document.querySelector('select.goog-te-combo');
-  if (select && select.value !== language) {
-    select.value = language;
+  if (select && select.value !== normalizedLanguage) {
+    select.value = normalizedLanguage;
     select.dispatchEvent(new Event('change'));
     pendingLanguage = null;
     languageSyncAttempts = 0;
@@ -118,7 +135,7 @@ const applyGoogleLanguage = (language) => {
       window.clearTimeout(languageSyncTimer);
       languageSyncTimer = null;
     }
-  } else if (select && select.value === language) {
+  } else if (select && select.value === normalizedLanguage) {
     pendingLanguage = null;
     languageSyncAttempts = 0;
   }
@@ -127,7 +144,7 @@ const applyGoogleLanguage = (language) => {
     scheduleLanguageSync();
   }
 
-  document.documentElement.setAttribute('lang', language);
+  document.documentElement.setAttribute('lang', normalizedLanguage);
 };
 
 const scheduleLanguageSync = () => {
@@ -205,7 +222,8 @@ const ensureTranslateDomSetup = () => {
 
 const getStoredLanguage = () => {
   if (typeof window === 'undefined') return null;
-  return window.localStorage.getItem(STORAGE_KEY);
+  const storedLanguage = window.localStorage.getItem(STORAGE_KEY);
+  return storedLanguage ? normalizeLanguageCode(storedLanguage) : null;
 };
 
 const detectLanguageFromBrowser = () => {
@@ -269,6 +287,7 @@ const detectLanguageByGeolocation = async () => {
 export {
   LANGS,
   STORAGE_KEY,
+  normalizeLanguageCode,
   applyGoogleLanguage,
   ensureGoogleTranslate,
   ensureTranslateDomSetup,


### PR DESCRIPTION
### Motivation
- Unificar e robustecer o suporte a idiomas para aceitar variantes como `pt-BR` / `en-US` e evitar mismatch entre a UI e o motor de tradução automática. 
- Oferecer uma experiência de seleção de idioma mais rica (chips de bandeira + dropdown) semelhante ao exemplo fornecido.

### Description
- Adiciona `normalizeLanguageCode` à `src/services/localization.js` para mapear variantes (`pt-BR`, `en-US`, etc.) para os códigos usados pela aplicação (`pt`, `en`, `es`, `fr`, `ja`).
- Atualiza `applyGoogleLanguage` para normalizar a entrada antes de escrever cookies, sincronizar o `select.goog-te-combo` e ajustar `document.documentElement.lang`.
- Ajusta `getStoredLanguage` para retornar `null` quando não há preferência e para normalizar o valor armazenado quando presente, preservando o fluxo de detecção automática.
- Substitui o componente `LanguagePopover` em `src/layouts/dashboard/LanguagePopover.js` por uma versão com quick-flag chips, botão dropdown com menu, indicador de idioma ativo e exibição de código (`pt-BR`, `en`, `es`, `fr`, `ja`), passando a usar `normalizeLanguageCode` e a persistir apenas códigos normalizados em `localStorage`.

### Testing
- Executado `npm run lint -- src/layouts/dashboard/LanguagePopover.js src/services/localization.js`, que completou sem erros.
- Iniciado servidor de desenvolvimento com `npm run dev` para validação manual do fluxo de UI (servidor levantou com sucesso). 
- Tentativa automatizada de navegação/screenshot via Playwright falhou por crash do Chromium no ambiente (`SIGSEGV`), portanto o teste end-to-end de renderização não pôde ser concluído aqui.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ad00ad8b90832e97a37e1cdd8f0e11)