### PR TITLE
Ajusta layout para exibir pedidos ao lado do checkout

### DIFF
--- a/src/pages/dashboard/SpeciesCatalogPage.js
+++ b/src/pages/dashboard/SpeciesCatalogPage.js
@@ -534,88 +534,92 @@ export default function ProductsMarketplace() {
           </Grid>
 
           <Grid item xs={12} md={7}>
-            <Card sx={{ height: '100%' }}>
-              <CardContent sx={{ display: 'flex', flexDirection: 'column', gap: 2, height: '100%' }}>
-                <Typography variant="h6" sx={{ mb: 2 }}>
-                  Checkout
-                </Typography>
-                <Grid container spacing={2}>
-                  <Grid item xs={12}>
-                    <TextField
-                      fullWidth
-                      label="Endereço de entrega"
-                      value={checkout.endereco}
-                      onChange={(event) => setCheckout((prev) => ({ ...prev, endereco: event.target.value }))}
-                    />
-                  </Grid>
-                  <Grid item xs={6}>
-                    <FormControl fullWidth>
-                      <InputLabel>Método de entrega</InputLabel>
-                      <Select
-                        value={checkout.entrega}
-                        label="Método de entrega"
-                        onChange={(event) => setCheckout((prev) => ({ ...prev, entrega: event.target.value }))}
-                      >
-                        <MenuItem value="padrão">Padrão</MenuItem>
-                        <MenuItem value="expresso">Expresso</MenuItem>
-                      </Select>
-                    </FormControl>
-                  </Grid>
-                  <Grid item xs={6}>
-                    <FormControl fullWidth>
-                      <InputLabel>Meio de pagamento</InputLabel>
-                      <Select
-                        value={checkout.pagamento}
-                        label="Meio de pagamento"
-                        onChange={(event) => setCheckout((prev) => ({ ...prev, pagamento: event.target.value }))}
-                      >
-                        <MenuItem value="pix">Pix</MenuItem>
-                        <MenuItem value="cartão">Cartão</MenuItem>
-                        <MenuItem value="boleto">Boleto</MenuItem>
-                      </Select>
-                    </FormControl>
-                  </Grid>
-                </Grid>
-                <Alert icon={<PaidIcon />} severity="info" sx={{ mt: 2 }}>
-                  Resumo do pedido: {cartItemsDetailed.length} itens, total de R$ {total.toFixed(2)}.
-                </Alert>
-                <Button fullWidth className="gsap-glow-button" variant="contained" sx={{ mt: 2 }}>
-                  Confirmar pedido
-                </Button>
-              </CardContent>
-            </Card>
+            <Grid container spacing={3} alignItems="stretch" sx={{ height: '100%' }}>
+              <Grid item xs={12} md={6}>
+                <Card sx={{ height: '100%' }}>
+                  <CardContent sx={{ display: 'flex', flexDirection: 'column', gap: 2, height: '100%' }}>
+                    <Typography variant="h6" sx={{ mb: 2 }}>
+                      Checkout
+                    </Typography>
+                    <Grid container spacing={2}>
+                      <Grid item xs={12}>
+                        <TextField
+                          fullWidth
+                          label="Endereço de entrega"
+                          value={checkout.endereco}
+                          onChange={(event) => setCheckout((prev) => ({ ...prev, endereco: event.target.value }))}
+                        />
+                      </Grid>
+                      <Grid item xs={6}>
+                        <FormControl fullWidth>
+                          <InputLabel>Método de entrega</InputLabel>
+                          <Select
+                            value={checkout.entrega}
+                            label="Método de entrega"
+                            onChange={(event) => setCheckout((prev) => ({ ...prev, entrega: event.target.value }))}
+                          >
+                            <MenuItem value="padrão">Padrão</MenuItem>
+                            <MenuItem value="expresso">Expresso</MenuItem>
+                          </Select>
+                        </FormControl>
+                      </Grid>
+                      <Grid item xs={6}>
+                        <FormControl fullWidth>
+                          <InputLabel>Meio de pagamento</InputLabel>
+                          <Select
+                            value={checkout.pagamento}
+                            label="Meio de pagamento"
+                            onChange={(event) => setCheckout((prev) => ({ ...prev, pagamento: event.target.value }))}
+                          >
+                            <MenuItem value="pix">Pix</MenuItem>
+                            <MenuItem value="cartão">Cartão</MenuItem>
+                            <MenuItem value="boleto">Boleto</MenuItem>
+                          </Select>
+                        </FormControl>
+                      </Grid>
+                    </Grid>
+                    <Alert icon={<PaidIcon />} severity="info" sx={{ mt: 2 }}>
+                      Resumo do pedido: {cartItemsDetailed.length} itens, total de R$ {total.toFixed(2)}.
+                    </Alert>
+                    <Button fullWidth className="gsap-glow-button" variant="contained" sx={{ mt: 2 }}>
+                      Confirmar pedido
+                    </Button>
+                  </CardContent>
+                </Card>
+              </Grid>
+
+              <Grid item xs={12} md={6}>
+                <Card sx={{ height: '100%' }}>
+                  <CardContent sx={{ display: 'flex', flexDirection: 'column', height: '100%' }}>
+                    <Typography variant="h6" sx={{ mb: 1 }}>
+                      Área do cliente (pedidos)
+                    </Typography>
+                    {orders.map((order) => (
+                      <Paper key={order.id} variant="outlined" sx={{ p: 1.5, mb: 1.5, borderRadius: 2 }}>
+                        <Typography variant="subtitle2">{order.id}</Typography>
+                        <Typography variant="body2">Itens: {order.itens}</Typography>
+                        <Stack direction="row" spacing={1} alignItems="center" sx={{ mt: 1 }}>
+                          <LocalShippingIcon fontSize="small" />
+                          <Typography variant="body2">Status: {order.status}</Typography>
+                        </Stack>
+                        <Typography variant="body2">Rastreamento: {order.rastreio}</Typography>
+                        <Stack direction="row" spacing={1} sx={{ mt: 1 }}>
+                          <Button size="small" variant="outlined">
+                            Recompra rápida
+                          </Button>
+                          <Button size="small">Solicitar suporte/troca</Button>
+                        </Stack>
+                      </Paper>
+                    ))}
+                  </CardContent>
+                </Card>
+              </Grid>
+            </Grid>
           </Grid>
         </Grid>
 
         <Grid className="gsap-reveal-section" container spacing={3} alignItems="stretch" sx={{ mt: 1, mb: 4 }}>
-          <Grid item xs={12} md={6}>
-            <Card sx={{ height: '100%' }}>
-              <CardContent sx={{ display: 'flex', flexDirection: 'column', height: '100%' }}>
-                <Typography variant="h6" sx={{ mb: 1 }}>
-                  Área do cliente (pedidos)
-                </Typography>
-                {orders.map((order) => (
-                  <Paper key={order.id} variant="outlined" sx={{ p: 1.5, mb: 1.5, borderRadius: 2 }}>
-                    <Typography variant="subtitle2">{order.id}</Typography>
-                    <Typography variant="body2">Itens: {order.itens}</Typography>
-                    <Stack direction="row" spacing={1} alignItems="center" sx={{ mt: 1 }}>
-                      <LocalShippingIcon fontSize="small" />
-                      <Typography variant="body2">Status: {order.status}</Typography>
-                    </Stack>
-                    <Typography variant="body2">Rastreamento: {order.rastreio}</Typography>
-                    <Stack direction="row" spacing={1} sx={{ mt: 1 }}>
-                      <Button size="small" variant="outlined">
-                        Recompra rápida
-                      </Button>
-                      <Button size="small">Solicitar suporte/troca</Button>
-                    </Stack>
-                  </Paper>
-                ))}
-              </CardContent>
-            </Card>
-          </Grid>
-
-          <Grid item xs={12} md={6}>
+          <Grid item xs={12}>
             <Card sx={{ height: '100%' }}>
               <CardContent sx={{ display: 'flex', flexDirection: 'column', height: '100%' }}>
                 <Typography variant="h6" sx={{ mb: 1 }}>


### PR DESCRIPTION
### Motivation
- Melhorar o layout para que o card `Área do cliente (pedidos)` seja exibido ao lado do card `Checkout` em larguras maiores, mantendo empilhamento em telas pequenas.
- Evitar duplicação e sobreposição de conteúdo movendo a lista de recomendações para uma linha separada com largura total.

### Description
- Reorganiza a coluna `md={7}` em `src/pages/dashboard/SpeciesCatalogPage.js` para usar um `Grid` interno com dois itens (`xs={12} md={6}`) que apresentam `Checkout` e `Área do cliente (pedidos)` lado a lado.
- Mantém todos os campos e ações do `Checkout` (endereço, método de entrega, meio de pagamento, resumo e botão de confirmação) inalterados funcionalmente.
- Move a seção de `Recomendações contextuais` para uma linha própria (`xs={12}`) abaixo, evitando duplicação de conteúdo.
- Atualiza a marcação e classes apenas na renderização; não há mudanças na lógica de estado nem nos nomes das variáveis.

### Testing
- Executado `npx eslint src/pages/dashboard/SpeciesCatalogPage.js` para validação estática do arquivo e sem erros reportados.
- Iniciado o servidor de desenvolvimento com `npm run dev -- --host 0.0.0.0 --port 4173` e verificado que a aplicação subiu corretamente.
- Capturada uma screenshot automática da rota `/dashboard/products` via Playwright para confirmar o layout visual (artefato gerado com sucesso).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ad0eacfa9483288473b5a464d7473c)