### PR TITLE
fix: add root redirects for legacy Hortelan 360 paths

### DIFF
--- a/src/routes.js
+++ b/src/routes.js
@@ -132,6 +132,18 @@ export default function Router() {
       ],
     },
     {
+      path: '/onboarding/:legacyPath',
+      element: <LegacyOnboardingRedirect />,
+    },
+    {
+      path: '/hortelan-360',
+      element: <Navigate to="/dashboard/hortelan-360" replace />,
+    },
+    {
+      path: '/hortelan360',
+      element: <Navigate to="/dashboard/hortelan-360" replace />,
+    },
+    {
       path: '*',
       element: <Navigate to="/404" replace />,
     },


### PR DESCRIPTION
### Motivation
- Corrigir caso onde ao acessar links legados do Hortelan 360 fora do prefixo `/dashboard` a aplicação exibia a splash e depois ia para a página `404` em vez de abrir a tela correta.

### Description
- Adiciona redirecionamentos no topo do roteador em `src/routes.js` para `/hortelan-360`, `/hortelan360` (para `/dashboard/hortelan-360`) e para `/onboarding/:legacyPath` (reutilizando `LegacyOnboardingRedirect`).

### Testing
- Executado `npm run lint -- src/routes.js` sem erros.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ad0618da9c83288aaf4b11cb8602a7)