### PR TITLE
Remove language selector from dashboard navbar

### DIFF
--- a/src/layouts/dashboard/DashboardNavbar.js
+++ b/src/layouts/dashboard/DashboardNavbar.js
@@ -7,7 +7,6 @@ import Iconify from '../../components/Iconify';
 //
 import Searchbar from './Searchbar';
 import AccountPopover from './AccountPopover';
-import LanguagePopover from './LanguagePopover';
 import NotificationsPopover from './NotificationsPopover';
 import Mode from './ModeTheme';
 
@@ -54,9 +53,6 @@ export default function DashboardNavbar({ onOpenSidebar }) {
 
         <Stack direction="row" alignItems="center" spacing={{ xs: 0.5, sm: 1.5 }}>
           <Mode />
-          <Box sx={{ display: { xs: 'none', sm: 'inline-flex' } }}>
-            <LanguagePopover />
-          </Box>
           <Box sx={{ display: { xs: 'none', md: 'inline-flex' } }}>
             <NotificationsPopover />
           </Box>


### PR DESCRIPTION
### Motivation
- Hide the language selector from the dashboard top bar so the "Idioma / Atual: pt-BR" control no longer appears in the UI.

### Description
- Removed the `LanguagePopover` import from `src/layouts/dashboard/DashboardNavbar.js`.
- Removed the JSX block that rendered the language selector from the navbar, leaving `Mode`, `NotificationsPopover`, and `AccountPopover`.

### Testing
- Ran `npx eslint src/layouts/dashboard/DashboardNavbar.js` which completed successfully.
- Attempted an automated Playwright screenshot of the running app which failed because Chromium crashed with `SIGSEGV` in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ad05ebdb6083288af2730ecf575fd0)