### PR TITLE
Use icon-only send button for chatbot in sidebar

### DIFF
--- a/src/layouts/dashboard/DashboardSidebar.js
+++ b/src/layouts/dashboard/DashboardSidebar.js
@@ -6,6 +6,7 @@ import { styled } from '@mui/material/styles';
 import { alpha } from '@mui/material/styles';
 import { Box, Link, Button, Drawer, Typography, Avatar, Stack, Paper, TextField } from '@mui/material';
 import SmartToyIcon from '@mui/icons-material/SmartToy';
+import SendRoundedIcon from '@mui/icons-material/SendRounded';
 // hooks
 import useResponsive from '../../hooks/useResponsive';
 // components
@@ -237,16 +238,17 @@ export default function DashboardSidebar({ isOpenSidebar, onCloseSidebar }) {
               <Button
                 onClick={handleSendMessage}
                 variant="contained"
-                fullWidth
+                aria-label="Enviar mensagem"
                 sx={{
-                  py: 1,
-                  borderRadius: 1.8,
+                  alignSelf: 'flex-end',
+                  minWidth: 0,
+                  width: 44,
+                  height: 44,
+                  borderRadius: '50%',
                   boxShadow: (theme) => `0 12px 20px ${alpha(theme.palette.primary.dark, 0.35)}`,
-                  textTransform: 'none',
-                  fontWeight: 700,
                 }}
               >
-                Enviar para o Chat Bot
+                <SendRoundedIcon fontSize="small" />
               </Button>
             </Stack>
           </Paper>


### PR DESCRIPTION
### Motivation
- Replace the textual "Enviar para o Chat Bot" button with an icon-only send control to match the requested UI change and free up horizontal space in the sidebar.

### Description
- Imported `SendRoundedIcon` from `@mui/icons-material` and replaced the button label with `<SendRoundedIcon fontSize="small" />`.
- Converted the `Button` from a `fullWidth` text button to a circular icon button by adding `aria-label="Enviar mensagem"`, `width: 44`, `height: 44`, `borderRadius: '50%'`, and removing the previous full-width/text styling.
- Preserved the existing `onClick` behavior by keeping the `handleSendMessage` handler unchanged.

### Testing
- Ran `npx eslint src/layouts/dashboard/DashboardSidebar.js`, which completed successfully.
- Started the dev server with `npm run dev -- --host 0.0.0.0 --port 4173` and captured a visual screenshot to validate the updated icon button.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ad073d070483288d4d0fca8a0338b9)