### PR TITLE
Adiciona ícones de bandeiras ao lado do seletor de tema

### DIFF
--- a/src/layouts/dashboard/DashboardNavbar.js
+++ b/src/layouts/dashboard/DashboardNavbar.js
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 // material
 import { alpha, styled } from '@mui/material/styles';
-import { Box, Stack, AppBar, Toolbar, IconButton } from '@mui/material';
+import { Box, Stack, AppBar, Toolbar, IconButton, Tooltip } from '@mui/material';
 // components
 import Iconify from '../../components/Iconify';
 //
@@ -34,6 +34,13 @@ const ToolbarStyle = styled(Toolbar)(({ theme }) => ({
   },
 }));
 
+const languageFlags = [
+  { code: 'EUA', icon: 'circle-flags:us' },
+  { code: 'Brasil', icon: 'circle-flags:br' },
+  { code: 'França', icon: 'circle-flags:fr' },
+  { code: 'Espanha', icon: 'circle-flags:es' },
+];
+
 // ----------------------------------------------------------------------
 
 DashboardNavbar.propTypes = {
@@ -53,6 +60,24 @@ export default function DashboardNavbar({ onOpenSidebar }) {
 
         <Stack direction="row" alignItems="center" spacing={{ xs: 0.5, sm: 1.5 }}>
           <Mode />
+          <Stack direction="row" alignItems="center" spacing={0.8} sx={{ mr: { xs: 0.5, sm: 0 } }}>
+            {languageFlags.map((flag) => (
+              <Tooltip key={flag.code} title={flag.code}>
+                <Box
+                  sx={{
+                    width: 24,
+                    height: 24,
+                    borderRadius: '50%',
+                    display: 'inline-flex',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                  }}
+                >
+                  <Iconify icon={flag.icon} width={24} height={24} />
+                </Box>
+              </Tooltip>
+            ))}
+          </Stack>
           <Box sx={{ display: { xs: 'none', md: 'inline-flex' } }}>
             <NotificationsPopover />
           </Box>

--- a/src/layouts/dashboard/DashboardNavbar.js
+++ b/src/layouts/dashboard/DashboardNavbar.js
@@ -1,4 +1,5 @@
 import PropTypes from 'prop-types';
+import { useEffect, useMemo, useState } from 'react';
 // material
 import { alpha, styled } from '@mui/material/styles';
 import { Box, Stack, AppBar, Toolbar, IconButton, Tooltip } from '@mui/material';
@@ -9,6 +10,16 @@ import Searchbar from './Searchbar';
 import AccountPopover from './AccountPopover';
 import NotificationsPopover from './NotificationsPopover';
 import Mode from './ModeTheme';
+import {
+  STORAGE_KEY,
+  normalizeLanguageCode,
+  applyGoogleLanguage,
+  ensureGoogleTranslate,
+  ensureTranslateDomSetup,
+  getStoredLanguage,
+  detectLanguageByGeolocation,
+  detectLanguageFromBrowser,
+} from '../../services/localization';
 
 // ----------------------------------------------------------------------
 
@@ -35,11 +46,82 @@ const ToolbarStyle = styled(Toolbar)(({ theme }) => ({
 }));
 
 const languageFlags = [
-  { code: 'EUA', icon: 'circle-flags:us' },
-  { code: 'Brasil', icon: 'circle-flags:br' },
-  { code: 'França', icon: 'circle-flags:fr' },
-  { code: 'Espanha', icon: 'circle-flags:es' },
+  { code: 'en', label: 'English (US)', icon: 'circle-flags:us' },
+  { code: 'pt', label: 'Português (Brasil)', icon: 'circle-flags:br' },
+  { code: 'fr', label: 'Français', icon: 'circle-flags:fr' },
+  { code: 'es', label: 'Español', icon: 'circle-flags:es' },
 ];
+
+function LanguageFlags() {
+  const [selectedLanguage, setSelectedLanguage] = useState('pt');
+
+  useEffect(() => {
+    ensureGoogleTranslate();
+    ensureTranslateDomSetup();
+
+    const manualLanguage = getStoredLanguage();
+    if (manualLanguage) {
+      setSelectedLanguage(manualLanguage);
+      applyGoogleLanguage(manualLanguage);
+      return;
+    }
+
+    const autoDetectLanguage = async () => {
+      try {
+        const detectedLanguage = await detectLanguageByGeolocation();
+        const normalizedLanguage = normalizeLanguageCode(detectedLanguage);
+        setSelectedLanguage(normalizedLanguage);
+        applyGoogleLanguage(normalizedLanguage);
+      } catch (error) {
+        const fallbackLanguage = normalizeLanguageCode(detectLanguageFromBrowser());
+        setSelectedLanguage(fallbackLanguage);
+        applyGoogleLanguage(fallbackLanguage);
+      }
+    };
+
+    autoDetectLanguage();
+  }, []);
+
+  const availableFlags = useMemo(() => languageFlags, []);
+
+  const handleLanguageChange = (languageCode) => {
+    const normalizedLanguage = normalizeLanguageCode(languageCode);
+    window.localStorage.setItem(STORAGE_KEY, normalizedLanguage);
+    setSelectedLanguage(normalizedLanguage);
+    applyGoogleLanguage(normalizedLanguage);
+  };
+
+  return (
+    <Stack direction="row" alignItems="center" spacing={0.8} sx={{ mr: { xs: 0.5, sm: 0 } }}>
+      {availableFlags.map((flag) => {
+        const isSelected = selectedLanguage === flag.code;
+
+        return (
+          <Tooltip key={flag.code} title={flag.label} arrow>
+            <IconButton
+              size="small"
+              onClick={() => handleLanguageChange(flag.code)}
+              sx={{
+                p: 0,
+                width: 26,
+                height: 26,
+                borderRadius: '50%',
+                border: '2px solid',
+                borderColor: isSelected ? 'primary.main' : 'transparent',
+                transition: (theme) => theme.transitions.create(['transform', 'border-color']),
+                '&:hover': {
+                  transform: 'translateY(-1px)',
+                },
+              }}
+            >
+              <Iconify icon={flag.icon} width={22} height={22} />
+            </IconButton>
+          </Tooltip>
+        );
+      })}
+    </Stack>
+  );
+}
 
 // ----------------------------------------------------------------------
 
@@ -60,24 +142,7 @@ export default function DashboardNavbar({ onOpenSidebar }) {
 
         <Stack direction="row" alignItems="center" spacing={{ xs: 0.5, sm: 1.5 }}>
           <Mode />
-          <Stack direction="row" alignItems="center" spacing={0.8} sx={{ mr: { xs: 0.5, sm: 0 } }}>
-            {languageFlags.map((flag) => (
-              <Tooltip key={flag.code} title={flag.code}>
-                <Box
-                  sx={{
-                    width: 24,
-                    height: 24,
-                    borderRadius: '50%',
-                    display: 'inline-flex',
-                    alignItems: 'center',
-                    justifyContent: 'center',
-                  }}
-                >
-                  <Iconify icon={flag.icon} width={24} height={24} />
-                </Box>
-              </Tooltip>
-            ))}
-          </Stack>
+          <LanguageFlags />
           <Box sx={{ display: { xs: 'none', md: 'inline-flex' } }}>
             <NotificationsPopover />
           </Box>


### PR DESCRIPTION
### Motivation
- Adicionar ícones de bandeiras circulares para seleção visual de idioma/país ao lado do switch claro/escuro na barra superior.

### Description
- Importa `Tooltip`, adiciona a lista `languageFlags` e renderiza as bandeiras com `Iconify` (`circle-flags:*`) dentro de caixas circulares com `Tooltip`, posicionadas ao lado do componente `Mode` em `src/layouts/dashboard/DashboardNavbar.js`.

### Testing
- Executados `npm run lint` (passou) e uma captura automática via Playwright contra o servidor de desenvolvimento (screenshot gerada com sucesso).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ad141cbb748328b0f0b8595b4320f3)