### PR TITLE
Ajusta layout dos widgets de indicadores para ocupar melhor a largura

### DIFF
--- a/src/pages/dashboard/MonitoringPage.js
+++ b/src/pages/dashboard/MonitoringPage.js
@@ -1111,29 +1111,31 @@ export default function DashboardApp() {
           </Grid>
 
           {enabledWidgets.indicadores && (
-            <>
-              <Grid item xs={12} md={4}>
+            <Grid item xs={12}>
+              <Box
+                sx={{
+                  display: 'grid',
+                  gap: 3,
+                  gridTemplateColumns: { xs: '1fr', md: 'repeat(3, minmax(0, 1fr))' },
+                }}
+              >
                 <AppWidgetSummary
                   title="Umidade média"
                   total={indicadorMedioUmidade}
                   icon1="carbon:soil-moisture-field"
                   color="primary"
                 />
-              </Grid>
 
-              <Grid item xs={12} md={4}>
                 <AppWidgetSummary
                   title="Temperatura média"
                   total={indicadorMediaTemperatura}
                   icon1="mdi:temperature-celsius"
                   color="warning"
                 />
-              </Grid>
 
-              <Grid item xs={12} md={4}>
                 <AppWidgetSummary title="Alertas ativos" total={indicadorAlertasAtivos} icon1="icon-park:alarm" color="error" />
-              </Grid>
-            </>
+              </Box>
+            </Grid>
           )}
 
           {enabledWidgets.resumoHortas && (


### PR DESCRIPTION
### Motivation
- Melhorar o preenchimento horizontal da seção de indicadores para que os `Mui.Paper` (cards) ocupem mais espaço e preencham a tela lateralmente; a intenção é apenas ajustar o layout visual sem tocar na lógica dos widgets.

### Description
- Substitui os três `Grid item` individuais por um único `Grid item` que contém um `Box` com `display: 'grid'` dentro de `src/pages/dashboard/MonitoringPage.js`.
- Define `gridTemplateColumns` responsivo como `1fr` em mobile e `repeat(3, minmax(0, 1fr))` a partir de `md`, e adiciona `gap: 3` para espaçamento uniforme.
- Mantém os mesmos componentes `AppWidgetSummary` e os mesmos dados (`Umidade média`, `Temperatura média`, `Alertas ativos`), somente alterando a estrutura do contêiner para melhorar a largura ocupada.

### Testing
- Rodei `npx eslint src/pages/dashboard/MonitoringPage.js` com sucesso para verificar estilo e sintaxe do arquivo modificado.
- Iniciei a aplicação com `npm run dev -- --host 0.0.0.0 --port 4173` e a aplicação subiu corretamente para validação visual.
- Gerei uma captura de tela via Playwright (`artifacts/monitoring-widgets-wide.png`) para confirmar o resultado visual e verificação manual do layout, que também foi bem-sucedida.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ad0e33abdc8328811d5ac0ad3d9f33)