### PR TITLE
Ajusta layout do painel de status para alinhar eventos e mapa

### DIFF
--- a/src/pages/dashboard/PlatformStatusPage.js
+++ b/src/pages/dashboard/PlatformStatusPage.js
@@ -437,7 +437,7 @@ export default function StatusPage() {
           </Grid>
 
           <Grid container spacing={3}>
-            <Grid item xs={12} lg={4}>
+            <Grid item xs={12}>
               <Card sx={dashboardCardSx}>
                 <CardContent sx={dashboardCardContentSx}>
                   <Typography variant="h6" sx={{ mb: 1 }}>


### PR DESCRIPTION
### Motivation
- Permitir que o card `Lista de eventos em streaming` fique ao lado do card `Mapa de hortas e dispositivos` em telas grandes, aproveitando melhor o espaço do painel.

### Description
- Modifiquei o `Grid` em `src/pages/dashboard/PlatformStatusPage.js` para que o card `Controles manuais e automação` seja `xs={12}`, permitindo que os cards `Mapa...` (`lg=4`) e `Lista de eventos...` (`lg=8`) compartilhem a mesma linha no breakpoint `lg`.

### Testing
- Executei `npx eslint src/pages/dashboard/PlatformStatusPage.js` com sucesso e tentei uma validação visual automatizada com Playwright, que falhou devido a um `SIGSEGV` no Chromium no ambiente de execução.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ad0f95a83083289f9e2c7c8fe18432)