### PR TITLE
Ajusta área dos widgets de indicadores no Monitoring

### DIFF
--- a/src/pages/dashboard/MonitoringPage.js
+++ b/src/pages/dashboard/MonitoringPage.js
@@ -1115,8 +1115,13 @@ export default function DashboardApp() {
               <Box
                 sx={{
                   display: 'grid',
+                  width: '100%',
                   gap: 3,
-                  gridTemplateColumns: { xs: '1fr', md: 'repeat(3, minmax(0, 1fr))' },
+                  gridTemplateColumns: {
+                    xs: '1fr',
+                    sm: 'repeat(2, minmax(0, 1fr))',
+                    lg: 'repeat(3, minmax(0, 1fr))',
+                  },
                 }}
               >
                 <AppWidgetSummary


### PR DESCRIPTION
### Motivation
- Expandir a área que agrupa os widgets "Umidade média", "Temperatura média" e "Alertas ativos" para ocupar melhor a largura disponível e melhorar o comportamento responsivo em breakpoints intermediários.

### Description
- Em `src/pages/dashboard/MonitoringPage.js` adicionei `width: '100%'` ao `Box` que envolve os widgets e alterei `gridTemplateColumns` para `xs: '1fr'`, `sm: 'repeat(2, minmax(0, 1fr))'`, `lg: 'repeat(3, minmax(0, 1fr))'` para melhorar a distribuição em telas pequenas, médias e grandes.

### Testing
- Executei `npm run lint` e a verificação de lint passou sem erros.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ad1c6ee6b08328ab5380c17622ff94)