### PR TITLE
Organiza a apresentação da aba Central de Ajuda

### DIFF
--- a/src/pages/HelpCenter.js
+++ b/src/pages/HelpCenter.js
@@ -18,6 +18,7 @@ import {
   ListItemText,
   MenuItem,
   Select,
+  Paper,
   Stack,
   Switch,
   Tab,
@@ -172,61 +173,72 @@ export default function HelpCenter() {
           {tab === 'central-ajuda' && (
             <Grid container spacing={3}>
               <Grid item xs={12} lg={6}>
-                <Card>
-                  <CardContent>
-                    <Typography variant="h6" gutterBottom>
-                      FAQ
-                    </Typography>
-                    <List disablePadding>
-                      {faqItems.map((item) => (
-                        <ListItem key={item.question} disableGutters>
-                          <ListItemText primary={item.question} secondary={item.answer} />
-                        </ListItem>
-                      ))}
-                    </List>
+                <Card sx={{ height: '100%' }}>
+                  <CardContent sx={{ height: '100%' }}>
+                    <Stack spacing={2} sx={{ height: '100%' }}>
+                      <Typography variant="h6">FAQ</Typography>
+                      <Paper variant="outlined" sx={{ p: 1.5 }}>
+                        <List disablePadding>
+                          {faqItems.map((item, index) => (
+                            <ListItem key={item.question} disableGutters divider={index < faqItems.length - 1} sx={{ py: 1.25 }}>
+                              <ListItemText
+                                primary={item.question}
+                                secondary={item.answer}
+                                primaryTypographyProps={{ fontWeight: 600 }}
+                                secondaryTypographyProps={{ sx: { mt: 0.5 } }}
+                              />
+                            </ListItem>
+                          ))}
+                        </List>
+                      </Paper>
+                    </Stack>
                   </CardContent>
                 </Card>
               </Grid>
               <Grid item xs={12} md={6} lg={3}>
-                <Card>
-                  <CardContent>
-                    <Typography variant="h6" gutterBottom>
-                      Guias rápidos
-                    </Typography>
-                    <List dense disablePadding>
-                      {quickGuides.map((guide) => (
-                        <ListItem key={guide} disableGutters>
-                          <ListItemText primary={guide} />
-                        </ListItem>
-                      ))}
-                    </List>
+                <Card sx={{ height: '100%' }}>
+                  <CardContent sx={{ height: '100%' }}>
+                    <Stack spacing={2} sx={{ height: '100%' }}>
+                      <Typography variant="h6">Guias rápidos</Typography>
+                      <Paper variant="outlined" sx={{ p: 1.5, flexGrow: 1 }}>
+                        <List dense disablePadding>
+                          {quickGuides.map((guide, index) => (
+                            <ListItem key={guide} disableGutters divider={index < quickGuides.length - 1} sx={{ py: 1 }}>
+                              <ListItemText primary={guide} />
+                            </ListItem>
+                          ))}
+                        </List>
+                      </Paper>
+                    </Stack>
                   </CardContent>
                 </Card>
               </Grid>
               <Grid item xs={12} md={6} lg={3}>
-                <Card>
-                  <CardContent>
-                    <Typography variant="h6" gutterBottom>
-                      Tutoriais de uso
-                    </Typography>
-                    <List dense disablePadding>
-                      {tutorials.map((tutorial) => (
-                        <ListItem key={tutorial} disableGutters>
-                          <ListItemText primary={tutorial} />
-                        </ListItem>
-                      ))}
-                    </List>
-                    <Divider sx={{ my: 2 }} />
-                    <Typography variant="subtitle2" gutterBottom>
-                      Base de conhecimento
-                    </Typography>
-                    <List dense disablePadding>
-                      {knowledgeBase.map((article) => (
-                        <ListItem key={article} disableGutters>
-                          <ListItemText primary={article} />
-                        </ListItem>
-                      ))}
-                    </List>
+                <Card sx={{ height: '100%' }}>
+                  <CardContent sx={{ height: '100%' }}>
+                    <Stack spacing={2} sx={{ height: '100%' }}>
+                      <Typography variant="h6">Tutoriais de uso</Typography>
+                      <Paper variant="outlined" sx={{ p: 1.5 }}>
+                        <List dense disablePadding>
+                          {tutorials.map((tutorial, index) => (
+                            <ListItem key={tutorial} disableGutters divider={index < tutorials.length - 1} sx={{ py: 1 }}>
+                              <ListItemText primary={tutorial} />
+                            </ListItem>
+                          ))}
+                        </List>
+                      </Paper>
+                      <Divider />
+                      <Typography variant="subtitle2">Base de conhecimento</Typography>
+                      <Paper variant="outlined" sx={{ p: 1.5, flexGrow: 1 }}>
+                        <List dense disablePadding>
+                          {knowledgeBase.map((article, index) => (
+                            <ListItem key={article} disableGutters divider={index < knowledgeBase.length - 1} sx={{ py: 1 }}>
+                              <ListItemText primary={article} />
+                            </ListItem>
+                          ))}
+                        </List>
+                      </Paper>
+                    </Stack>
                   </CardContent>
                 </Card>
               </Grid>


### PR DESCRIPTION
### Motivation
- Melhorar o alinhamento e a legibilidade dos blocos da aba "Central de ajuda" para garantir apresentação consistente entre colunas.
- Destacar perguntas/respostas e separar visualmente seções (FAQ, Guias rápidos, Tutoriais, Base de conhecimento) para facilitar a leitura.

### Description
- Adiciona `Paper` (importado de MUI) e envolve as listas com `Paper variant="outlined"` e padding para criar blocos visuais claros.
- Padroniza altura dos `Card` com `sx={{ height: '100%' }}`, organiza o conteúdo com `Stack` e usa `flexGrow` para manter alinhamento entre colunas.
- Ajusta `ListItem` para usar `divider` e `sx` de padding, e aplica `primaryTypographyProps`/`secondaryTypographyProps` ao FAQ para reforçar hierarquia tipográfica.
- Refatora o markup em `src/pages/HelpCenter.js` para aplicar essas mudanças nas seções FAQ, Guias rápidos, Tutoriais e Base de conhecimento.

### Testing
- Rodei `npx eslint src/pages/HelpCenter.js` e a verificação terminou com sucesso.
- Iniciei a aplicação com `npm run dev -- --host 0.0.0.0 --port 4173` e o servidor subiu corretamente.
- Gereis uma captura automatizada da rota `/dashboard/suporte` com um script Playwright para validar visualmente o layout alterado.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ad0984df44832892f5f415c60f12b2)