### PR TITLE
fix: adicionar aliases de rota para Hortelan 360

### DIFF
--- a/src/routes.js
+++ b/src/routes.js
@@ -49,7 +49,7 @@ const renderLazy = (Component, fallback = lazyModuleFallback) => (
 
 // ----------------------------------------------------------------------
 
-const LEGACY_ONBOARDING_ROUTES = new Set(['hortelan-360', 'hortelan360']);
+const LEGACY_ONBOARDING_ROUTES = new Set(['hortelan-360', 'hortelan360', 'hortelan_360', 'hortelan 360']);
 
 function LegacyOnboardingRedirect() {
   const { legacyPath = '' } = useParams();
@@ -79,6 +79,8 @@ export default function Router() {
         { path: 'blog', element: renderLazy(CommunityPage) },
         { path: 'hortelan-360', element: renderLazy(Hortelan360Page) },
         { path: 'hortelan360', element: <Navigate to="/dashboard/hortelan-360" replace /> },
+        { path: 'hortelan_360', element: <Navigate to="/dashboard/hortelan-360" replace /> },
+        { path: 'hortelan 360', element: <Navigate to="/dashboard/hortelan-360" replace /> },
         { path: 'onboarding/:legacyPath', element: <LegacyOnboardingRedirect /> },
         { path: 'onboarding', element: renderLazy(OnboardingPage) },
         { path: 'status', element: renderLazy(PlatformStatusPage) },
@@ -141,6 +143,14 @@ export default function Router() {
     },
     {
       path: '/hortelan360',
+      element: <Navigate to="/dashboard/hortelan-360" replace />,
+    },
+    {
+      path: '/hortelan_360',
+      element: <Navigate to="/dashboard/hortelan-360" replace />,
+    },
+    {
+      path: '/hortelan 360',
       element: <Navigate to="/dashboard/hortelan-360" replace />,
     },
     {


### PR DESCRIPTION
### Motivation
- Corrigir 404 ao acessar variantes da URL do módulo Hortelan 360 ao mapear formas legadas/incorretas da rota para a rota canônica.

### Description
- Atualiza `src/routes.js` adicionando `hortelan_360` e `hortelan 360` ao `LEGACY_ONBOARDING_ROUTES` e incluindo redirecionamentos para essas variantes dentro de `/dashboard` e no nível raiz para `"/dashboard/hortelan-360"`.

### Testing
- Executado `npm run build` após as mudanças e a build completou com sucesso.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ad0db3e15c83289365813838cecd83)