### PR TITLE
Align products list and product details side-by-side earlier (use `sm` breakpoint)

### DIFF
--- a/src/pages/dashboard/SpeciesCatalogPage.js
+++ b/src/pages/dashboard/SpeciesCatalogPage.js
@@ -368,7 +368,7 @@ export default function ProductsMarketplace() {
         </Paper>
 
         <Grid className="gsap-story-section" container spacing={3} alignItems="stretch">
-          <Grid item xs={12} md={5}>
+          <Grid item xs={12} sm={5}>
             <Card className="gsap-story-card" sx={{ height: '100%' }}>
               <CardContent sx={{ display: 'flex', flexDirection: 'column', gap: 2.5, height: '100%' }}>
                 <Typography variant="h6" sx={{ mb: 2 }}>
@@ -411,7 +411,7 @@ export default function ProductsMarketplace() {
             </Card>
           </Grid>
 
-          <Grid item xs={12} md={7}>
+          <Grid item xs={12} sm={7}>
             {selectedProduct && (
               <Card className="gsap-story-card" sx={{ height: '100%' }}>
                 <CardContent sx={{ display: 'flex', flexDirection: 'column', gap: 2, height: '100%' }}>


### PR DESCRIPTION
### Motivation
- Keep the "Produtos" list and the "Página de produto" panel side-by-side on smaller screens (tablet / medium-small desktop) so the details stay beside the list earlier in the responsive layout.

### Description
- Updated two `Grid` items in `src/pages/dashboard/SpeciesCatalogPage.js` by changing their breakpoint props from `md` to `sm` so the product list and detail panels display side-by-side at the `sm` breakpoint.

### Testing
- Ran `npm run lint` which completed successfully. 
- Started the dev server with `npm run dev` and it served the app (Vite ready). 
- Attempted an automated Playwright screenshot, but the Chromium launch crashed with a `SIGSEGV`, so no screenshot artifact was produced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ad0e8ffbf88328806ab4255cc7c9c7)