### PR TITLE
Normalize hortelan-360 route and lazy-load onboarding legacy path

### DIFF
--- a/src/routes.js
+++ b/src/routes.js
@@ -50,7 +50,7 @@ export default function Router() {
         { path: 'user', element: <Navigate to="/dashboard/admin" replace /> },
         { path: 'products', element: renderLazy(SpeciesCatalogPage) },
         { path: 'blog', element: renderLazy(CommunityPage) },
-        { path: 'hortelan 360', element: renderLazy(Hortelan360Page) },
+        { path: 'hortelan-360', element: renderLazy(Hortelan360Page) },
         { path: 'onboarding', element: renderLazy(OnboardingPage) },
         { path: 'status', element: renderLazy(PlatformStatusPage) },
         { path: 'security', element: renderLazy(SecurityCenterPage) },
@@ -104,7 +104,7 @@ export default function Router() {
     },
     {
       path: '/onboarding/:legacyPath',
-      element: <LegacyOnboardingRedirect />,
+      element: renderLazy(OnboardingPage),
     },
     {
       path: '/hortelan-360',


### PR DESCRIPTION
### Motivation
- Standardize the dashboard route for the Hortelan 360 page to use a hyphenated path instead of a space for consistency and reliable routing.
- Replace the legacy onboarding redirect with the actual onboarding component to directly render the onboarding flow when a legacy path is visited.

### Description
- Renamed the dashboard child route from `hortelan 360` to `hortelan-360` to remove the space and use a hyphenated path.
- Changed the `/onboarding/:legacyPath` route to render the onboarding page by using `renderLazy(OnboardingPage)` instead of `LegacyOnboardingRedirect`.
- Left existing top-level redirect routes in place that map `'/hortelan-360'`, `'/hortelan360'`, `'/hortelan_360'`, and `'/hortelan 360'` to `'/dashboard/hortelan-360'` to preserve compatibility for various incoming URL variants.

### Testing
- Ran existing unit tests and route integration tests; all tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ad17de0440832883d11a81c2398c00)