### PR TITLE
Moderniza chatbot lateral e adiciona controle de expansão da área de mensagens

### DIFF
--- a/src/layouts/dashboard/DashboardSidebar.js
+++ b/src/layouts/dashboard/DashboardSidebar.js
@@ -7,6 +7,8 @@ import { alpha } from '@mui/material/styles';
 import { Box, Link, Button, Drawer, Typography, Avatar, Stack, Paper, TextField } from '@mui/material';
 import SmartToyIcon from '@mui/icons-material/SmartToy';
 import SendRoundedIcon from '@mui/icons-material/SendRounded';
+import OpenInFullRoundedIcon from '@mui/icons-material/OpenInFullRounded';
+import CloseFullscreenRoundedIcon from '@mui/icons-material/CloseFullscreenRounded';
 // hooks
 import useResponsive from '../../hooks/useResponsive';
 // components
@@ -53,6 +55,7 @@ export default function DashboardSidebar({ isOpenSidebar, onCloseSidebar }) {
   const mobileDrawerWidth = { xs: '86vw', sm: 320 };
   const [prompt, setPrompt] = useState('');
   const [messages, setMessages] = useState([{ role: 'bot', content: BOT_GREETING }]);
+  const [isChatExpanded, setIsChatExpanded] = useState(false);
 
   const hortelanReply = useMemo(
     () => (question) => {
@@ -170,18 +173,36 @@ export default function DashboardSidebar({ isOpenSidebar, onCloseSidebar }) {
                     </Typography>
                   </Box>
                 </Stack>
-                <Box sx={{ width: 8, height: 8, borderRadius: '50%', bgcolor: 'success.main', boxShadow: '0 0 0 4px rgba(34,197,94,0.18)' }} />
+                <Stack direction="row" spacing={1} alignItems="center">
+                  <Box
+                    sx={{ width: 8, height: 8, borderRadius: '50%', bgcolor: 'success.main', boxShadow: '0 0 0 4px rgba(34,197,94,0.18)' }}
+                  />
+                  <Button
+                    size="small"
+                    variant="text"
+                    onClick={() => setIsChatExpanded((prev) => !prev)}
+                    startIcon={isChatExpanded ? <CloseFullscreenRoundedIcon fontSize="inherit" /> : <OpenInFullRoundedIcon fontSize="inherit" />}
+                    sx={{ minWidth: 0, px: 1, borderRadius: 2, color: 'text.secondary', fontSize: '0.7rem', fontWeight: 700 }}
+                  >
+                    {isChatExpanded ? 'Reduzir' : 'Expandir'}
+                  </Button>
+                </Stack>
               </Stack>
 
               <Stack
                 spacing={0.9}
                 sx={(theme) => ({
-                  maxHeight: 200,
+                  maxHeight: isChatExpanded ? 320 : 200,
+                  minHeight: isChatExpanded ? 320 : 140,
                   overflowY: 'auto',
                   px: 0.5,
                   py: 0.25,
                   borderRadius: 2,
                   bgcolor: alpha(theme.palette.background.neutral || theme.palette.grey[500], 0.18),
+                  border: `1px solid ${alpha(theme.palette.primary.main, 0.22)}`,
+                  transition: theme.transitions.create(['max-height', 'min-height'], {
+                    duration: theme.transitions.duration.shortest,
+                  }),
                 })}
               >
                 {messages.map((message, index) => (


### PR DESCRIPTION
### Motivation
- Tornar o widget do Hortelan Bot mais tecnológico e melhorar a leitura de conversas na sidebar sem precisar abrir outra tela.

### Description
- Adicionei ícones `OpenInFullRoundedIcon` e `CloseFullscreenRoundedIcon` e o estado `isChatExpanded` para controlar modo expandido do chat na sidebar (`src/layouts/dashboard/DashboardSidebar.js`).
- Incluí botão de cabeçalho que alterna entre `Expandir` / `Reduzir` e altera altura mínima/máxima do container de mensagens com transição suave e borda de destaque para melhor legibilidade.
- Ajustei o `Stack` de mensagens para usar `maxHeight`/`minHeight` condicionais quando `isChatExpanded` estiver ativo e preservei comportamento existente de envio de mensagens (`handleSendMessage`).
- Skills: nenhum skill especial foi usado porque a alteração foi localizada e implementada diretamente no componente.

### Testing
- Executado `npm run lint -- src/layouts/dashboard/DashboardSidebar.js` e o lint passou com sucesso.
- Inicializado o app com `npm run dev -- --host 0.0.0.0 --port 4173` e a aplicação foi carregada localmente sem erros.
- Playwright automatizado abriu `http://127.0.0.1:4173/dashboard/app`, clicou em `Expandir` e gerou screenshot do chat expandido (`artifacts/chatbot-modern-expanded-state.png`) com sucesso.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ad10092f988328bb1848735aef7bc4)