### PR TITLE
Ajusta largura horizontal do conteúdo em MonitoringPage

### DIFF
--- a/src/pages/dashboard/MonitoringPage.js
+++ b/src/pages/dashboard/MonitoringPage.js
@@ -1079,7 +1079,7 @@ export default function DashboardApp() {
 
   return (
     <Page title="Dashboard">
-      <Container maxWidth="xl">
+      <Container maxWidth={false} sx={{ px: { xs: 2, md: 3 } }}>
         <Typography variant="h4" sx={{ mb: 5 }}>
           Welcome {user?.name || 'User'} to the Hortelan AgTech Ltda System
         </Typography>


### PR DESCRIPTION
### Motivation
- Permitir que o conteúdo da página de monitoramento ocupe mais largura horizontal removendo o limite fixo de largura do `Container` e mantendo padding responsivo para evitar que o conteúdo fique colado nas bordas.

### Description
- Substitui ` <Container maxWidth="xl"> ` por ` <Container maxWidth={false} sx={{ px: { xs: 2, md: 3 } }}> ` em `src/pages/dashboard/MonitoringPage.js` para permitir preenchimento lateral maior.

### Testing
- Executado `npm run lint` com sucesso (sem erros). 
- Subida a aplicação com `npm run dev -- --host 0.0.0.0 --port 4173` para validação visual, processo iniciado com sucesso. 
- Rodado um script Playwright que abriu `http://127.0.0.1:4173/dashboard/monitoring` e capturou a screenshot `artifacts/monitoring-content-width.png`, confirmando o maior preenchimento horizontal (sucesso).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ad0e4f6b64832885bb1778cf0b5547)