### PR TITLE
Remove chatbot descriptive text from dashboard sidebar help card

### DIFF
--- a/src/layouts/dashboard/DashboardSidebar.js
+++ b/src/layouts/dashboard/DashboardSidebar.js
@@ -136,9 +136,6 @@ export default function DashboardSidebar({ isOpenSidebar, onCloseSidebar }) {
             <Typography gutterBottom variant="h6">
               Precisa de ajuda com a sua operação?
             </Typography>
-            <Typography variant="body2" sx={{ color: 'text.secondary' }}>
-              Converse direto com o nosso chat bot de IA especializado na plataforma Hortelan.
-            </Typography>
           </Box>
 
           <Paper


### PR DESCRIPTION
### Motivation
- Remove an unnecessary descriptive line from the dashboard sidebar help card to declutter the UI and keep the card focused on the call-to-action.

### Description
- Deleted the secondary `Typography` line that read "Converse direto com o nosso chat bot de IA especializado na plataforma Hortelan." in `src/layouts/dashboard/DashboardSidebar.js` while preserving the surrounding layout and bot preview.

### Testing
- Ran `npx eslint src/layouts/dashboard/DashboardSidebar.js` and started the app with `npm run dev` to visually validate the change (screenshot artifact captured), and both checks completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ad0758ea5c83288dd065ff4fc6d953)