### PR TITLE
Organiza estrutura visual de conteúdos na aba Monitoramento

### DIFF
--- a/src/pages/dashboard/MonitoringPage.js
+++ b/src/pages/dashboard/MonitoringPage.js
@@ -57,6 +57,26 @@ const dateTimeFormatter = new Intl.DateTimeFormat('pt-BR', {
   timeStyle: 'short',
 });
 
+const monitoringContentSx = {
+  '& .MuiCard-root': {
+    height: '100%',
+    display: 'flex',
+    flexDirection: 'column',
+  },
+  '& .MuiCardContent-root': {
+    height: '100%',
+    display: 'flex',
+    flexDirection: 'column',
+    gap: 1.5,
+    '&:last-child': {
+      pb: 3,
+    },
+  },
+  '& .MuiPaper-root': {
+    height: '100%',
+  },
+};
+
 const cropCatalog = {
   'Alface Crespa': { family: 'Folhosas', cycle: '45-60 dias' },
   'Alface Americana': { family: 'Folhosas', cycle: '55-70 dias' },
@@ -1064,7 +1084,8 @@ export default function DashboardApp() {
           Welcome {user?.name || 'User'} to the Hortelan AgTech Ltda System
         </Typography>
 
-        <Grid container spacing={3}>
+        <Box sx={monitoringContentSx}>
+          <Grid container spacing={3}>
           <Grid item xs={12}>
             <Card>
               <CardContent>
@@ -2793,7 +2814,8 @@ export default function DashboardApp() {
               ]}
             />
           </Grid>
-        </Grid>
+          </Grid>
+        </Box>
       </Container>
     </Page>
   );


### PR DESCRIPTION
### Motivation
- Melhorar alinhamento e consistência visual da página de Monitoramento padronizando comportamento de `Card`, `CardContent` e `Paper` para evitar blocos desalinhados entre os widgets.

### Description
- Adicionei o objeto `monitoringContentSx` com regras `sx` que forçam `MuiCard`, `MuiCardContent` e `MuiPaper` a usar altura completa e layout em coluna flex para manter alinhamento e espaçamento consistente.
- Envolvi o `Grid` principal da página em um `Box` com `sx={monitoringContentSx}` para aplicar o estilo a todos os blocos da tela de Monitoramento.
- A alteração foi feita no arquivo `src/pages/dashboard/MonitoringPage.js` sem alterações funcionais no comportamento dos widgets.

### Testing
- Executei `npm run lint -- src/pages/dashboard/MonitoringPage.js` e não foram reportados erros de linting.
- Iniciei o servidor de desenvolvimento com `npm run dev` e gerei uma captura automatizada da página via Playwright para validar a renderização; a página carregou e a captura foi produzida com sucesso.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ad06b71e6c83289157544b477f6158)