### PR TITLE
fix(auth): habilita fallback de autenticação em dev com Vite

### DIFF
--- a/src/auth/AuthContext.js
+++ b/src/auth/AuthContext.js
@@ -46,8 +46,19 @@ function isApiBaseUrlLikelyMisconfigured(error) {
   return error?.status === 404 || error?.status === 405;
 }
 
+function isRunningLocallyWithVite() {
+  if (typeof window === 'undefined') {
+    return false;
+  }
+
+  const currentHost = window.location?.hostname || '';
+  const isLocalEnvironment = ['localhost', '127.0.0.1', '0.0.0.0'].includes(currentHost);
+
+  return Boolean(import.meta.env.DEV) && isLocalEnvironment;
+}
+
 function canUseDemoAuthFallback(error) {
-  if (ENABLE_DEMO_AUTH) {
+  if (ENABLE_DEMO_AUTH || isRunningLocallyWithVite()) {
     return true;
   }
 


### PR DESCRIPTION
### Motivation
- Evitar que, ao rodar o projeto localmente com Vite e sem backend disponível, a tela de login falhe com a mensagem "Serviço de autenticação indisponível" e permitir usar o fallback/demo durante desenvolvimento.

### Description
- Adicionado `isRunningLocallyWithVite()` em `src/auth/AuthContext.js` e alterada a lógica de `canUseDemoAuthFallback` para permitir fallback quando `import.meta.env.DEV` é verdadeiro e o host é `localhost|127.0.0.1|0.0.0.0`, além da flag `VITE_ENABLE_DEMO_AUTH` existente.

### Testing
- Executado `npx eslint src/auth/AuthContext.js` e não foram reportados erros (lint passou com sucesso).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ad0495c7748328a3e3b2ef0e013f57)