### PR TITLE
refactor(subscriptions): organizar layout de cards e papers

### DIFF
--- a/src/pages/dashboard/SubscriptionsPage.js
+++ b/src/pages/dashboard/SubscriptionsPage.js
@@ -4,13 +4,16 @@ import {
   Box,
   Button,
   Card,
+  CardContent,
   Chip,
   Container,
   Divider,
   FormControl,
+  Grid,
   InputLabel,
   LinearProgress,
   MenuItem,
+  Paper,
   Select,
   Stack,
   Table,
@@ -194,141 +197,168 @@ export default function Subscriptions() {
 
   return (
     <Page title="Assinaturas e planos">
-      <Container>
+      <Container maxWidth="lg" sx={{ pb: 4 }}>
         <Stack spacing={3}>
           <Typography variant="h4">Assinaturas e planos</Typography>
 
           {feedback && <Alert severity={feedback.type}>{feedback.message}</Alert>}
 
-          <Card sx={{ p: 3 }}>
-            <Stack spacing={2}>
+          <Card>
+            <CardContent>
+              <Stack spacing={2.5}>
               <Typography variant="h6">16.1 Planos de uso</Typography>
               <Typography variant="body2" color="text.secondary">
                 Escolha o melhor plano para sua operação: gratuito, premium, família/equipe ou educacional/empresa (B2B).
               </Typography>
 
-              <Stack direction={{ xs: 'column', md: 'row' }} spacing={2}>
-                <FormControl fullWidth>
-                  <InputLabel id="plan-select-label">Plano</InputLabel>
-                  <Select
-                    labelId="plan-select-label"
-                    value={selectedPlan}
-                    label="Plano"
-                    onChange={(event) => setSelectedPlan(event.target.value)}
-                  >
-                    {Object.entries(PLAN_CATALOG).map(([value, plan]) => (
-                      <MenuItem key={value} value={value}>{plan.label}</MenuItem>
-                    ))}
-                  </Select>
-                </FormControl>
+                <Grid container spacing={2}>
+                  <Grid item xs={12} md={6}>
+                    <FormControl fullWidth>
+                      <InputLabel id="plan-select-label">Plano</InputLabel>
+                      <Select
+                        labelId="plan-select-label"
+                        value={selectedPlan}
+                        label="Plano"
+                        onChange={(event) => setSelectedPlan(event.target.value)}
+                      >
+                        {Object.entries(PLAN_CATALOG).map(([value, plan]) => (
+                          <MenuItem key={value} value={value}>{plan.label}</MenuItem>
+                        ))}
+                      </Select>
+                    </FormControl>
+                  </Grid>
 
-                <FormControl fullWidth>
-                  <InputLabel id="billing-select-label">Ciclo de cobrança</InputLabel>
-                  <Select
-                    labelId="billing-select-label"
-                    value={billingCycle}
-                    label="Ciclo de cobrança"
-                    onChange={(event) => setBillingCycle(event.target.value)}
-                  >
-                    <MenuItem value="monthly">Mensal</MenuItem>
-                    <MenuItem value="yearly">Anual</MenuItem>
-                  </Select>
-                </FormControl>
-              </Stack>
+                  <Grid item xs={12} md={6}>
+                    <FormControl fullWidth>
+                      <InputLabel id="billing-select-label">Ciclo de cobrança</InputLabel>
+                      <Select
+                        labelId="billing-select-label"
+                        value={billingCycle}
+                        label="Ciclo de cobrança"
+                        onChange={(event) => setBillingCycle(event.target.value)}
+                      >
+                        <MenuItem value="monthly">Mensal</MenuItem>
+                        <MenuItem value="yearly">Anual</MenuItem>
+                      </Select>
+                    </FormControl>
+                  </Grid>
+                </Grid>
 
-              <Stack direction={{ xs: 'column', md: 'row' }} spacing={2} alignItems={{ md: 'center' }}>
-                <Typography variant="h5">
-                  {formatCurrency(billingCycle === 'yearly' ? activePlan.yearlyPrice : activePlan.monthlyPrice)}
-                  <Typography component="span" variant="body2" color="text.secondary"> / {billingCycle === 'yearly' ? 'ano' : 'mês'}</Typography>
-                </Typography>
-                <Button variant="contained" onClick={handlePlanChange}>Confirmar upgrade/downgrade</Button>
-              </Stack>
+                <Paper variant="outlined" sx={{ p: 2 }}>
+                  <Stack direction={{ xs: 'column', md: 'row' }} spacing={2} alignItems={{ md: 'center' }} justifyContent="space-between">
+                    <Typography variant="h5">
+                      {formatCurrency(billingCycle === 'yearly' ? activePlan.yearlyPrice : activePlan.monthlyPrice)}
+                      <Typography component="span" variant="body2" color="text.secondary"> / {billingCycle === 'yearly' ? 'ano' : 'mês'}</Typography>
+                    </Typography>
+                    <Button variant="contained" onClick={handlePlanChange}>Confirmar upgrade/downgrade</Button>
+                  </Stack>
+                </Paper>
 
-              <Stack direction="row" spacing={1} flexWrap="wrap">
-                {activePlan.features.map((feature) => (
-                  <Chip key={feature} label={feature} sx={{ mb: 1 }} />
-                ))}
+                <Stack direction="row" spacing={1} flexWrap="wrap" useFlexGap>
+                  {activePlan.features.map((feature) => (
+                    <Chip key={feature} label={feature} />
+                  ))}
+                </Stack>
               </Stack>
-            </Stack>
+            </CardContent>
           </Card>
 
-          <Card sx={{ p: 3 }}>
-            <Stack spacing={2}>
+          <Card>
+            <CardContent>
+              <Stack spacing={2.5}>
               <Typography variant="h6">16.2 Gestão da assinatura</Typography>
 
-              <Stack direction={{ xs: 'column', md: 'row' }} spacing={2} justifyContent="space-between">
-                <Stack spacing={0.5}>
-                  <Typography variant="body2" color="text.secondary">Status atual</Typography>
-                  <Chip
-                    color={subscription.status === 'active' ? 'success' : 'warning'}
-                    label={subscription.status === 'active' ? 'Ativa' : 'Cancelada'}
-                    sx={{ width: 'fit-content' }}
-                  />
-                </Stack>
+                <Paper variant="outlined" sx={{ p: 2 }}>
+                  <Grid container spacing={2} alignItems="center">
+                    <Grid item xs={12} md={4}>
+                      <Stack spacing={0.5}>
+                        <Typography variant="body2" color="text.secondary">Status atual</Typography>
+                        <Chip
+                          color={subscription.status === 'active' ? 'success' : 'warning'}
+                          label={subscription.status === 'active' ? 'Ativa' : 'Cancelada'}
+                          sx={{ width: 'fit-content' }}
+                        />
+                      </Stack>
+                    </Grid>
 
-                <Stack spacing={0.5}>
-                  <Typography variant="body2" color="text.secondary">Próxima renovação</Typography>
-                  <Typography variant="subtitle2">{subscription.renewalDate ? formatDate(subscription.renewalDate) : 'Não definido'}</Typography>
-                </Stack>
+                    <Grid item xs={12} md={4}>
+                      <Stack spacing={0.5}>
+                        <Typography variant="body2" color="text.secondary">Próxima renovação</Typography>
+                        <Typography variant="subtitle2">{subscription.renewalDate ? formatDate(subscription.renewalDate) : 'Não definido'}</Typography>
+                      </Stack>
+                    </Grid>
 
-                <Stack direction="row" spacing={1}>
-                  <Button variant="outlined" color="error" onClick={handleCancel}>Cancelar</Button>
-                  <Button variant="outlined" onClick={handleRenew}>Renovar</Button>
-                </Stack>
-              </Stack>
+                    <Grid item xs={12} md={4}>
+                      <Stack direction="row" spacing={1} justifyContent={{ xs: 'flex-start', md: 'flex-end' }}>
+                        <Button variant="outlined" color="error" onClick={handleCancel}>Cancelar</Button>
+                        <Button variant="outlined" onClick={handleRenew}>Renovar</Button>
+                      </Stack>
+                    </Grid>
+                  </Grid>
+                </Paper>
 
               <Divider />
 
               <Typography variant="subtitle2">Histórico de cobrança</Typography>
-              <Table size="small">
-                <TableHead>
-                  <TableRow>
-                    <TableCell>Data</TableCell>
-                    <TableCell>Descrição</TableCell>
-                    <TableCell>Status</TableCell>
-                    <TableCell align="right">Valor</TableCell>
-                  </TableRow>
-                </TableHead>
-                <TableBody>
-                  {(subscription.billingHistory || []).slice(0, 6).map((invoice) => (
-                    <TableRow key={invoice.id}>
-                      <TableCell>{formatDate(invoice.date)}</TableCell>
-                      <TableCell>{invoice.description}</TableCell>
-                      <TableCell>{invoice.status}</TableCell>
-                      <TableCell align="right">{formatCurrency(invoice.amount)}</TableCell>
-                    </TableRow>
-                  ))}
-                </TableBody>
-              </Table>
-            </Stack>
+                <Paper variant="outlined" sx={{ overflowX: 'auto' }}>
+                  <Table size="small">
+                    <TableHead>
+                      <TableRow>
+                        <TableCell>Data</TableCell>
+                        <TableCell>Descrição</TableCell>
+                        <TableCell>Status</TableCell>
+                        <TableCell align="right">Valor</TableCell>
+                      </TableRow>
+                    </TableHead>
+                    <TableBody>
+                      {(subscription.billingHistory || []).slice(0, 6).map((invoice) => (
+                        <TableRow key={invoice.id}>
+                          <TableCell>{formatDate(invoice.date)}</TableCell>
+                          <TableCell>{invoice.description}</TableCell>
+                          <TableCell>{invoice.status}</TableCell>
+                          <TableCell align="right">{formatCurrency(invoice.amount)}</TableCell>
+                        </TableRow>
+                      ))}
+                    </TableBody>
+                  </Table>
+                </Paper>
+              </Stack>
+            </CardContent>
           </Card>
 
-          <Card sx={{ p: 3 }}>
-            <Stack spacing={2}>
+          <Card>
+            <CardContent>
+              <Stack spacing={2.5}>
               <Typography variant="h6">16.3 Controle de limites por plano</Typography>
-              {[
-                ['Número de hortas', currentUsage.gardens, subscription.limits?.gardens || 1],
-                ['Número de dispositivos', currentUsage.devices, subscription.limits?.devices || 1],
-                ['IA/diagnóstico por foto', currentUsage.aiPhotoDiagnostics, subscription.limits?.aiPhotoDiagnostics || 1],
-                ['Exportações avançadas', currentUsage.advancedExports, subscription.limits?.advancedExports || 1],
-              ].map(([label, used, limit]) => {
-                const ratio = Math.min((Number(used) / Number(limit)) * 100, 100);
 
-                return (
-                  <Box key={label}>
-                    <Stack direction="row" justifyContent="space-between">
-                      <Typography variant="body2">{label}</Typography>
-                      <Typography variant="body2" color="text.secondary">{used}/{limit}</Typography>
-                    </Stack>
-                    <LinearProgress variant="determinate" value={Number.isNaN(ratio) ? 0 : ratio} sx={{ mt: 1 }} />
-                  </Box>
-                );
-              })}
+                <Paper variant="outlined" sx={{ p: 2 }}>
+                  <Stack spacing={2}>
+                    {[
+                      ['Número de hortas', currentUsage.gardens, subscription.limits?.gardens || 1],
+                      ['Número de dispositivos', currentUsage.devices, subscription.limits?.devices || 1],
+                      ['IA/diagnóstico por foto', currentUsage.aiPhotoDiagnostics, subscription.limits?.aiPhotoDiagnostics || 1],
+                      ['Exportações avançadas', currentUsage.advancedExports, subscription.limits?.advancedExports || 1],
+                    ].map(([label, used, limit]) => {
+                      const ratio = Math.min((Number(used) / Number(limit)) * 100, 100);
+
+                      return (
+                        <Box key={label}>
+                          <Stack direction="row" justifyContent="space-between" spacing={1}>
+                            <Typography variant="body2">{label}</Typography>
+                            <Typography variant="body2" color="text.secondary">{used}/{limit}</Typography>
+                          </Stack>
+                          <LinearProgress variant="determinate" value={Number.isNaN(ratio) ? 0 : ratio} sx={{ mt: 1 }} />
+                        </Box>
+                      );
+                    })}
+                  </Stack>
+                </Paper>
 
               <Alert severity="info">
                 Histórico de dados disponível por {subscription.limits?.dataHistoryDays || 30} dias para o plano atual.
               </Alert>
-            </Stack>
+              </Stack>
+            </CardContent>
           </Card>
         </Stack>
       </Container>


### PR DESCRIPTION
### Motivation
- Melhorar o alinhamento e a leitura da página "Assinaturas e planos" padronizando o uso de componentes MUI como `CardContent`, `Paper` e `Grid` para organizar visualmente cada seção.
- Deixar os blocos responsivos e com espaçamento consistente para facilitar manutenção e futuras customizações de estilo.

### Description
- Substitui blocos `Card` com `sx` de padding por `Card` + `CardContent` e ajusta `Stack` para espaçamentos mais consistentes; também define `Container maxWidth="lg"` com `sx={{ pb: 4 }}` para layout mais previsível.
- Usa `Grid` para alinhar os controles de seleção de plano/ciclo e para o resumo de status/renovação/ações, mantendo a lógica existente de seleção e manipulação de assinatura intacta.
- Encapsula preço/ação, status/renovação/ações e listas de limites/histórico em `Paper variant="outlined"` com padding e `overflowX: 'auto'` para a tabela, melhorando separação visual e responsividade.
- Ajusta indicadores e listas (chips, `LinearProgress`) com `Stack` e pequenos ajustes de espaçamento para garantir alinhamento correto entre `MuiCardContent`, `Paper` e demais elementos MUI.

### Testing
- Executado `npm run lint` e a verificação de linting passou sem erros.
- Servidor de desenvolvimento iniciado e a página `/dashboard/subscriptions` foi renderizada com captura de tela automatizada via Playwright para validação visual, que foi executada com sucesso.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ad09596e388328a9f0839a335ae9b3)