### PR TITLE
Add legacy onboarding redirect and route handling

### DIFF
--- a/src/routes.js
+++ b/src/routes.js
@@ -1,5 +1,5 @@
 import { Suspense, lazy } from 'react';
-import { Navigate, useRoutes } from 'react-router-dom';
+import { Navigate, useParams, useRoutes } from 'react-router-dom';
 // layouts
 import DashboardLayout from './layouts/dashboard';
 import LogoOnlyLayout from './layouts/LogoOnlyLayout';
@@ -49,6 +49,18 @@ const renderLazy = (Component, fallback = lazyModuleFallback) => (
 
 // ----------------------------------------------------------------------
 
+const LEGACY_ONBOARDING_ROUTES = new Set(['hortelan-360', 'hortelan360']);
+
+function LegacyOnboardingRedirect() {
+  const { legacyPath = '' } = useParams();
+
+  if (LEGACY_ONBOARDING_ROUTES.has(legacyPath)) {
+    return <Navigate to="/dashboard/hortelan-360" replace />;
+  }
+
+  return <Navigate to="/dashboard/onboarding" replace />;
+}
+
 export default function Router() {
   return useRoutes([
     {
@@ -67,6 +79,7 @@ export default function Router() {
         { path: 'blog', element: renderLazy(CommunityPage) },
         { path: 'hortelan-360', element: renderLazy(Hortelan360Page) },
         { path: 'hortelan360', element: <Navigate to="/dashboard/hortelan-360" replace /> },
+        { path: 'onboarding/:legacyPath', element: <LegacyOnboardingRedirect /> },
         { path: 'onboarding', element: renderLazy(OnboardingPage) },
         { path: 'status', element: renderLazy(PlatformStatusPage) },
         { path: 'security', element: renderLazy(SecurityCenterPage) },


### PR DESCRIPTION
### Motivation
- Preserve compatibility with old onboarding URLs by routing legacy paths to the current onboarding pages.
- Ensure users hitting legacy variants like `hortelan360` or `hortelan-360` are sent to the correct modern route.

### Description
- Add `useParams` import and introduce a `LEGACY_ONBOARDING_ROUTES` set containing legacy path keys.
- Implement `LegacyOnboardingRedirect` component that reads `:legacyPath` and redirects to `/dashboard/hortelan-360` for known legacy keys or to `/dashboard/onboarding` otherwise.
- Register a new route `onboarding/:legacyPath` that uses `LegacyOnboardingRedirect`, keeping the existing `hortelan360` redirect in place.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69acffa50dcc832ea567027ee304b30a)