### PR TITLE
Improve responsive behavior for login and dashboard across screen sizes

### DIFF
--- a/src/layouts/dashboard/DashboardNavbar.js
+++ b/src/layouts/dashboard/DashboardNavbar.js
@@ -40,6 +40,12 @@ const RootStyle = styled(AppBar)(({ theme }) => ({
 
 const ToolbarStyle = styled(Toolbar)(({ theme }) => ({
   minHeight: APPBAR_MOBILE,
+  paddingLeft: theme.spacing(1),
+  paddingRight: theme.spacing(1),
+  [theme.breakpoints.up('sm')]: {
+    paddingLeft: theme.spacing(2),
+    paddingRight: theme.spacing(2),
+  },
   [theme.breakpoints.up('lg')]: {
     minHeight: APPBAR_DESKTOP,
     padding: theme.spacing(0, 5),
@@ -138,7 +144,9 @@ export default function DashboardNavbar({ onOpenSidebar }) {
           <Iconify icon="eva:menu-2-fill" />
         </IconButton>
 
-        <Searchbar />
+        <Box sx={{ minWidth: 0, flexShrink: 1 }}>
+          <Searchbar />
+        </Box>
         <Box sx={{ flexGrow: 1 }} />
 
         <Box
@@ -161,7 +169,7 @@ export default function DashboardNavbar({ onOpenSidebar }) {
           AgroTech Intelligence
         </Box>
 
-        <Stack direction="row" alignItems="center" spacing={{ xs: 0.5, sm: 1.5 }}>
+        <Stack direction="row" alignItems="center" spacing={{ xs: 0.25, sm: 1.5 }} sx={{ flexShrink: 0 }}>
           <Mode />
           <LanguageFlags />
           <Box sx={{ display: { xs: 'none', md: 'inline-flex' } }}>

--- a/src/layouts/dashboard/DashboardSidebar.js
+++ b/src/layouts/dashboard/DashboardSidebar.js
@@ -52,7 +52,7 @@ export default function DashboardSidebar({ isOpenSidebar, onCloseSidebar }) {
 
   const isDesktop = useResponsive('up', 'lg');
   const { user } = useAuth();
-  const mobileDrawerWidth = { xs: '86vw', sm: 320 };
+  const mobileDrawerWidth = { xs: '90vw', sm: 340 };
   const [prompt, setPrompt] = useState('');
   const [messages, setMessages] = useState([{ role: 'bot', content: BOT_GREETING }]);
   const [isChatExpanded, setIsChatExpanded] = useState(false);
@@ -104,11 +104,11 @@ export default function DashboardSidebar({ isOpenSidebar, onCloseSidebar }) {
         '& .simplebar-content': { height: 1, display: 'flex', flexDirection: 'column' },
       }}
     >
-      <Box sx={{ px: 2.5, py: 3, display: 'inline-flex' }}>
+      <Box sx={{ px: { xs: 2, sm: 2.5 }, py: { xs: 2, sm: 3 }, display: 'inline-flex' }}>
         <Logo sx={{ width: 80, height: 80 }} />
       </Box>
 
-      <Box sx={{ mb: 5, mx: 2.5 }}>
+      <Box sx={{ mb: 4, mx: { xs: 2, sm: 2.5 } }}>
         <Link underline="none" component={RouterLink} to="#">
           <AccountStyle>
             <Avatar src={user?.photoURL || ''} alt={user?.name || 'Usuário'} />
@@ -128,7 +128,7 @@ export default function DashboardSidebar({ isOpenSidebar, onCloseSidebar }) {
 
       <Box sx={{ flexGrow: 1 }} />
 
-      <Box sx={{ px: 2.5, pb: 3, mt: 10 }}>
+      <Box sx={{ px: { xs: 2, sm: 2.5 }, pb: 3, mt: { xs: 6, sm: 10 } }}>
         <Stack alignItems="center" spacing={3} sx={{ pt: 5, borderRadius: 2, position: 'relative' }}>
           <Box
             component="img"
@@ -154,8 +154,8 @@ export default function DashboardSidebar({ isOpenSidebar, onCloseSidebar }) {
             })}
           >
             <Stack spacing={1.4}>
-              <Stack direction="row" spacing={1} alignItems="center" justifyContent="space-between">
-                <Stack direction="row" spacing={1} alignItems="center">
+              <Stack direction={{ xs: 'column', sm: 'row' }} spacing={1} alignItems={{ xs: 'flex-start', sm: 'center' }} justifyContent="space-between">
+                <Stack direction="row" spacing={1} alignItems="center" sx={{ minWidth: 0 }}>
                   <Avatar
                     sx={(theme) => ({
                       width: 28,
@@ -166,14 +166,14 @@ export default function DashboardSidebar({ isOpenSidebar, onCloseSidebar }) {
                   >
                     <SmartToyIcon fontSize="small" />
                   </Avatar>
-                  <Box>
-                    <Typography variant="subtitle2">Hortelan Bot</Typography>
+                  <Box sx={{ minWidth: 0 }}>
+                    <Typography variant="subtitle2" noWrap>Hortelan Bot</Typography>
                     <Typography variant="caption" sx={{ color: 'text.secondary', display: 'block', lineHeight: 1.2 }}>
                       Assistente inteligente da operação
                     </Typography>
                   </Box>
                 </Stack>
-                <Stack direction="row" spacing={1} alignItems="center">
+                <Stack direction="row" spacing={1} alignItems="center" sx={{ width: { xs: '100%', sm: 'auto' }, justifyContent: { xs: 'space-between', sm: 'flex-end' } }}>
                   <Box
                     sx={{ width: 8, height: 8, borderRadius: '50%', bgcolor: 'success.main', boxShadow: '0 0 0 4px rgba(34,197,94,0.18)' }}
                   />
@@ -192,8 +192,8 @@ export default function DashboardSidebar({ isOpenSidebar, onCloseSidebar }) {
               <Stack
                 spacing={0.9}
                 sx={(theme) => ({
-                  maxHeight: isChatExpanded ? 320 : 200,
-                  minHeight: isChatExpanded ? 320 : 140,
+                  maxHeight: isChatExpanded ? { xs: 260, sm: 320 } : { xs: 170, sm: 200 },
+                  minHeight: isChatExpanded ? { xs: 220, sm: 320 } : { xs: 120, sm: 140 },
                   overflowY: 'auto',
                   px: 0.5,
                   py: 0.25,

--- a/src/layouts/dashboard/index.js
+++ b/src/layouts/dashboard/index.js
@@ -163,8 +163,8 @@ export default function DashboardLayout() {
               variant="outlined"
               size="small"
             />
-            <Typography variant="h4">{context.title}</Typography>
-            <Typography sx={{ opacity: 0.9, maxWidth: 840 }}>{context.subtitle}</Typography>
+            <Typography variant="h4" sx={{ fontSize: { xs: '1.35rem', sm: '1.65rem', md: '2rem' }, lineHeight: 1.2 }}>{context.title}</Typography>
+            <Typography sx={{ opacity: 0.9, maxWidth: 840, fontSize: { xs: '0.9rem', sm: '1rem' } }}>{context.subtitle}</Typography>
           </Stack>
         </Box>
 

--- a/src/pages/dashboard/MonitoringPage.js
+++ b/src/pages/dashboard/MonitoringPage.js
@@ -1079,7 +1079,7 @@ export default function DashboardApp() {
 
   return (
     <Page title="Dashboard">
-      <Container maxWidth={false} sx={{ px: { xs: 2, md: 3 } }}>
+      <Container maxWidth={false} sx={{ px: { xs: 1.5, sm: 2, md: 3 } }}>
         <Card
           sx={(theme) => ({
             mb: 4,
@@ -1091,11 +1091,11 @@ export default function DashboardApp() {
             '&::after': {
               content: '""',
               position: 'absolute',
-              width: 320,
-              height: 320,
+              width: { xs: 220, sm: 280, md: 320 },
+              height: { xs: 220, sm: 280, md: 320 },
               borderRadius: '50%',
-              right: -140,
-              top: -150,
+              right: { xs: -110, sm: -120, md: -140 },
+              top: { xs: -120, sm: -135, md: -150 },
               backgroundColor: 'rgba(255,255,255,0.15)',
             },
           })}

--- a/src/sections/auth/login/Login.js
+++ b/src/sections/auth/login/Login.js
@@ -23,22 +23,25 @@ import { RegisterForm } from '../register';
 
 
 const RootStyle = styled('div')(({ theme }) => ({
+  minHeight: '100dvh',
   [theme.breakpoints.up('md')]: {
     display: 'flex',
   },
 }));
 
 const HeaderStyle = styled('header')(({ theme }) => ({
-  top: 0,
   zIndex: 9,
   lineHeight: 0,
   width: '100%',
   display: 'flex',
   alignItems: 'center',
-  position: 'absolute',
-  padding: theme.spacing(3),
+  position: 'relative',
+  padding: theme.spacing(2.5, 2),
   justifyContent: 'space-between',
+  gap: theme.spacing(1.5),
   [theme.breakpoints.up('md')]: {
+    top: 0,
+    position: 'absolute',
     alignItems: 'flex-start',
     padding: theme.spacing(7, 5, 0, 7),
   },
@@ -56,6 +59,9 @@ const SectionStyle = styled(Card)(({ theme }) => ({
   border: `1px solid ${alpha(theme.palette.primary.main, 0.16)}`,
   background: `linear-gradient(160deg, ${alpha(theme.palette.primary.lighter, 0.42)} 0%, ${alpha(theme.palette.info.lighter, 0.28)} 45%, ${theme.palette.background.paper} 100%)`,
   boxShadow: `0 20px 40px ${alpha(theme.palette.primary.dark, 0.12)}`,
+  [theme.breakpoints.down('lg')]: {
+    maxWidth: 420,
+  },
 }));
 
 const leafFloat = keyframes`
@@ -113,11 +119,14 @@ const Cable = styled('div')(({ theme }) => ({
 const ContentStyle = styled('div')(({ theme }) => ({
   maxWidth: 480,
   margin: 'auto',
-  minHeight: '100vh',
+  minHeight: '100dvh',
   display: 'flex',
   justifyContent: 'center',
   flexDirection: 'column',
-  padding: theme.spacing(12, 0),
+  padding: theme.spacing(5, 0, 6),
+  [theme.breakpoints.up('md')]: {
+    padding: theme.spacing(12, 0),
+  },
 }));
 
 function LoginFields() {
@@ -307,7 +316,7 @@ export default function LoginForm() {
     <Page title={isRegisterMode ? 'Cadastro' : 'Login'}>
       <RootStyle>
         <HeaderStyle>
-          <Logo sx={{ width: 120, height: 120 }} />
+          <Logo sx={{ width: { xs: 76, sm: 94, md: 120 }, height: { xs: 76, sm: 94, md: 120 } }} />
           {smUp && (
             <Typography variant="body2" sx={{ mt: { md: -2 } }}>
               {isRegisterMode ? 'Já tem uma conta? ' : 'Não tem uma conta? '}
@@ -344,7 +353,7 @@ export default function LoginForm() {
           </SectionStyle>
         )}
 
-        <Container maxWidth="sm">
+        <Container maxWidth="sm" sx={{ px: { xs: 2.25, sm: 3 } }}>
           <ContentStyle>
             <Typography variant="h4" gutterBottom>
               {isRegisterMode ? 'Cadastre-se para começar' : 'Entrar na Hortelan'}


### PR DESCRIPTION
### Motivation
- Tornar a interface consistente e legível em todos os tamanhos de tela (mobile, tablet, desktop) sem quebrar a organização visual existente.
- Corrigir pontos onde elementos fixos ou dimensões rígidas causavam overflow, cortes ou compressão em telas menores.

### Description
- Ajustei a tela de autenticação (`src/sections/auth/login/Login.js`) para usar `min-height: 100dvh`, tornar o `Header` relativo em telas pequenas e ajustar paddings, logo e largura do painel ilustrativo por breakpoint para melhor encaixe em mobile/tablet.
- Adaptei a AppBar (`src/layouts/dashboard/DashboardNavbar.js`) adicionando paddings responsivos e encapsulando o `Searchbar` para evitar crowding, além de forçar que o cluster de ações à direita não provoque overflow (`flexShrink`/spacing ajustado).
- Melhorei o Drawer/sidebar (`src/layouts/dashboard/DashboardSidebar.js`) com largura móvel maior, paddings responsivos, empilhamento do bloco do bot em xs e alturas dinâmicas para o painel de chat para preservar legibilidade em telas compactas.
- Tornei o hero/contexto do dashboard (`src/layouts/dashboard/index.js` e `src/pages/dashboard/MonitoringPage.js`) mais responsivo alterando tipografia responsiva para título/subtítulo, reduzindo paddings horizontais em `xs` e tornando a orb decorativa dimensionada/posicionada por breakpoint.

### Testing
- Executado `npm run lint` e a verificação de lint passou com sucesso.
- Executado `npm run build` e o build de produção completou sem erros.
- Levantei o servidor de desenvolvimento e executei um script headless (Playwright) para capturar screenshots de verificação visual em mobile e tablet; capturas geradas: `artifacts/login-mobile-responsive.png` e `artifacts/dashboard-tablet-responsive.png`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ad22010fe08328b6a7af5715eb4911)