### PR TITLE
Remove dashboard module loading splash screen

### DIFF
--- a/src/routes.js
+++ b/src/routes.js
@@ -26,22 +26,7 @@ const IntegrationsOperationsPage = lazy(() => import('./pages/dashboard/Integrat
 const IntegrationsPage = lazy(() => import('./pages/dashboard/IntegrationsPage'));
 const LoginForm = lazy(() => import('./sections/auth/login').then((module) => ({ default: module.LoginForm })));
 
-const lazyModuleFallback = (
-  <div
-    style={{
-      minHeight: '100vh',
-      display: 'grid',
-      placeItems: 'center',
-      background: '#0b1220',
-      color: '#ffffff',
-      fontWeight: 700,
-    }}
-  >
-    Carregando módulo...
-  </div>
-);
-
-const renderLazy = (Component, fallback = lazyModuleFallback) => (
+const renderLazy = (Component, fallback = null) => (
   <Suspense fallback={fallback}>
     <Component />
   </Suspense>


### PR DESCRIPTION
### Motivation
- Remove the blue "Carregando módulo..." interstitial that appears when entering dashboard pages so routes render without the global lazy-loading overlay.

### Description
- Deleted the `lazyModuleFallback` overlay and changed `renderLazy` to use `fallback = null` by default in `src/routes.js`, leaving route paths and redirects unchanged.

### Testing
- Ran lint on the changed file with `npm run lint -- src/routes.js`, which succeeded.
- Attempted an automated Playwright screenshot to validate the UI, but the Chromium process crashed with `SIGSEGV` so the end-to-end check failed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ad0caf56708328ac0b022174b3b1b7)