### PR TITLE
UI refresh: theme palette, cards, dashboard header/banner and auth visuals

### DIFF
--- a/src/layouts/dashboard/DashboardNavbar.js
+++ b/src/layouts/dashboard/DashboardNavbar.js
@@ -17,10 +17,11 @@ const APPBAR_MOBILE = 64;
 const APPBAR_DESKTOP = 92;
 
 const RootStyle = styled(AppBar)(({ theme }) => ({
-  boxShadow: 'none',
-  backdropFilter: 'blur(6px)',
-  WebkitBackdropFilter: 'blur(6px)', // Fix on Mobile
-  backgroundColor: alpha(theme.palette.background.default, 0.72),
+  backdropFilter: 'blur(14px)',
+  WebkitBackdropFilter: 'blur(14px)', // Fix on Mobile
+  background: `linear-gradient(135deg, ${alpha(theme.palette.background.paper, 0.88)} 0%, ${alpha(theme.palette.primary.lighter, 0.45)} 48%, ${alpha(theme.palette.info.lighter, 0.36)} 100%)`,
+  borderBottom: `1px solid ${alpha(theme.palette.primary.main, 0.16)}`,
+  boxShadow: `0 10px 28px ${alpha(theme.palette.info.dark, 0.08)}`,
   [theme.breakpoints.up('lg')]: {
     width: `calc(100% - ${DRAWER_WIDTH + 1}px)`,
   },
@@ -50,6 +51,26 @@ export default function DashboardNavbar({ onOpenSidebar }) {
 
         <Searchbar />
         <Box sx={{ flexGrow: 1 }} />
+
+        <Box
+          sx={(theme) => ({
+            display: { xs: 'none', md: 'flex' },
+            alignItems: 'center',
+            px: 1.8,
+            py: 0.7,
+            borderRadius: 999,
+            mr: 1.5,
+            color: 'text.secondary',
+            border: `1px solid ${alpha(theme.palette.primary.main, 0.18)}`,
+            background: `linear-gradient(120deg, ${alpha(theme.palette.primary.light, 0.12)}, ${alpha(theme.palette.info.light, 0.12)})`,
+            fontSize: 12,
+            fontWeight: 700,
+            letterSpacing: 0.6,
+            textTransform: 'uppercase',
+          })}
+        >
+          AgroTech Intelligence
+        </Box>
 
         <Stack direction="row" alignItems="center" spacing={{ xs: 0.5, sm: 1.5 }}>
           <Mode />

--- a/src/layouts/dashboard/DashboardSidebar.js
+++ b/src/layouts/dashboard/DashboardSidebar.js
@@ -294,11 +294,13 @@ export default function DashboardSidebar({ isOpenSidebar, onCloseSidebar }) {
           open
           variant="persistent"
           PaperProps={{
-            sx: {
+            sx: (theme) => ({
               width: DRAWER_WIDTH,
-              bgcolor: 'background.default',
-              borderRightStyle: 'dashed',
-            },
+              bgcolor: alpha(theme.palette.background.paper, 0.9),
+              borderRight: `1px solid ${alpha(theme.palette.primary.main, 0.16)}`,
+              backdropFilter: 'blur(8px)',
+              backgroundImage: `linear-gradient(170deg, ${alpha(theme.palette.primary.lighter, 0.28)} 0%, ${alpha(theme.palette.info.lighter, 0.2)} 45%, ${alpha(theme.palette.background.paper, 0.94)} 100%)`,
+            }),
           }}
         >
           {renderContent}

--- a/src/layouts/dashboard/index.js
+++ b/src/layouts/dashboard/index.js
@@ -1,7 +1,8 @@
-import { useState } from 'react';
-import { Outlet } from 'react-router-dom';
+import { useMemo, useState } from 'react';
+import { Outlet, useLocation } from 'react-router-dom';
 // material
-import { styled } from '@mui/material/styles';
+import { alpha, styled } from '@mui/material/styles';
+import { Box, Chip, Stack, Typography } from '@mui/material';
 //
 import DashboardNavbar from './DashboardNavbar';
 import DashboardSidebar from './DashboardSidebar';
@@ -11,11 +12,87 @@ import DashboardSidebar from './DashboardSidebar';
 const APP_BAR_MOBILE = 64;
 const APP_BAR_DESKTOP = 92;
 
-const RootStyle = styled('div')({
+const PAGE_CONTEXT = {
+  '/dashboard/app': {
+    badge: 'Monitoramento inteligente',
+    title: 'Centro de Comando AgroTech',
+    subtitle: 'Sensores, alertas e automações em uma experiência unificada para operação em tempo real.',
+  },
+  '/dashboard/admin': {
+    badge: 'Operação e governança',
+    title: 'Administração da Plataforma',
+    subtitle: 'Gerencie usuários, dispositivos, conteúdo e billing com foco em eficiência operacional.',
+  },
+  '/dashboard/products': {
+    badge: 'Dados agronômicos',
+    title: 'Catálogo de Espécies',
+    subtitle: 'Recomendações técnicas com visão moderna para produtividade, qualidade e rastreabilidade.',
+  },
+  '/dashboard/onboarding': {
+    badge: 'Adoção acelerada',
+    title: 'Onboarding Guiado',
+    subtitle: 'Jornadas práticas para ativar recursos-chave da plataforma com rapidez e clareza.',
+  },
+  '/dashboard/hortelan-360': {
+    badge: 'Visão 360°',
+    title: 'Hortelan 360 Intelligence',
+    subtitle: 'Integre indicadores estratégicos e operacionais em um painel executivo de alta precisão.',
+  },
+  '/dashboard/blog': {
+    badge: 'Ecossistema colaborativo',
+    title: 'Comunidade AgroTech',
+    subtitle: 'Compartilhe aprendizados, casos e melhores práticas orientadas por dados.',
+  },
+  '/dashboard/alertas': {
+    badge: 'Resposta proativa',
+    title: 'Central de Alertas',
+    subtitle: 'Priorize incidentes críticos e reaja rapidamente com contexto operacional em tempo real.',
+  },
+  '/dashboard/relatorios': {
+    badge: 'Business insights',
+    title: 'Relatórios e Performance',
+    subtitle: 'Transforme dados de campo em indicadores acionáveis para decisões mais inteligentes.',
+  },
+  '/dashboard/assinaturas': {
+    badge: 'Gestão comercial',
+    title: 'Planos e Assinaturas',
+    subtitle: 'Acompanhe ativos, upgrades e retenção com experiência clara e orientada a valor.',
+  },
+  '/dashboard/integracoes': {
+    badge: 'Conectividade',
+    title: 'Integrações da Plataforma',
+    subtitle: 'Conecte sistemas, APIs e fluxos de operação para uma stack AgroTech moderna.',
+  },
+  '/dashboard/suporte': {
+    badge: 'Sucesso do cliente',
+    title: 'Central de Ajuda',
+    subtitle: 'Documentação e suporte em um hub inteligente para reduzir dúvidas e acelerar resolução.',
+  },
+  '/dashboard/status': {
+    badge: 'Confiabilidade',
+    title: 'Status da Plataforma',
+    subtitle: 'Visibilidade contínua de disponibilidade, incidentes e saúde dos serviços.',
+  },
+  '/dashboard/security': {
+    badge: 'Cyber resilience',
+    title: 'Segurança e Compliance',
+    subtitle: 'Proteja contas, acessos e integrações com controles avançados e monitoramento ativo.',
+  },
+  '/dashboard/profile': {
+    badge: 'Experiência personalizada',
+    title: 'Perfil e Preferências',
+    subtitle: 'Ajuste identidade, notificações e preferências para uma operação do seu jeito.',
+  },
+};
+
+const RootStyle = styled('div')(({ theme }) => ({
   display: 'flex',
   minHeight: '100%',
-  overflowX: 'hidden'
-});
+  overflowX: 'hidden',
+  background: `radial-gradient(circle at 10% -10%, ${theme.palette.primary.lighter}66 0%, transparent 48%),
+    radial-gradient(circle at 90% 0%, ${theme.palette.info.lighter}7A 0%, transparent 42%),
+    ${theme.palette.background.default}`,
+}));
 
 const MainStyle = styled('div')(({ theme }) => ({
   flexGrow: 1,
@@ -27,6 +104,7 @@ const MainStyle = styled('div')(({ theme }) => ({
   paddingLeft: theme.spacing(1.5),
   paddingRight: theme.spacing(1.5),
   paddingBottom: theme.spacing(10),
+  position: 'relative',
   [theme.breakpoints.up('sm')]: {
     paddingLeft: theme.spacing(3),
     paddingRight: theme.spacing(3),
@@ -35,20 +113,61 @@ const MainStyle = styled('div')(({ theme }) => ({
   [theme.breakpoints.up('lg')]: {
     paddingTop: APP_BAR_DESKTOP + 24,
     paddingLeft: theme.spacing(4),
-    paddingRight: theme.spacing(4)
-  }
+    paddingRight: theme.spacing(4),
+  },
 }));
 
 // ----------------------------------------------------------------------
 
 export default function DashboardLayout() {
   const [open, setOpen] = useState(false);
+  const { pathname } = useLocation();
+
+  const context = useMemo(() => {
+    const exactMatch = PAGE_CONTEXT[pathname];
+    if (exactMatch) return exactMatch;
+
+    const dynamicMatch = Object.keys(PAGE_CONTEXT).find((key) => pathname.startsWith(key));
+    return PAGE_CONTEXT[dynamicMatch] || PAGE_CONTEXT['/dashboard/app'];
+  }, [pathname]);
 
   return (
     <RootStyle>
       <DashboardNavbar onOpenSidebar={() => setOpen(true)} />
       <DashboardSidebar isOpenSidebar={open} onCloseSidebar={() => setOpen(false)} />
       <MainStyle>
+        <Box
+          sx={(theme) => ({
+            mb: 3,
+            p: { xs: 2, md: 3 },
+            borderRadius: 3,
+            border: `1px solid ${alpha(theme.palette.primary.main, 0.18)}`,
+            background: `linear-gradient(135deg, ${alpha(theme.palette.primary.dark, 0.96)} 0%, ${alpha(
+              theme.palette.primary.main,
+              0.92
+            )} 42%, ${alpha(theme.palette.info.main, 0.9)} 100%)`,
+            color: 'common.white',
+            boxShadow: `0 18px 36px ${alpha(theme.palette.primary.dark, 0.24)}`,
+          })}
+        >
+          <Stack spacing={1}>
+            <Chip
+              label={context.badge}
+              sx={{
+                alignSelf: 'flex-start',
+                color: 'common.white',
+                borderColor: 'rgba(255,255,255,0.36)',
+                bgcolor: 'rgba(255,255,255,0.12)',
+                fontWeight: 700,
+              }}
+              variant="outlined"
+              size="small"
+            />
+            <Typography variant="h4">{context.title}</Typography>
+            <Typography sx={{ opacity: 0.9, maxWidth: 840 }}>{context.subtitle}</Typography>
+          </Stack>
+        </Box>
+
         <Outlet />
       </MainStyle>
     </RootStyle>

--- a/src/pages/dashboard/MonitoringPage.js
+++ b/src/pages/dashboard/MonitoringPage.js
@@ -1080,9 +1080,39 @@ export default function DashboardApp() {
   return (
     <Page title="Dashboard">
       <Container maxWidth={false} sx={{ px: { xs: 2, md: 3 } }}>
-        <Typography variant="h4" sx={{ mb: 5 }}>
-          Welcome {user?.name || 'User'} to the Hortelan System
-        </Typography>
+        <Card
+          sx={(theme) => ({
+            mb: 4,
+            border: `1px solid ${theme.palette.primary.lighter}`,
+            background: `linear-gradient(135deg, ${theme.palette.primary.dark} 0%, ${theme.palette.primary.main} 42%, ${theme.palette.info.main} 100%)`,
+            color: 'common.white',
+            overflow: 'hidden',
+            position: 'relative',
+            '&::after': {
+              content: '""',
+              position: 'absolute',
+              width: 320,
+              height: 320,
+              borderRadius: '50%',
+              right: -140,
+              top: -150,
+              backgroundColor: 'rgba(255,255,255,0.15)',
+            },
+          })}
+        >
+          <CardContent sx={{ position: 'relative', zIndex: 1 }}>
+            <Typography variant="overline" sx={{ opacity: 0.85, letterSpacing: 1.6 }}>
+              AgroTech Command Center
+            </Typography>
+            <Typography variant="h4" sx={{ mt: 1, mb: 1 }}>
+              Olá, {user?.name || 'Usuário'} 👋
+            </Typography>
+            <Typography sx={{ maxWidth: 700, opacity: 0.92 }}>
+              Bem-vindo ao painel inteligente da Hortelan. Acompanhe sensores, automações e alertas em tempo real para
+              elevar produtividade com decisões baseadas em dados.
+            </Typography>
+          </CardContent>
+        </Card>
 
         <Box sx={monitoringContentSx}>
           <Grid container spacing={3}>

--- a/src/sections/auth/login/Login.js
+++ b/src/sections/auth/login/Login.js
@@ -53,6 +53,9 @@ const SectionStyle = styled(Card)(({ theme }) => ({
   flexDirection: 'column',
   justifyContent: 'center',
   margin: theme.spacing(2, 0, 2, 2),
+  border: `1px solid ${alpha(theme.palette.primary.main, 0.16)}`,
+  background: `linear-gradient(160deg, ${alpha(theme.palette.primary.lighter, 0.42)} 0%, ${alpha(theme.palette.info.lighter, 0.28)} 45%, ${theme.palette.background.paper} 100%)`,
+  boxShadow: `0 20px 40px ${alpha(theme.palette.primary.dark, 0.12)}`,
 }));
 
 const leafFloat = keyframes`
@@ -327,8 +330,11 @@ export default function LoginForm() {
               <Leaf sx={{ bottom: '12%', right: '12%', width: 62, height: 92, animationDuration: '4.8s' }} />
               <Cable />
             </DecorativeScene>
-            <Typography variant="h3" sx={{ px: 5, mt: 10, mb: 5 }}>
+            <Typography variant="h3" sx={{ px: 5, mt: 10, mb: 1 }}>
               {isRegisterMode ? 'Crie sua conta na Hortelan' : 'Olá, bem-vindo de volta à Hortelan'}
+            </Typography>
+            <Typography sx={{ px: 5, mb: 4, color: 'text.secondary' }}>
+              Plataforma AgroTech com monitoramento inteligente, automações e decisões orientadas por dados em tempo real.
             </Typography>
             <img
               src={isRegisterMode ? '/static/illustrations/illustration_register.png' : '/static/illustrations/illustration_login.png'}
@@ -342,6 +348,25 @@ export default function LoginForm() {
           <ContentStyle>
             <Typography variant="h4" gutterBottom>
               {isRegisterMode ? 'Cadastre-se para começar' : 'Entrar na Hortelan'}
+            </Typography>
+
+            <Typography
+              variant="overline"
+              sx={(theme) => ({
+                color: 'primary.main',
+                fontWeight: 800,
+                letterSpacing: 1.2,
+                display: 'inline-flex',
+                alignSelf: 'flex-start',
+                px: 1.4,
+                py: 0.4,
+                borderRadius: 999,
+                mb: 1.5,
+                border: `1px solid ${alpha(theme.palette.primary.main, 0.24)}`,
+                background: `linear-gradient(120deg, ${alpha(theme.palette.primary.light, 0.2)}, ${alpha(theme.palette.info.light, 0.15)})`,
+              })}
+            >
+              AgroTech Experience
             </Typography>
 
             <Typography sx={{ color: 'text.secondary', mb: isRegisterMode ? 5 : 1 }}>

--- a/src/theme/overrides/Card.js
+++ b/src/theme/overrides/Card.js
@@ -1,3 +1,5 @@
+import { alpha } from '@mui/material/styles';
+
 // ----------------------------------------------------------------------
 
 export default function Card(theme) {
@@ -5,8 +7,13 @@ export default function Card(theme) {
     MuiCard: {
       styleOverrides: {
         root: {
-          boxShadow: theme.shadows[2],
+          boxShadow: `0 10px 30px ${alpha(theme.palette.primary.dark, 0.08)}`,
           borderRadius: Number(theme.shape.borderRadius) * 2,
+          border: `1px solid ${alpha(theme.palette.primary.main, 0.12)}`,
+          backgroundImage: `linear-gradient(165deg, ${alpha(theme.palette.background.paper, 0.98)} 0%, ${alpha(
+            theme.palette.primary.lighter,
+            0.12
+          )} 100%)`,
           position: 'relative',
           zIndex: 0, // Fix Safari overflow: hidden with border radius
         },

--- a/src/theme/palette.js
+++ b/src/theme/palette.js
@@ -29,29 +29,29 @@ const GREY = {
 };
 
 const PRIMARY = {
-  lighter: '#D1E9FC',
-  light: '#76B0F1',
-  main: '#2065D1',
-  dark: '#103996',
-  darker: '#061B64',
+  lighter: '#CCFBEF',
+  light: '#5BE4C4',
+  main: '#16B88A',
+  dark: '#0A7A60',
+  darker: '#044B3E',
   contrastText: '#fff',
 };
 
 const SECONDARY = {
-  lighter: '#D6E4FF',
-  light: '#84A9FF',
-  main: '#3366FF',
-  dark: '#1939B7',
-  darker: '#091A7A',
+  lighter: '#D9ECFF',
+  light: '#6DBDFF',
+  main: '#2B7FFF',
+  dark: '#1451C5',
+  darker: '#0A327D',
   contrastText: '#fff',
 };
 
 const INFO = {
-  lighter: '#D0F2FF',
-  light: '#74CAFF',
-  main: '#1890FF',
-  dark: '#0C53B7',
-  darker: '#04297A',
+  lighter: '#D5F9FF',
+  light: '#68DAFF',
+  main: '#0DB3E8',
+  dark: '#0A6EAA',
+  darker: '#04416F',
   contrastText: '#fff',
 };
 
@@ -121,7 +121,7 @@ function getPalette(mode = 'light') {
     },
     background: {
       paper: isLight ? '#fff' : GREY[800],
-      default: isLight ? GREY[100] : GREY[900],
+      default: isLight ? '#F2F8F6' : GREY[900],
       neutral: isLight ? GREY[200] : alpha(GREY[500], 0.12),
     },
     action: {


### PR DESCRIPTION
### Motivation
- Refresh the dashboard visual identity with updated color palette and richer backgrounds to match the AgroTech brand.  
- Surface per-route context in the dashboard to give users immediate orientation about the current area.  
- Improve onboarding/login impressions and card styling to make the UX more modern and consistent.

### Description
- Updated theme palette in `src/theme/palette.js` to new primary/secondary/info color ramp and adjusted background defaults.  
- Enhanced global card styles in `src/theme/overrides/Card.js` to add gradients, border, and custom shadow using `alpha`.  
- Restyled the dashboard app frame in `src/layouts/dashboard/index.js` to add background accents, a `PAGE_CONTEXT` mapping, and a contextual banner that uses `useLocation` and `useMemo` to show a `Chip`, title and subtitle above the outlet.  
- Modified `DashboardNavbar.js` to use a translucent gradient appbar, increased blur, and added a brand label pill (`AgroTech Intelligence`).  
- Modified `DashboardSidebar.js` to apply a blurred, semi-transparent gradient `PaperProps` on desktop with a subtle right border.  
- Updated `MonitoringPage.js` to replace the simple greeting with a styled hero `Card` showing the user greeting and updated copy, and kept existing widgets section below.  
- Improved login/register visuals in `src/sections/auth/login/Login.js` by adding a styled `SectionStyle`, decorative copy, and an overline badge for the auth form.  
- Added and used `alpha` imports and small layout adjustments across files to support the new visual treatments.

### Testing
- Ran lint and unit test suite via `yarn lint` and `yarn test`, and no test regressions were reported.  
- Performed local smoke check of the dashboard routes to verify the contextual banner renders for mapped paths and the updated components mount correctly.  
- Verified that the login and monitoring pages render without runtime errors in local development build.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ad15a7fce483289d0295af457aa960)